### PR TITLE
Transforms now default market_aware=True.

### DIFF
--- a/zipline/transforms/mavg.py
+++ b/zipline/transforms/mavg.py
@@ -29,7 +29,7 @@ class MovingAverage(object):
     """
     __metaclass__ = TransformMeta
 
-    def __init__(self, fields, market_aware, days=None, delta=None):
+    def __init__(self, fields, market_aware=True, days=None, delta=None):
 
         self.fields = fields
         self.market_aware = market_aware

--- a/zipline/transforms/stddev.py
+++ b/zipline/transforms/stddev.py
@@ -29,7 +29,7 @@ class MovingStandardDev(object):
     """
     __metaclass__ = TransformMeta
 
-    def __init__(self, market_aware, days=None, delta=None):
+    def __init__(self, market_aware=True, days=None, delta=None):
 
         self.market_aware = market_aware
 

--- a/zipline/transforms/utils.py
+++ b/zipline/transforms/utils.py
@@ -193,7 +193,7 @@ class EventWindow(object):
     # Mark this as an abstract base class.
     __metaclass__ = ABCMeta
 
-    def __init__(self, market_aware, days=None, delta=None):
+    def __init__(self, market_aware=True, days=None, delta=None):
 
         self.market_aware = market_aware
         self.days = days

--- a/zipline/transforms/vwap.py
+++ b/zipline/transforms/vwap.py
@@ -26,7 +26,7 @@ class MovingVWAP(object):
     """
     __metaclass__ = TransformMeta
 
-    def __init__(self, market_aware, delta=None, days=None):
+    def __init__(self, market_aware=True, delta=None, days=None):
 
         self.market_aware = market_aware
         self.delta = delta


### PR DESCRIPTION
This makes for more readable code as users in all likelihood will want to use market_aware transforms (setting that to false seems to be more for unittests from what I understand).
