### PR TITLE
Removes `created` member from risk metrics.

### DIFF
--- a/zipline/finance/risk.py
+++ b/zipline/finance/risk.py
@@ -56,7 +56,6 @@ import datetime
 import math
 import numpy as np
 import numpy.linalg as la
-from zipline.utils.date_utils import epoch_now
 
 log = logbook.Logger('Risk')
 
@@ -572,7 +571,6 @@ class RiskReport(object):
 
         self.algorithm_returns = algorithm_returns
         self.trading_environment = trading_environment
-        self.created = epoch_now()
 
         if len(self.algorithm_returns) == 0:
             start_date = self.trading_environment.period_start
@@ -607,7 +605,6 @@ class RiskReport(object):
             'three_month': [x.to_dict() for x in self.three_month_periods],
             'six_month': [x.to_dict() for x in self.six_month_periods],
             'twelve_month': [x.to_dict() for x in self.year_periods],
-            'created': self.created
         }
 
     def periods_in_range(self, months_per, start, end):


### PR DESCRIPTION
`created` was being set, but unused.

It is one of the rare uses of the epoch_now and EPOCH,
so removing on the path of trimming down date_utils.
