### PR TITLE
BUG: Fixed unittest2 import error on Python 2.7

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -20,12 +20,7 @@ import datetime
 
 import pytz
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 
 from zipline.finance.slippage import VolumeShareSlippage
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 from datetime import timedelta
 import numpy as np
 

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 
 import zipline.utils.simfactory as simfactory
 from zipline.test_algorithms import (

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -18,12 +18,7 @@ Tests for the zipline.finance package
 """
 import pytz
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 from datetime import datetime, timedelta
 
 from nose.tools import timed

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -15,12 +15,7 @@
 
 import pytz
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 from itertools import chain, izip_longest
 from datetime import datetime, timedelta
 from collections import deque

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 
 import zipline.utils.factory as factory
 from zipline.sources import DataFrameSource

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -18,12 +18,7 @@ import numpy as np
 import pandas as pd
 
 from datetime import timedelta, datetime
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 
 from zipline import ndict
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import unittest2
-    TestCase = unittest2.TestCase
-except ImportError:
-    import unittest
-    TestCase = unittest.TestCase
+from unittest import TestCase
 from zipline.utils.factory import load_from_yahoo
 import pandas as pd
 import pytz


### PR DESCRIPTION
Hi,

I get a lot of `ImportError`s when I try to run `nosetests` on the zipline codebase. This fixes it for me on Python 2.7.3.

What version of Python are you running on? Hopefully this fix will keep everything working as it was before on your setup.
