### PR TITLE
Removed quarter utilities unused by zipline

### DIFF
--- a/zipline/utils/date_utils.py
+++ b/zipline/utils/date_utils.py
@@ -27,52 +27,6 @@ def parse_iso8061(date_string):
     return dt
 
 
-# quarter utilities
-# ---------------------
-def get_quarter(dt):
-    """
-    convert the given datetime to an integer representing
-    the number of calendar quarters since 0.
-    """
-    quarters = dt.year * 4
-    month = dt.month
-    if month <= 3:
-        return quarters + 1
-    elif month <= 6:
-        return quarters + 2
-    elif month <= 9:
-        return quarters + 3
-    else:
-        return quarters + 4
-
-
-def dates_of_quarter(quarter_num):
-    year = quarter_num / 4
-    quarter = quarter_num % 4
-    if quarter == 0:
-        quarter = 4
-
-    if quarter == 1:
-        start = datetime(year, 1, 1, 0, 0, tzinfo=pytz.utc)
-        end = datetime(year, 3, 31, 23, 59, tzinfo=pytz.utc)
-        return start, end
-
-    elif quarter == 2:
-        start = datetime(year, 4, 1, 0, 0, tzinfo=pytz.utc)
-        end = datetime(year, 6, 30, 23, 59, tzinfo=pytz.utc)
-        return start, end
-
-    elif quarter == 3:
-        start = datetime(year, 7, 1, 0, 0, tzinfo=pytz.utc)
-        end = datetime(year, 9, 30, 23, 59, tzinfo=pytz.utc)
-        return start, end
-
-    elif quarter == 4:
-        start = datetime(year, 10, 1, 0, 0, tzinfo=pytz.utc)
-        end = datetime(year, 12, 31, 23, 59, tzinfo=pytz.utc)
-        return start, end
-
-
 # Epoch utilities
 # ---------------------
 UNIX_EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc)

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -18,8 +18,7 @@ def teardown_logger(test):
 def check_list(test, a, b, label):
     test.assertTrue(isinstance(a, (list, blist.blist)))
     test.assertTrue(isinstance(b, (list, blist.blist)))
-    i = 0
-    for a_val, b_val in izip(a, b):
+    for i, (a_val, b_val) in enumerate(izip(a, b)):
         check(test, a_val, b_val, label + "[" + str(i) + "]")
 
 


### PR DESCRIPTION
There are bugs in these functions, but I fixed them in dataloader, where I moved them.  zipline doesn't use them.
