### PR TITLE
Fills in missing slots in transform data panels.

### DIFF
--- a/zipline/transforms/utils.py
+++ b/zipline/transforms/utils.py
@@ -454,6 +454,16 @@ class BatchTransform(EventWindow):
                 fields[field_name] = pd.DataFrame.from_dict(values_per_sid)
 
         data = pd.Panel.from_dict(fields, orient='items')
+
+        # Fills in gaps of missing data during transform of multiple
+        # stocks.
+        # e.g. we may be missing minute data because of illiquidity
+        # of one stock
+        data = data.fillna(method='ffill')
+        # Drop any empty rows after the fill.
+        # This will drop a leading row of N/A
+        data = data.dropna()
+
         return data
 
     def handle_remove(self, event):


### PR DESCRIPTION
Forward fills data, so that when using multiple stocks,
we don't have cases where one stock has data and the other doesn't.
