### PR TITLE
Remove unused ISO 8601 stuff from Zipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Dependencies
 * pandas (>= 0.9.0)
 * pytz
 * msgpack-python
-* iso8601
 * Logbook
 * blist
 

--- a/zipline/utils/date_utils.py
+++ b/zipline/utils/date_utils.py
@@ -15,16 +15,7 @@
 
 
 import pytz
-import iso8601
 from datetime import datetime, timedelta
-
-
-# iso8061 utility
-# ---------------------
-def parse_iso8061(date_string):
-    dt = iso8601.parse_date(date_string)
-    dt = dt.replace(tzinfo=pytz.utc)
-    return dt
 
 
 # Epoch utilities
@@ -62,11 +53,6 @@ def UN_EPOCH(ms_since_epoch):
     delta = timedelta(milliseconds=ms_since_epoch)
     dt = UNIX_EPOCH + delta
     return dt
-
-
-def iso8061_to_epoch(datestring):
-    dt = parse_iso8061(datestring)
-    return EPOCH(dt)
 
 
 def epoch_now():


### PR DESCRIPTION
Branch is misnamed. It was originally for fixing the typo but morphed into removing the code from Zipline completely. Please review and pull when ready, @ehebert .
