### PR TITLE
Forward-fill missing treasury data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 before_install:
   - sudo apt-get install gfortran
 install:
-  - cat etc/requirements_dev.txt  | grep -v "^#" | grep -v "^$" | grep -v ipython | grep -v nose | xargs pip install
+  - cat etc/requirements_dev.txt  | grep -v "^#" | grep -v "^$" | grep -v ipython | grep -v nose== | xargs pip install
   - etc/ordered_pip.sh etc/requirements.txt
 before_script:
   - "flake8 zipline tests"

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,6 +4,7 @@ pyzmq==2.2.0.1
 
 # Testing
 nose==1.2.1
+nose-parameterized==0.1
 nosexcover==1.0.7
 coverage==3.5.3
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -627,12 +627,12 @@ class Risk(unittest.TestCase):
                           0.0038,
                           0.0044,
                           0.0043,
-                          0.0041])
+                          0.004])
 
         self.assertEqual([round(x.treasury_period_return, 4)
                           for x in metrics.three_month_periods],
                          [0.0114,
-                          0.0118,
+                          0.0116,
                           0.0122,
                           0.0125,
                           0.0129,
@@ -640,7 +640,7 @@ class Risk(unittest.TestCase):
                           0.0123,
                           0.0128,
                           0.0125,
-                          0.0128])
+                          0.0127])
         self.assertEqual([round(x.treasury_period_return, 4)
                           for x in metrics.six_month_periods],
                          [0.0260,
@@ -649,7 +649,7 @@ class Risk(unittest.TestCase):
                           0.0252,
                           0.0259,
                           0.0256,
-                          0.0258])
+                          0.0257])
 
         self.assertEqual([round(x.treasury_period_return, 4)
                           for x in metrics.year_periods],


### PR DESCRIPTION
To handle, for instance, Columbus Day Oct 11, 2010, on which there was no treasury data.

Note that we're only forward-filling data, no longer searching both back and forward in time.
