### PR TITLE
Handle days in which we have no trade events

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -22,13 +22,51 @@ import pytz
 import itertools
 from operator import attrgetter
 
-import zipline.utils.factory as factory
+from zipline.utils import factory
 import zipline.finance.performance as perf
 from zipline.utils.protocol_utils import ndict
 from zipline.gens.sort import date_sort
 from zipline.protocol import DATASOURCE_TYPE
 
 from zipline.finance.trading import TradingEnvironment
+
+
+def create_env(start_dt=None):
+    benchmark_returns, treasury_curves = \
+        factory.load_market_data()
+
+    if not start_dt:
+        for n in range(100):
+
+            random_index = random.randint(
+                0,
+                len(treasury_curves)
+            )
+
+            start_dt = treasury_curves.keys()[random_index]
+            end_dt = start_dt + datetime.timedelta(days=365)
+
+            now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+
+            if end_dt <= now:
+                break
+    else:
+        end_dt = start_dt + datetime.timedelta(days=365)
+        now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+
+    assert end_dt <= now, """
+failed to find a date suitable daterange after 100 attempts. please double
+check treasury and benchmark data in findb, and re-run the test."""
+    assert start_dt < end_dt, "start_dt must be less than end_dt"
+
+    trading_environment = TradingEnvironment(
+        benchmark_returns,
+        treasury_curves,
+        period_start=start_dt,
+        period_end=end_dt
+    )
+
+    return trading_environment, start_dt, end_dt
 
 
 class PerformanceTestCase(unittest.TestCase):
@@ -38,44 +76,7 @@ class PerformanceTestCase(unittest.TestCase):
         self.oneday = datetime.timedelta(days=1)
         self.tradingday = datetime.timedelta(hours=6, minutes=30)
 
-        self.trading_environment, self.dt, self.end_dt = self.create_env()
-
-    def create_env(self, start_dt=None):
-        benchmark_returns, treasury_curves = \
-            factory.load_market_data()
-
-        if not start_dt:
-            for n in range(100):
-
-                random_index = random.randint(
-                    0,
-                    len(treasury_curves)
-                )
-
-                start_dt = treasury_curves.keys()[random_index]
-                end_dt = start_dt + datetime.timedelta(days=365)
-
-                now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
-
-                if end_dt <= now:
-                    break
-        else:
-            end_dt = start_dt + datetime.timedelta(days=365)
-            now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
-
-        assert end_dt <= now, """
-failed to find a date suitable daterange after 100 attempts. please double
-check treasury and benchmark data in findb, and re-run the test."""
-        assert start_dt < end_dt, "start_dt must be less than end_dt"
-
-        trading_environment = TradingEnvironment(
-            benchmark_returns,
-            treasury_curves,
-            period_start=start_dt,
-            period_end=end_dt
-        )
-
-        return trading_environment, start_dt, end_dt
+        self.trading_environment, self.dt, self.end_dt = create_env()
 
     def test_long_position(self):
         """
@@ -536,18 +537,34 @@ shares in position"
             "should be -400 for all trades and transactions in period"
         )
 
-    @parameterized.expand([
-                          (datetime.datetime(year=2008,
+
+class PerformanceTrackerTestCase(unittest.TestCase):
+
+    @parameterized.expand(list(itertools.chain(
+
+                          ((start_dt, 0, 0, 0)
+                          for start_dt in
+                          [datetime.datetime(year=2010,
                                              month=10,
                                              day=9,
-                                             tzinfo=pytz.utc),),
-                          (datetime.datetime(year=2010,
-                                             month=10,
-                                             day=9,
-                                             tzinfo=pytz.utc),),
-                          (None,),  # random start_dt
-                          ])
-    def test_tracker(self, start_dt):
+                                             tzinfo=pytz.utc),
+                           None]),  # random start_dt
+
+                          ((datetime.datetime(year=2008,
+                                              month=10,
+                                              day=9,
+                                              tzinfo=pytz.utc),
+                          delete_from_start,
+                          delete_from_middle,
+                          delete_from_end)
+                          for delete_from_start in range(3)
+                          for delete_from_middle in range(3)
+                          for delete_from_end in range(3)))))
+    def test_tracker(self,
+                     start_dt,
+                     delete_from_start,
+                     delete_from_middle,
+                     delete_from_end):
 
         trade_count = 100
         sid = 133
@@ -556,7 +573,7 @@ shares in position"
         volume = [100] * trade_count
         trade_time_increment = datetime.timedelta(days=1)
 
-        trading_environment, start_dt, end_dt = self.create_env(start_dt)
+        trading_environment, start_dt, end_dt = create_env(start_dt)
 
         trade_history = factory.create_trade_history(
             sid,
@@ -579,10 +596,9 @@ shares in position"
             source_id="factory2"
         )
 
-        trade_history.extend(trade_history2)
-
-        trading_environment.period_start = trade_history[0].dt
-        trading_environment.period_end = trade_history[-1].dt
+        trading_environment.period_start = \
+            trade_history[0].dt.replace(hour=0, minute=0, second=0)
+        trading_environment.period_end = trade_history2[-1].dt
         trading_environment.first_open = \
             trading_environment.calculate_first_open()
         trading_environment.last_close = \
@@ -598,6 +614,20 @@ shares in position"
             trading_environment
         )
 
+        trade_history = \
+            trade_history[delete_from_start:
+                          len(trade_history) - delete_from_end]
+        trade_history2 = \
+            trade_history2[delete_from_start:
+                           len(trade_history2) - delete_from_end]
+
+        if delete_from_middle:
+            middle = len(trade_history) / 2
+            del trade_history[middle:middle + delete_from_middle]
+            del trade_history2[middle:middle + delete_from_middle]
+
+        trade_history.extend(trade_history2)
+
         # date_sort requires 'DONE' messages from each source
         events = itertools.chain(trade_history,
                                  [ndict({
@@ -611,14 +641,17 @@ shares in position"
                                         'type': DATASOURCE_TYPE.TRADE
                                         })])
         events = date_sort(events, ('factory1', 'factory2'))
-        events = itertools.chain(events,
-                                 [ndict({'dt': 'DONE'})])
+        events = itertools.chain(events, [ndict({'dt': 'DONE'})])
 
-        events = [self.event_with_txn(event, trading_environment)
+        events = [self.event_with_txn(event, trade_history[0].dt)
                   for event in events]
 
-        list(perf_tracker.transform(
-            itertools.groupby(events, attrgetter('dt'))))
+        messages = \
+            [msg for date, snapshot in
+                perf_tracker.transform(
+                    itertools.groupby(events, attrgetter('dt')))
+                for event in snapshot
+                for msg in event.perf_messages]
 
         #we skip two trades, to test case of None transaction
         txn_count = len(trade_history) - 2
@@ -631,11 +664,12 @@ shares in position"
         self.assertEqual(perf_tracker.last_close,
                          perf_tracker.cumulative_risk_metrics.end_date)
 
-    def event_with_txn(self, event, env):
+        self.assertEqual(len(messages), trading_environment.days_in_period)
+
+    def event_with_txn(self, event, no_txn_dt):
         #create a transaction for all but
         #first trade in each sid, to simulate None transaction
-        if event.dt != env.period_start \
-                and event.dt != 'DONE':
+        if event.dt != no_txn_dt and event.dt != 'DONE':
             txn = ndict({
                 'sid': event.sid,
                 'amount': -25,


### PR DESCRIPTION
We emit perf messages for every trading day in the
backtest period, even empty days.
