### PR TITLE
Enables performance messages on days that have no trades.

### DIFF
--- a/zipline/finance/performance.py
+++ b/zipline/finance/performance.py
@@ -220,14 +220,11 @@ class PerformanceTracker(object):
 
             for event in snapshot:
                 if date != "DONE":
-                    event.perf_message = self.process_event(event)
+                    event.perf_messages = self.process_event(event)
                     event.portfolio = self.get_portfolio()
                 else:
-                    # the stream will end on the last trading day, but will
-                    # not trigger an end of day, so we trigger the final
-                    # market close here
-                    event.perf_message = self.handle_market_close()
-                    event.risk_message = self.handle_simulation_end()
+                    event.perf_messages, event.risk_message = \
+                        self.handle_simulation_end()
 
                 del event['TRANSACTION']
                 new_snapshot.append(event)
@@ -255,12 +252,12 @@ class PerformanceTracker(object):
 
     def process_event(self, event):
 
-        message = None
+        messages = []
 
         self.event_count += 1
 
-        if(event.dt > self.market_close):
-            message = self.handle_market_close()
+        while event.dt > self.market_close:
+            messages.append(self.handle_market_close())
 
         if event.TRANSACTION:
             self.txn_count += 1
@@ -275,7 +272,7 @@ class PerformanceTracker(object):
         self.cumulative_performance.calculate_performance()
         self.todays_performance.calculate_performance()
 
-        return message
+        return messages
 
     def handle_market_close(self):
 
@@ -337,9 +334,18 @@ Last successful date: %s" % self.market_open)
         When the simulation is complete, run the full period risk report
         and send it out on the results socket.
         """
+        # the stream will end on the last trading day, but will
+        # not trigger an end of day, so we trigger the final
+        # market close(s) here
+        perf_messages = []
+
+        while self.last_close > self.market_close:
+            perf_messages.append(self.handle_market_close())
+
+        perf_messages.append(self.handle_market_close())
 
         log_msg = "Simulated {n} trading days out of {m}."
-        log.info(log_msg.format(n=self.day_count, m=self.total_days))
+        log.info(log_msg.format(n=int(self.day_count), m=self.total_days))
         log.info("first open: {d}".format(
             d=self.trading_environment.first_open))
         log.info("last close: {d}".format(
@@ -351,7 +357,7 @@ Last successful date: %s" % self.market_open)
         )
 
         risk_dict = self.risk_report.to_dict()
-        return risk_dict
+        return perf_messages, risk_dict
 
 
 class Position(object):


### PR DESCRIPTION
Previously, on days that were trading days, but there with no
event data to process for that day, performance metrics were
not emitted, since the handling was based on having an event
trigger the daily performance metric.

Handled by grouping together performance messages, on market open,
for all days since the last market close.

Also, changes perf_tracker unit test to simulate missing data.

Taken from @richafrank's branch handling the same case.
