### PR TITLE
Recycles objects for portfolio and positions. 

### DIFF
--- a/zipline/finance/performance.py
+++ b/zipline/finance/performance.py
@@ -136,7 +136,6 @@ import datetime
 import pytz
 import math
 
-from zipline.utils.protocol_utils import ndict
 import zipline.protocol as zp
 import zipline.finance.risk as risk
 from zipline.protocol import Portfolio
@@ -572,7 +571,7 @@ class PerformancePeriod(object):
 
         for sid, pos in self.positions.iteritems():
             if sid not in positions:
-                positions[sid] = ndict()
+                positions[sid] = zp.Position()
             position = positions[sid]
             position.sid = pos.sid
             position.amount = pos.amount

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -65,3 +65,9 @@ class Portfolio(object):
 
     def __repr__(self):
         return "Portfolio({0})".format(self.__dict__)
+
+
+class Position(object):
+
+    def __repr__(self):
+        return "Position({0})".format(self.__dict__)


### PR DESCRIPTION
Recycles the objects created to pass the portfolio and positions to handle_data.

Since these values are passed to every call to handle_data, the object
creation for each hit of this loop becomes a high overall cost.
Instead of creating on object on each pass, this patch uses the same object for each pass,
but changes the values contained with in before passing along to handle_data.

With some benchmarking, seeing a large order of magnitude gain.
i.e. in a data set where `as_portfolio` took over 5 seconds, when recycling values `as_portfolio` now takes under 0.5 seconds.

Also, changes the containing type of the positions to be a regular Python dict, since accessing the values inside of the ndict had too much of a penalty.
This changes the existing behavior when a position is being accessed when that position does not exist.
Previously, a position for that sid would be created, but with  zeroed out values (i.e. the default/starting values).
Code inside of handle_data will now have to check for existence of a position before accessing it.

i.e., previously:

```
position = context.portfolio.positions['STOCK']
```

Would return a value of `position` as the following:

```
ndict({'sid': 'STOCK',
         'cost_basis': 0.0,
         'last_sale_price': 0.0,
         'amount': 0})
```

Now, a handle_data that accesses positions, should wrap the call as such:

```
if 'STOCK' in context.portfolio.positions:
    position = context.portfolio.positions['STOCK']
```

or

```
try:
    position = context.portfolio.positions['STOCK']
except KeyError:
    log.info("No position held for 'STOCK'")
```
