### PR TITLE
Recycles objects for portfolio and positions.

### DIFF
--- a/zipline/finance/performance.py
+++ b/zipline/finance/performance.py
@@ -136,7 +136,6 @@ import datetime
 import pytz
 import math
 
-from zipline.utils.protocol_utils import ndict
 import zipline.protocol as zp
 import zipline.finance.risk as risk
 
@@ -446,6 +445,7 @@ class PerformancePeriod(object):
         # when returning portfolio information.
         # So as not to avoid creating a new object for each event
         self._portfolio_store = zp.Portfolio()
+        self._positions_store = zp.Positions()
 
     def calculate_performance(self):
         self.ending_value = self.calculate_positions_value()
@@ -566,11 +566,15 @@ class PerformancePeriod(object):
 
     def get_positions(self):
 
-        positions = ndict(internal=position_ndict())
+        positions = self._positions_store
 
         for sid, pos in self.positions.iteritems():
-            cur = pos.to_dict()
-            positions[sid] = ndict(cur)
+            if sid not in positions:
+                positions[sid] = zp.Position(sid)
+            position = positions[sid]
+            position.amount = pos.amount
+            position.cost_basis = pos.cost_basis
+            position.last_sale_price = pos.last_sale_price
 
         return positions
 
@@ -587,12 +591,4 @@ class positiondict(dict):
     def __missing__(self, key):
         pos = Position(key)
         self[key] = pos
-        return pos
-
-
-class position_ndict(dict):
-
-    def __missing__(self, key):
-        pos = Position(key)
-        self[key] = ndict(pos.to_dict())
         return pos

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -65,3 +65,23 @@ class Portfolio(object):
 
     def __repr__(self):
         return "Portfolio({0})".format(self.__dict__)
+
+
+class Position(object):
+
+    def __init__(self, sid):
+        self.sid = sid
+        self.amount = 0
+        self.cost_basis = 0.0  # per share
+        self.last_sale_price = 0.0
+
+    def __repr__(self):
+        return "Position({0})".format(self.__dict__)
+
+
+class Positions(dict):
+
+    def __missing__(self, key):
+        pos = Position(key)
+        self[key] = pos
+        return pos


### PR DESCRIPTION
Performance (speed) improvement in the `performance` module.

The creation of new portfolio and position objects on every event to pass to handle_data was incurring a large overhead.

This patch recycles the object used for each handle_data and sets new values, which speeds up performance by an order of magnitude. For a dataset that used to spend 5+ seconds in `as_portfolio`, the time spent is now under 0.5 seconds.
