### PR TITLE
Uses an object for sid data to be passed to handle data.

### DIFF
--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -18,6 +18,7 @@ from logbook import Logger, Processor
 from collections import defaultdict
 
 from zipline import ndict
+from zipline.protocol import SIDData
 
 from zipline.finance.trading import TransactionSimulator
 from zipline.finance.performance import PerformanceTracker
@@ -151,9 +152,9 @@ class AlgorithmSimulator(object):
         # ==============
 
         # The algorithm's universe as of our most recent event.
-        # We want an ndict that will have empty ndicts as default
+        # We want an ndict that will have empty objects as default
         # values on missing keys.
-        self.universe = ndict(internal=defaultdict(ndict))
+        self.universe = ndict(internal=defaultdict(SIDData))
 
         # We don't have a datetime for the current snapshot until we
         # receive a message.
@@ -251,7 +252,8 @@ class AlgorithmSimulator(object):
         self.algo.set_portfolio(event.portfolio)
 
         # Update our knowledge of this event's sid
-        self.universe[event.sid].update(event.__dict__)
+        sid_data = self.universe[event.sid]
+        sid_data.__dict__.update(event.__dict__)
 
     def simulate_snapshot(self, date):
         """

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -85,3 +85,22 @@ class Positions(dict):
         pos = Position(key)
         self[key] = pos
         return pos
+
+
+class SIDData(object):
+
+    def __init__(self, initial_values=None):
+        if initial_values:
+            self.__dict__ = initial_values
+
+    def __getitem__(self, name):
+        return self.__dict__[name]
+
+    def __setitem__(self, name, value):
+        self.__dict__[name] = value
+
+    def __len__(self):
+        return len(self.__dict__)
+
+    def __repr__(self):
+        return "SIDData({0})".format(self.__dict__)

--- a/zipline/transforms/utils.py
+++ b/zipline/transforms/utils.py
@@ -446,7 +446,7 @@ class BatchTransform(EventWindow):
         # every sid has the same fields.
         sid_keys = []
         for sid in event.data.itervalues():
-            keys = set([name for name, value in sid.items()
+            keys = set([name for name, value in sid.__dict__.items()
                         if (isinstance(value, (int, float)))])
             sid_keys.append(keys)
 
@@ -511,7 +511,7 @@ class BatchTransform(EventWindow):
             for sid in sids:
                 fields = tick.data[sid]
                 for field_name in self.field_names:
-                    data[field_name][sid].ix[dt] = fields[field_name]
+                    data[field_name][sid].ix[dt] = fields.__dict__[field_name]
 
         if self.clean_nans:
             # Fills in gaps of missing data during transform


### PR DESCRIPTION
Moving another datatype off of ndict, to make it easier to inspect
objects in memory when debugging.
