### PR TITLE
Add Delorean to dependency list in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'Topic :: System :: Distributed Computing',
     ],
     install_requires=[
+        'delorean',
         'msgpack-python',
         'iso8601',
         'Logbook',


### PR DESCRIPTION
Delorean is required in [tradingcalendar](https://github.com/quantopian/zipline/blob/master/zipline/utils/tradingcalendar.py#L22)
