### PR TITLE
README.md: update "Dependencies" section from setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Dependencies
 * msgpack-python
 * Logbook
 * blist
+* requests
+* delorean
+* iso8601
 
 Quickstart
 ==========


### PR DESCRIPTION
The README.md "Dependencies" section was a bit different than setup.py's dependencies (e.g., "requests" python module is not mentioned in Dependencies but is required by setup.py).  Merge this pull request if you want the Dependencies section to specify the complete list of direct dependencies.
