### PR TITLE
ENH: Stream benchmark and treasury data when downloading

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -17,6 +17,7 @@ six==1.3.0
 
 # For fetching remote data
 requests==1.2.0
+lxml==3.1.2
 
 # For remaining sane when coping with dates
 delorean==0.2.0

--- a/zipline/data/treasuries.py
+++ b/zipline/data/treasuries.py
@@ -16,8 +16,8 @@
 
 import requests
 
-from StringIO import StringIO
-from xml.dom.minidom import parse
+from collections import OrderedDict
+from lxml import etree as ET
 
 from loader_utils import (
     guarded_conversion,
@@ -62,26 +62,67 @@ def treasury_mappings():
             in _CURVE_MAPPINGS.iteritems()}
 
 
+class iter_to_stream(object):
+    """
+    Exposes an iterable as an i/o stream
+    """
+    def __init__(self, iterable):
+        self.buffered = ""
+        self.iter = iter(iterable)
+
+    def read(self, size):
+        result = ""
+        while size > 0:
+            data = self.buffered or next(self.iter, None)
+            self.buffered = ""
+            if data is None:
+                break
+            size -= len(data)
+            if size < 0:
+                data, self.buffered = data[:size], data[size:]
+            result += data
+        return result
+
+
 def get_treasury_source():
     url = """\
 http://data.treasury.gov/feed.svc/DailyTreasuryYieldCurveRateData\
 """
-    res = requests.get(url)
+    res = requests.get(url, stream=True)
+    stream = iter_to_stream(res.iter_lines())
 
-    content = StringIO(res.content)
-    dom = parse(content)
+    elements = ET.iterparse(stream, ('end', 'start-ns', 'end-ns'))
 
-    entries = dom.getElementsByTagName("entry")
+    namespaces = OrderedDict()
+    properties_xpath = ['']
 
-    for entry in entries:
-        properties = entry.getElementsByTagName("m:properties")
-        datum = {node.nodeName.replace('d:', ''):
-                 node.childNodes[0].nodeValue
-                 if len(node.childNodes)
-                 else None
-                 for node in properties[0].childNodes
-                 if node.nodeType == dom.ELEMENT_NODE}
-        yield datum
+    def updated_namespaces():
+        if '' in namespaces and 'm' in namespaces:
+            properties_xpath[0] = "{%s}content/{%s}properties" % (
+                namespaces[''], namespaces['m']
+            )
+        else:
+            properties_xpath[0] = ''
+
+    for event, element in elements:
+        if event == 'end':
+            tag = ET.QName(element.tag).localname
+            if tag == "entry":
+                properties = element.find(properties_xpath[0])
+                datum = {ET.QName(node.tag).localname: node.text
+                         for node in properties.iterchildren()
+                         if ET.iselement(node)}
+                # clear the element after we've dealt with it:
+                element.clear()
+                yield datum
+
+        elif event == 'start-ns':
+            namespaces[element[0]] = element[1]
+            updated_namespaces()
+
+        elif event == 'end-ns':
+            namespaces.popitem()
+            updated_namespaces()
 
 
 def get_treasury_data():


### PR DESCRIPTION
instead of loading entire csv or xml into memory.

Using `res = requests.get(..., stream=True)` and `res.iter_lines()` with lazy, iterable consumers.  We end up with the full, converted data set, but we created it iteratively.
