### PR TITLE
BUG: Fix updating of trading_days_total in minute.

### DIFF
--- a/tests/test_batchtransform.py
+++ b/tests/test_batchtransform.py
@@ -147,6 +147,16 @@ class TestBatchTransformMinutely(TestCase):
         for bt in algo.history[wl:]:
             self.assertEqual(len(bt), wl)
 
+    def test_window_length(self):
+        algo = BatchTransformAlgorithmMinute(sim_params=self.sim_params,
+                                             window_length=1, refresh_period=0)
+        algo.run(self.source)
+        wl = int(algo.window_length * 6.5 * 60)
+        np.testing.assert_array_equal(algo.history[:(wl - 1)],
+                                      [None] * (wl - 1))
+        for bt in algo.history[wl:]:
+            self.assertEqual(len(bt), wl)
+
 
 class TestBatchTransform(TestCase):
     def setUp(self):

--- a/zipline/transforms/utils.py
+++ b/zipline/transforms/utils.py
@@ -456,9 +456,14 @@ class BatchTransform(object):
                                                   columns=sids))
 
         # update trading day counters
-        if self.last_dt.day != event.dt.day:
-            self.last_dt = event.dt
+        _, mkt_close = trading.environment.get_open_and_close(event.dt)
+        if self.bars == 'daily':
+            # Daily bars have their dt set to midnight.
+            mkt_close = mkt_close.replace(hour=0, minute=0, second=0)
+        if event.dt >= mkt_close:
             self.trading_days_total += 1
+
+        self.last_dt = event.dt
 
         if self.trading_days_total >= self.window_length:
             self.full = True


### PR DESCRIPTION
In the batch_transform we were incrementing the trading_days counter if there
is a new day event. Thus with a window_length of 1 and daily bars you will
update the batch_transform on the first day which is correct. But with minutes
you update with the first minute bar of the day which is not correct.

This is fixed by calculating the market_close explicity and seeing whether the
event.dt is on or past it.

I also added a unittest to test the correct behavior of this.
