### PR TITLE
Don't use hardwired Python interpreter

### DIFF
--- a/tests/test_algorithm_gen.py
+++ b/tests/test_algorithm_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2013 Quantopian, Inc.
 #

--- a/zipline/examples/buyapple.py
+++ b/zipline/examples/buyapple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2012 Quantopian, Inc.
 #

--- a/zipline/examples/dual_ema_talib.py
+++ b/zipline/examples/dual_ema_talib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2013 Quantopian, Inc.
 #

--- a/zipline/examples/dual_moving_average.py
+++ b/zipline/examples/dual_moving_average.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2013 Quantopian, Inc.
 #

--- a/zipline/examples/pairtrade.py
+++ b/zipline/examples/pairtrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2013 Quantopian, Inc.
 #


### PR DESCRIPTION
From the commit message: "Instead use /urs/bin/env to detect the Python interpreter. This way the scripts work better with the possible virtual environment."

A little fix done while going through the code.
