### PR TITLE
Fix docstring for TradingAlgorithm

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -69,6 +69,7 @@ class TradingAlgorithm(object):
 
         def handle_data(self, data):
             sid = self.sids[0]
+            amount = self.amount
             self.order(sid, amount)
     ```
     To then to run this algorithm:


### PR DESCRIPTION
From the commit message: "Fix the example given in the class docstring as the original didn't work on REPL."

A little fix done while going through the code.
