### PR TITLE
Add a VirtualBox-based Vagrant config file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ benchmarks.db
 
 # downloaded data
 zipline/data/*.msgpack
+
+# Vagrant temp folder
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.provider :virtualbox do |vb|
+  	vb.customize ["modifyvm", :id, "--memory", 2048, "--cpus", 2]
+  end
+  config.vm.provision "shell", path: "vagrant_init.sh"
+  
+end

--- a/vagrant_init.sh
+++ b/vagrant_init.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script will be run by Vagrant to 
+# set up everything necessary to use Zipline.
+
+# Because this is intended be a disposable dev VM setup,
+# no effort is made to use virtualenv/virtualenvwrapper
+
+# It is assumed that you have "vagrant up"
+# from the root of the zipline github checkout.
+# This will put the zipline code in the 
+# /vagrant folder in the system.
+
+VAGRANT_LOG="/home/vagrant/vagrant.log"
+
+# Need to "hold" grub-pc so that it doesn't break
+# the rest of the package installs (in case of a "apt-get upgrade")
+# (grub-pc will complain that your boot device changed, probably
+#  due to something that vagrant did, and break your console)
+
+echo "Obstructing updates to grub-pc..."
+apt-mark hold grub-pc 2>&1 >> "$VAGRANT_LOG"
+
+# Run a full apt-get update first.
+echo "Updating apt-get caches..."
+apt-get -y update 2>&1 >> "$VAGRANT_LOG"
+
+# Install required packages
+echo "Installing required packages..."
+apt-get -y install python-pip python-dev g++ make libfreetype6-dev libpng-dev libopenblas-dev liblapack-dev gfortran 2>&1 >> "$VAGRANT_LOG"
+
+# Add ta-lib
+echo "Installing ta-lib integration..."
+wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz 2>&1 >> "$VAGRANT_LOG"
+tar -xvzf ta-lib-0.4.0-src.tar.gz 2>&1 >> "$VAGRANT_LOG"
+cd ta-lib/ 
+./configure --prefix=/usr 2>&1 >> "$VAGRANT_LOG"
+make 2>&1 >> "$VAGRANT_LOG"
+sudo make install 2>&1 >> "$VAGRANT_LOG"
+cd ../
+
+# Add Zipline python dependencies
+echo "Installing python package dependencies..."
+/vagrant/etc/ordered_pip.sh /vagrant/etc/requirements.txt 2>&1 >> "$VAGRANT_LOG"
+# Add scipy next (if it's not done now, breaks installing of statsmodels for some reason ??)
+echo "Installing scipy..."
+pip install scipy==0.12.0 2>&1 >> "$VAGRANT_LOG"
+echo "Installing zipline dev python dependencies..."
+pip install -r /vagrant/etc/requirements_dev.txt 2>&1 >> "$VAGRANT_LOG"
+echo "Finished!"


### PR DESCRIPTION
This is a very simple change to automate the building of a Zipline development environment using Vagrant (www.vagrantup.com).

This particular configuration requires VirtualBox, though I'm sure it could be customized to work with EC2 using the other Vagrant Provider (https://github.com/mitchellh/vagrant-aws). 

This VagrantFile will, on "vagrant up"...
- Create a simple, minimal Precise Pangolin (12.04) Ubuntu 64 bit VM
- Customize the VM with 2 virtual CPU's and 2048MB of RAM
- Configure SSH for passwordless access (from the command-line)
- Add the required packages from the Ubuntu repo to support zipline
- Add (and compile) ta-lib 
- Add the required Pip packages

This takes ~25 minutes on my fairly beefy macbook, mostly spent in downloading packages from the Ubuntu mirrors.

When Vagrant is done, you can start hacking on zipline with a ...
- vagrant ssh
- cd /vagrant
- python {some python script that uses zipline}

In the spirit of making this a disposable dev environment, I decided to forego configuring virtualenv and instead install everything in site-packages.

"nosetests" and "examples/dual_moving_average.py" both succeed after the configuration finishes.

Let me know if you have any questions!
