### PR TITLE
Fix documentation compilation warnings and improve formatting of output

### DIFF
--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -428,18 +428,16 @@ def load_from_yahoo(indexes=None,
     which removes the impact of splits and dividends. If the argument
     'adjusted' is False, then the non-adjusted 'close' field is used instead.
 
-    :Arguments:
-        indexes : dict (Default: {'SPX': '^GSPC'})
-            Financial indexes to load.
-        stocks : list (Default: ['AAPL', 'GE', 'IBM', 'MSFT',
-                                 'XOM', 'AA', 'JNJ', 'PEP', 'KO'])
-            Stock closing prices to load.
-        start : datetime (Default: datetime(1993, 1, 1, 0, 0, 0, 0, pytz.utc))
-            Retrieve prices from start date on.
-        end : datetime (Default: datetime(2002, 1, 1, 0, 0, 0, 0, pytz.utc))
-            Retrieve prices until end date.
-        adjusted : bool (Default: True)
-            Adjust the price for splits and dividends.
+    :param indexes: Financial indexes to load.
+    :type indexes: dict
+    :param stocks: Stock closing prices to load.
+    :type stocks: list
+    :param start: Retrieve prices from start date on.
+    :type start: datetime
+    :param end: Retrieve prices until end date.
+    :type end: datetime
+    :param adjusted: Adjust the price for splits and dividends.
+    :type adjusted: bool
 
     """
     data = _load_raw_yahoo_data(indexes, stocks, start, end)
@@ -460,6 +458,7 @@ def load_bars_from_yahoo(indexes=None,
     """
     Loads data from Yahoo into a panel with the following
     column names for each indicated security:
+
         - open
         - high
         - low
@@ -471,19 +470,17 @@ def load_bars_from_yahoo(indexes=None,
     impact of splits and dividends. If the argument 'adjusted' is True, then
     the open, high, low, and close values are adjusted as well.
 
-    :Arguments:
-        indexes : dict (Default: {'SPX': '^GSPC'})
-            Financial indexes to load.
-        stocks : list (Default: ['AAPL', 'GE', 'IBM', 'MSFT',
-                                 'XOM', 'AA', 'JNJ', 'PEP', 'KO'])
-            Stock closing prices to load.
-        start : datetime (Default: datetime(1993, 1, 1, 0, 0, 0, 0, pytz.utc))
-            Retrieve prices from start date on.
-        end : datetime (Default: datetime(2002, 1, 1, 0, 0, 0, 0, pytz.utc))
-            Retrieve prices until end date.
-        adjusted : bool (Default: True)
-            Adjust open/high/low/close for splits and dividends.  The 'price'
-            field is always adjusted.
+    :param indexes: Financial indexes to load.
+    :type indexes: dict
+    :param stocks: Stock closing prices to load.
+    :type stocks: list
+    :param start: Retrieve prices from start date on.
+    :type start: datetime
+    :param end: Retrieve prices until end date.
+    :type end: datetime
+    :param adjusted: Adjust open/high/low/close for splits and dividends.
+        The 'price' field is always adjusted.
+    :type adjusted: bool
 
     """
     data = _load_raw_yahoo_data(indexes, stocks, start, end)


### PR DESCRIPTION
There were some warnings being output when I was compiling the docs. This change fixes those warnings. It also removes the documentation of the default types, which already gets included automatically and was wrong because not kept in sync with the function signature. Finally, I changed the formatting to the Sphinx formatting. This looks much better in the compiled documents, but does make the source a bit harder to read. I've seen other folks suggesting it might be easier to follow the Google style guide (http://google-styleguide.googlecode.com/svn/trunk/pyguide.html#Comments) and ignore the Sphinx formatting. I'll let you guys decide whether you like that last change or not. I've attached screenshots of the before and after of the compiled docs.

![before](https://f.cloud.github.com/assets/322311/785909/1c5f80aa-ea94-11e2-93c9-ff778f02fe51.png)
![after](https://f.cloud.github.com/assets/322311/785910/1c65c88e-ea94-11e2-9e69-7c9d1ace10ee.png)
