### PR TITLE
Calculate benchmark returns for first day in dataset instead of just using 0

### DIFF
--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -120,7 +120,8 @@ def get_benchmark_returns(symbol, start_date=None, end_date=None):
     benchmark_returns = []
     for i, data_point in enumerate(data_points):
         if i == 0:
-            returns = 0
+            curr_open = data_points[i]['open']
+            returns = (data_points[i]['close'] - curr_open) / curr_open
         else:
             prev_close = data_points[i-1]['close']
             returns = (data_point['close'] - prev_close) / prev_close


### PR DESCRIPTION
Strangely this didn't change the results of any of the tests. The risk report must be ignoring the first data point, which probably points to something else to be fixed.
