### PR TITLE
Trading calendar fixes

### DIFF
--- a/zipline/utils/tradingcalendar.py
+++ b/zipline/utils/tradingcalendar.py
@@ -236,7 +236,8 @@ def get_non_trading_days(start, end):
     # - President Gerald R. Ford - Jan 2, 2007
     non_trading_days.append(datetime(2007, 1, 2, tzinfo=pytz.utc))
 
-    return pd.DatetimeIndex(sorted(non_trading_days))
+    non_trading_days.sort()
+    return pd.DatetimeIndex(non_trading_days)
 
 
 def get_trading_days(start, end):
@@ -350,4 +351,5 @@ def get_early_closes(start, end):
     if start <= nye_1999 and nye_1999 <= end:
         early_closes.append(nye_1999)
 
-    return pd.DatetimeIndex(sorted(early_closes))
+    early_closes.sort()
+    return pd.DatetimeIndex(early_closes)


### PR DESCRIPTION
- Don't include New Year's Eve 1999 in early closes returned to the user if it's outside the requested range.
- Use sort() instead of sorted(), for performance.
