### PR TITLE
fixing some bugs with splits (ratios and empty positions)

### DIFF
--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -422,6 +422,7 @@ class FinanceTestCase(TestCase):
         self.assertEqual(1, aapl_order['sid'])
 
         # make sure the fls order did change
-        self.assertEqual(33, fls_order['amount'])
-        self.assertEqual(30, fls_order['limit'])
+        # to 300 shares at 3.33
+        self.assertEqual(300, fls_order['amount'])
+        self.assertEqual(3.33, fls_order['limit'])
         self.assertEqual(2, fls_order['sid'])

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -110,7 +110,9 @@ class TestSplitPerformance(unittest.TestCase):
             # set up a long position in sid 1
             # 100 shares at $20 apiece = $2000 position
             events.insert(0, create_txn(events[0], 20, 100))
-            events.append(factory.create_split(1, 0.33333,
+
+            # set up a split with ratio 3
+            events.append(factory.create_split(1, 3,
                           env.next_trading_day(events[1].dt)))
 
             results = calculate_results(self, events)

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -255,16 +255,16 @@ class Order(object):
         # info here: http://finra.complinet.com/en/display/display_plain.html?
         # rbid=2403&element_id=8950&record_id=12208&print=1
 
-        # if we have an open order for 100 shares at $20, and we get
-        # a 3:1 split, we now want to have an open order for 33 shares at $60
-        # for the amount, we round down to the nearest whole share
-        self.amount = int(self.amount * ratio)
+        # new_share_amount = old_share_amount / ratio
+        # new_price = old_price * ratio
+
+        self.amount = int(self.amount / ratio)
 
         if self.limit:
-            self.limit = round(self.limit / ratio, 2)
+            self.limit = round(self.limit * ratio, 2)
 
         if self.stop:
-            self.stop = round(self.stop / ratio, 2)
+            self.stop = round(self.stop * ratio, 2)
 
     @property
     def open(self):


### PR DESCRIPTION
I had the split ratios backwards, fixed them.

Also added some logging to more easily track splits.
