### PR TITLE
Minimum price variation

### DIFF
--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -1,3 +1,5 @@
+import math
+
 from nose_parameterized import parameterized
 from unittest import TestCase
 
@@ -16,6 +18,8 @@ class BlotterTestCase(TestCase):
     def test_round_for_minimum_price_variation_buy(self, price, expected):
         result = round_for_minimum_price_variation(price, is_buy=True)
         self.assertEqual(result, expected)
+        self.assertEqual(math.copysign(1.0, result),
+                         math.copysign(1.0, expected))
 
     @parameterized.expand([(0.00, 0.00),
                            (0.01, 0.01),
@@ -27,3 +31,5 @@ class BlotterTestCase(TestCase):
     def test_round_for_minimum_price_variation_sell(self, price, expected):
         result = round_for_minimum_price_variation(price, is_buy=False)
         self.assertEqual(result, expected)
+        self.assertEqual(math.copysign(1.0, result),
+                         math.copysign(1.0, expected))

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -47,7 +47,10 @@ ORDER_STATUS = Enum(
 # buy: [.0095, .0195) -> round to .01, sell: (.0005, .0105] -> round to .01
 def round_for_minimum_price_variation(x, is_buy, diff=(0.0095 - .005)):
     # relies on rounding half away from zero, unlike numpy's bankers' rounding
-    return round(x - (diff if is_buy else -diff), 2)
+    rounded = round(x - (diff if is_buy else -diff), 2)
+    if zp_math.tolerant_equals(rounded, 0.0):
+        return 0.0
+    return rounded
 
 
 class Blotter(object):


### PR DESCRIPTION
Ensure limit prices conform to a minimum price variation of a penny, which works for _most_ stocks (not, for instance, BRK).  The rounding "midpoint" is custom and depends on buy/sell direction, instead of .5 of a penny. 

If the limit price is close to zero, it could get rounded to -0.0, so we take the `abs` - not sure if returning -0.0 would be a problem or not.
