### PR TITLE
ENH: Add option of instantly filling orders.

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -22,6 +22,7 @@ import zipline.utils.factory as factory
 from zipline.test_algorithms import (TestRegisterTransformAlgorithm,
                                      RecordAlgorithm,
                                      TestOrderAlgorithm,
+                                     TestOrderInstantAlgorithm,
                                      TestOrderValueAlgorithm,
                                      TestTargetAlgorithm,
                                      TestOrderPercentAlgorithm,
@@ -186,3 +187,10 @@ class TestTransformAlgorithm(TestCase):
                 data_frequency='daily'
             )
             algo.run(self.df)
+
+    def test_order_instant(self):
+        algo = TestOrderInstantAlgorithm(sim_params=self.sim_params,
+                                         data_frequency='daily',
+                                         instant_fill=True)
+
+        algo.run(self.df)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -112,6 +112,8 @@ class TradingAlgorithm(object):
         else:
             self.data_frequency = None
 
+        self.instant_fill = kwargs.pop('instant_fill', False)
+
         # Override annualizer if set
         if 'annualizer' in kwargs:
             self.annualizer = kwargs['annualizer']

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -234,6 +234,24 @@ class TestOrderAlgorithm(TradingAlgorithm):
         self.order(0, 1)
 
 
+class TestOrderInstantAlgorithm(TradingAlgorithm):
+    def initialize(self):
+        self.incr = 0
+        self.last_price = None
+
+    def handle_data(self, data):
+        if self.incr == 0:
+            assert 0 not in self.portfolio.positions
+        else:
+            assert self.portfolio.positions[0]['amount'] == \
+                self.incr, "Orders not filled immediately."
+            assert self.portfolio.positions[0]['last_sale_price'] == \
+                self.last_price, "Orders was not filled at last price."
+        self.incr += 2
+        self.order_value(0, data[0].price * 2.)
+        self.last_price = data[0].price
+
+
 class TestOrderValueAlgorithm(TradingAlgorithm):
     def initialize(self):
         self.incr = 0


### PR DESCRIPTION
There is currently a one-day delay when placing orders in `handle_data()` to their execution (when data frequency is daily).

This adds a flag to `TradingAlgorithm` called `instant_fill` (defaults to `False`) that changes this behavior so that orders get executed immediately.
