### PR TITLE
Fix max-drawdown stuck at 0%

### DIFF
--- a/tests/risk/test_risk_cumulative.py
+++ b/tests/risk/test_risk_cumulative.py
@@ -110,3 +110,9 @@ class TestRisk(unittest.TestCase):
                 value,
                 decimal=2,
                 err_msg="Mismatch at %s" % (dt,))
+
+    def test_max_drawdown_calculated(self):
+        # We don't track max_drawdown by day, so it doesn't make sense to
+        # generate a full answer key for it. For now, ensure it's just
+        # "not zero"
+        self.assertNotEqual(self.cumulative_metrics_06.max_drawdown, 0.0)

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -406,7 +406,7 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             compound = 0.0
             # BUG? Shouldn't this be set to log(1.0 + 0) ?
 
-        if len(self.compounded_log_returns[:self.latest_dt]) == 0:
+        if np.isnan(self.compounded_log_returns[self.latest_dt]):
             self.compounded_log_returns[self.latest_dt] = compound
         else:
             self.compounded_log_returns[self.latest_dt] = \


### PR DESCRIPTION
@ehebert, Can you validate this for me?

The pandas array is pre-filled in `__init__`, so the `len == 0` check never hit.
