### PR TITLE
MAINT: Clean up imports of zipline.finance.trading

### DIFF
--- a/tests/test_algorithm_gen.py
+++ b/tests/test_algorithm_gen.py
@@ -20,7 +20,7 @@ from nose.tools import timed
 from datetime import datetime
 
 import pytz
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from zipline.algorithm import TradingAlgorithm
 from zipline.finance import slippage
 from zipline.utils import factory

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -37,7 +37,7 @@ import zipline.utils.simfactory as simfactory
 from zipline.finance.blotter import Blotter
 from zipline.gens.composites import date_sorted_sources
 
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from zipline.finance.trading import SimulationParameters
 
 from zipline.finance.performance import PerformanceTracker

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -32,7 +32,7 @@ import zipline.utils.math_utils as zp_math
 from zipline.gens.composites import date_sorted_sources
 from zipline.finance.trading import SimulationParameters
 from zipline.finance.blotter import Order
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from zipline.protocol import DATASOURCE_TYPE
 from zipline.utils.factory import create_random_simulation_parameters
 import zipline.protocol

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -41,7 +41,7 @@ from zipline.finance.slippage import (
 from zipline.finance.commission import PerShare, PerTrade
 from zipline.finance.blotter import Blotter
 from zipline.finance.constants import ANNUALIZER
-import zipline.finance.trading as trading
+from zipline.finance import trading
 import zipline.protocol
 from zipline.protocol import Event
 

--- a/zipline/examples/dual_moving_average.py
+++ b/zipline/examples/dual_moving_average.py
@@ -17,7 +17,7 @@
 import matplotlib.pyplot as plt
 
 from zipline.algorithm import TradingAlgorithm
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from zipline.transforms import MovingAverage
 from zipline.utils.factory import load_from_yahoo
 

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -65,7 +65,7 @@ from pandas.tseries.tools import normalize_date
 
 import zipline.protocol as zp
 import zipline.finance.risk as risk
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from . period import PerformancePeriod
 
 log = logbook.Logger('Performance')

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -18,7 +18,7 @@ import logbook
 import math
 import numpy as np
 
-import zipline.finance.trading as trading
+from zipline.finance import trading
 import zipline.utils.math_utils as zp_math
 
 import pandas as pd

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -20,7 +20,7 @@ import math
 import numpy as np
 import numpy.linalg as la
 
-import zipline.finance.trading as trading
+from zipline.finance import trading
 
 import pandas as pd
 

--- a/zipline/finance/risk/risk.py
+++ b/zipline/finance/risk/risk.py
@@ -58,7 +58,7 @@ Risk Report
 import logbook
 import numpy as np
 
-import zipline.finance.trading as trading
+from zipline.finance import trading
 import zipline.utils.math_utils as zp_math
 
 log = logbook.Logger('Risk')

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -44,7 +44,7 @@ log = logbook.Logger('Trading')
 # subsequently referenced directly by zipline financial
 # components. To set the environment, you can set the property on
 # the module directly:
-#       import zipline.finance.trading as trading
+#       from zipline.finance import trading
 #       trading.environment = TradingEnvironment()
 #
 # or if you want to switch the environment for a limited context

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from logbook import Logger, Processor
 
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from zipline.protocol import (
     BarData,
     SIDData,

--- a/zipline/transforms/batch_transform.py
+++ b/zipline/transforms/batch_transform.py
@@ -29,7 +29,7 @@ import pandas as pd
 from zipline.utils.data import RollingPanel
 from zipline.protocol import Event
 
-import zipline.finance.trading as trading
+from zipline.finance import trading
 
 from . utils import check_window_length
 

--- a/zipline/transforms/utils.py
+++ b/zipline/transforms/utils.py
@@ -29,7 +29,7 @@ from abc import ABCMeta, abstractmethod
 
 from zipline.protocol import DATASOURCE_TYPE
 from zipline.gens.utils import assert_sort_unframe_protocol, hash_args
-import zipline.finance.trading as trading
+from zipline.finance import trading
 
 log = logbook.Logger('Transform')
 

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -31,7 +31,7 @@ from zipline.sources import (SpecificEquityTrades,
                              DataFrameSource,
                              DataPanelSource)
 from zipline.finance.trading import SimulationParameters
-import zipline.finance.trading as trading
+from zipline.finance import trading
 from zipline.sources.test_source import (
     date_gen,
     create_trade


### PR DESCRIPTION
Use "from zipline.finance import trading" instead of "import
zipline.finance.trading as trading".
