### PR TITLE
Commission PerShare minimum trade amount

### DIFF
--- a/zipline/finance/commission.py
+++ b/zipline/finance/commission.py
@@ -20,7 +20,7 @@ class PerShare(object):
     share cost with an optional minimum cost per trade.
     """
 
-    def __init__(self, cost=0.03, min_trade_cost=0.0):
+    def __init__(self, cost=0.03, min_cost=0.0, min_trade_cost=0.0):
         """
         Cost parameter is the cost of a trade per-share. $0.03
         means three cents per share, which is a very conservative


### PR DESCRIPTION
Extended commission PerShare method to include a minimum cost per trade (e.g. $1.00)
