### PR TITLE
ENH: Add symbol api function and overload decorator

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -38,6 +38,7 @@ from zipline.test_algorithms import (TestRegisterTransformAlgorithm,
                                      handle_data_api,
                                      noop_algo,
                                      api_algo,
+                                     api_symbol_algo,
                                      call_all_order_methods,
                                      record_variables,
                                      record_float_magic
@@ -292,6 +293,10 @@ class TestAlgoScript(TestCase):
 
     def test_api_calls_string(self):
         algo = TradingAlgorithm(script=api_algo)
+        algo.run(self.df)
+
+    def test_api_symbol(self):
+        algo = TradingAlgorithm(script=api_symbol_algo)
         algo.run(self.df)
 
     def test_fixed_slippage(self):

--- a/zipline/api.py
+++ b/zipline/api.py
@@ -29,6 +29,15 @@ from zipline.finance.slippage import (
 
 batch_transform = zipline.transforms.BatchTransform
 
+
+def symbol(symbol_str, as_of_date=None):
+    """Default symbol lookup for any source that directly maps the
+    symbol to the identifier (e.g. yahoo finance).
+
+    Keyword argument as_of_date is ignored.
+    """
+    return symbol_str
+
 __all__ = [
     'slippage',
     'commission',

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -745,6 +745,17 @@ def handle_data(context, data):
     record(incr=context.incr)
 """
 
+api_symbol_algo = """
+from zipline.api import (order,
+                         symbol)
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    order(symbol(0), 1)
+"""
+
 call_all_order_methods = """
 from zipline.api import (order,
                          order_value,


### PR DESCRIPTION
A symbol() lookup feature was added to Quantopian.
By adding the same API function to zipline we can
make copy&pasting of a zipline algo to Quantopian
easier.

This also provides support for overwriting the
default identity-based symbol() call. This would
allow a user to e.g. write a symbol-lookup function
for the Bloomberg database.
