### PR TITLE
Check that self.logger exists

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -471,7 +471,8 @@ class TradingAlgorithm(object):
             zero_message = "Price of 0 for {psid}; can't infer value".format(
                 psid=sid
             )
-            self.logger.debug(zero_message)
+            if self.logger:
+                self.logger.debug(zero_message)
             # Don't place any order
             return
         else:


### PR DESCRIPTION
`self.logger` is initialized as `None` and there is no guarantee that users have set it, so check that it exists before trying to pass messages to it
