### PR TITLE
use current_data instead of last_sale_price

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -592,7 +592,7 @@ class TradingAlgorithm(object):
         """
         if sid in self.portfolio.positions:
             current_position = self.portfolio.positions[sid].amount
-            current_price = self.portfolio.positions[sid].last_sale_price
+            current_price = self.trading_client.current_data[sid].price
             current_value = current_position * current_price
             req_value = target - current_value
             return self.order_value(sid, req_value, limit_price, stop_price)
@@ -613,7 +613,7 @@ class TradingAlgorithm(object):
         """
         if sid in self.portfolio.positions:
             current_position = self.portfolio.positions[sid].amount
-            current_price = self.portfolio.positions[sid].last_sale_price
+            current_price = self.trading_client.current_data[sid].price
             current_value = current_position * current_price
         else:
             current_value = 0


### PR DESCRIPTION
It seems more clear to get price values from `self.trading_client.current_data[sid].price` than from `self.portfolio.positions[sid].last_sale_price`. The two values are the same, so this is just a readability change, but it is also the same behavior as in `self.order_value()` and I feel like they should use the same syntax.
