### PR TITLE
Missing package six in the install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
         'pytz',
         'requests',
         'numpy',
-        'pandas'
+        'pandas',
+        'six'
     ],
     url="https://github.com/quantopian/zipline"
 )


### PR DESCRIPTION
Hi,

Sorry if it is not the right / complete way to fix it, I am not yet used to the python package system.

When I installed zipline the first time and tried to execute the demo, I got the error "ImportError: No module named six".

Indeed, the package is imported here :
https://github.com/quantopian/zipline/blob/master/zipline/data/loader.py#L29

Thanks !
