### PR TITLE
PERF: Use self.updated_portfolio instead of self.portfolio in TradingAlgorithm.

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -667,8 +667,8 @@ class TradingAlgorithm(object):
         order for the difference between the target number of shares and the
         current number of shares.
         """
-        if sid in self.portfolio.positions:
-            current_position = self.portfolio.positions[sid].amount
+        if sid in self.updated_portfolio().positions:
+            current_position = self.updated_portfolio().positions[sid].amount
             req_shares = target - current_position
             return self.order(sid, req_shares,
                               limit_price=limit_price,
@@ -690,8 +690,8 @@ class TradingAlgorithm(object):
         order for the difference between the target value and the
         current value.
         """
-        if sid in self.portfolio.positions:
-            current_position = self.portfolio.positions[sid].amount
+        if sid in self.updated_portfolio().positions:
+            current_position = self.updated_portfolio().positions[sid].amount
             current_price = self.trading_client.current_data[sid].price
             current_value = current_position * current_price
             req_value = target - current_value
@@ -717,13 +717,13 @@ class TradingAlgorithm(object):
 
         Note that target must expressed as a decimal (0.50 means 50\%).
         """
-        if sid in self.portfolio.positions:
-            current_position = self.portfolio.positions[sid].amount
+        if sid in self.updated_portfolio().positions:
+            current_position = self.updated_portfolio().positions[sid].amount
             current_price = self.trading_client.current_data[sid].price
             current_value = current_position * current_price
         else:
             current_value = 0
-        target_value = self.portfolio.portfolio_value * target
+        target_value = self.updated_portfolio().portfolio_value * target
 
         req_value = target_value - current_value
         return self.order_value(sid, req_value,


### PR DESCRIPTION
The self.portfolio property on TradingAlgorithm internally causes a refresh of
the latest portfolio data every time it's accessed.  We also have an
updated_portfolio method, which only does this refresh when it's deemed
necessary.  Use the latter in API convenience methods instead of the former.
