### PR TITLE
ENH: new api_methods - total_commission and cancel_all_open_orders 

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -788,3 +788,25 @@ class TradingAlgorithm(object):
             bar_count, frequency, field, ffill)
         history_spec = self.history_specs[spec_key_str]
         return self.history_container.get_history(history_spec, self.datetime)
+
+    @api_method
+    def cancel_all_open_orders(self):
+        open_orders = self.get_open_orders()
+        if open_orders:
+            for key in open_orders:
+                x = [oo.id for oo in open_orders[key]]
+                for i in x:
+                    self.cancel_order(i)
+
+    @api_method
+    def total_commission(self):
+        ords = self.all_raw_orders()
+        commission = 0
+        for i in ords:
+            x = ords[i].commission
+            if x is not None:
+                commission += x
+        return commission
+
+    def all_raw_orders(self):
+        return self.blotter.orders


### PR DESCRIPTION
added 2 api_methods
cancell_all_open_orders() - cancels any open orders in the blotter.
total_commission() - gets the sum of the commission costs since the start of the backtest.

added method all_raw_orders() because the raw_orders() method only returns the open orders.