### PR TITLE
Use env_trading_calender for open and closes data

### DIFF
--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -116,7 +116,7 @@ class TradingEnvironment(object):
         self.early_closes = get_early_closes(self.first_trading_day,
                                              self.last_trading_day)
 
-        self.open_and_closes = tradingcalendar.open_and_closes.ix[
+        self.open_and_closes = env_trading_calendar.open_and_closes.ix[
             self.trading_days]
 
     def __enter__(self, *args, **kwargs):


### PR DESCRIPTION
TradingEnvironment class uses env_trading_calendar for trading days but the default trading calendar for open_and_close data, which causes errors later, because of misalignment of trading days. The issue can be resolved by using env_trading_calendar for open_and_closes as well
