### PR TITLE
MAINT: delete duplicate attribute in zipline.protocol.Portfolio

### DIFF
--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -79,7 +79,6 @@ class Portfolio(object):
         self.positions = Positions()
         self.start_date = None
         self.positions_value = 0.0
-        self.portfolio_value = 0.0
 
     def __getitem__(self, key):
         return self.__dict__[key]


### PR DESCRIPTION
Deleted a duplicate of Portfolio.portfolio_value, it was defined on lines 75 and 82.
