### PR TITLE
Move statsmodels from into requirements.txt

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -6,6 +6,9 @@ Logbook==0.6.0
 pytz==2013.9
 numpy==1.8.0
 
+# Needed for parts of pandas.stats
+statsmodels==0.5.0
+
 pandas==0.12.0
 python-dateutil==2.2
 six==1.5.2

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -25,6 +25,5 @@ matplotlib==1.3.1
 tornado==3.2
 pyparsing==2.0.1
 patsy==0.2.1
-statsmodels==0.4.3
 
 Markdown==2.3.1


### PR DESCRIPTION
Pandas website states statsmodels is needed for parts of pandas.stats.
Also, bring in version of 0.5.0rc1 to fix #3669
