### PR TITLE
Update setup.py to tie in numpy includes location.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-
+import numpy as np
 from setuptools import setup, find_packages
 
 LONG_DESCRIPTION = None
@@ -48,6 +48,7 @@ setup(
     author_email='opensource@quantopian.com',
     packages=find_packages(),
     scripts=['scripts/run_algo.py'],
+    include_dirs = [np.get_include()],
     long_description=LONG_DESCRIPTION,
     license='Apache 2.0',
     classifiers=[


### PR DESCRIPTION
Build of statsmodels==0.5.0 errors out in jenkins build:
test_algo_crash (integration.test_arbiter_deluge.TestArbiterDeluge) ... /mnt/jenkins/.pyxbld/temp.linux-x86_64-2.7/pyrex/statsmodels/tsa/kalmanf/kalman_loglike.c:340:31: error: numpy/arrayobject.h: No such file or directory

Update setup.py to include the location of numpy header files.
