### PR TITLE
MAINT/PERF: Make the portfolio property call `updated_portfolio`.

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -601,13 +601,9 @@ class TradingAlgorithm(object):
 
     @property
     def portfolio(self):
-        # internally this will cause a refresh of the
-        # period performance calculations.
-        return self.perf_tracker.get_portfolio()
+        return self.updated_portfolio()
 
     def updated_portfolio(self):
-        # internally this will cause a refresh of the
-        # period performance calculations.
         if self.portfolio_needs_update:
             self._portfolio = self.perf_tracker.get_portfolio()
             self.portfolio_needs_update = False


### PR DESCRIPTION
Make the portfolio property on TradingAlgorithm call `updated_portfolio`
internally.  This prevents needless recomputation of the portfolio between
calls to `handle_data`, and also prevents issues where the portfolio object
could be unexpectedly modified in place in the body of a `handle_date` call.

Also adds some optimizations to `PerformancePeriod.get_positions` to 
avoid needless insertions/deletions from the `Positions` object that's supplied
on the algo-facing portfolio.
