### PR TITLE
ENH: Filter out empty lists from `get_open_orders`.

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -758,9 +758,11 @@ class TradingAlgorithm(object):
     @api_method
     def get_open_orders(self, sid=None):
         if sid is None:
-            return {key: [order.to_api_obj() for order in orders]
-                    for key, orders
-                    in self.blotter.open_orders.iteritems()}
+            return {
+                key: [order.to_api_obj() for order in orders]
+                for key, orders in iteritems(self.blotter.open_orders)
+                if orders
+            }
         if sid in self.blotter.open_orders:
             orders = self.blotter.open_orders[sid]
             return [order.to_api_obj() for order in orders]


### PR DESCRIPTION
Filter out empty lists from `get_open_orders` so that we have consistent
behavior between the case where a user has never placed an order and the case
where the user has placed an order but it has been executed or cancelled.

A nice side-effect, which was the impetus for this change, is that you can
check if you have any open orders by doing:

```
len(get_open_orders()) == 0
```

Also adds a test for the behavior of `get_open_orders`, which was previously
lacking.
