### PR TITLE
STY: Remove warning when ordering zero shares.

### DIFF
--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -100,12 +100,7 @@ class Blotter(object):
         amount = int(almost_equal_to(amount))
 
         # just validates amount and passes rest on to TransactionSimulator
-        # Tell the user if they try to buy 0 shares of something.
         if amount == 0:
-            zero_message = "Requested to trade zero shares of {psid}".format(
-                psid=sid
-            )
-            log.debug(zero_message)
             # Don't bother placing orders for 0 shares.
             return
         elif amount > self.max_shares:


### PR DESCRIPTION
Many algorithms that use the new order methods like order_target()
will legitimately try to order 0 shares many times. The printed
warning at every turn is quite annoying and too verbose. We do not
display it on Quantopian either so I'm removing it here as well.
