### PR TITLE
MAINT: Refactored target order methods

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -706,8 +706,7 @@ class TradingAlgorithm(object):
 
     @api_method
     def order_target_value(self, sid, target,
-                           limit_price=None, stop_price=None,
-                           style=None, include_open_orders=False):
+                           limit_price=None, stop_price=None, style=None):
         """
         Place an order to adjust a position to a target value. If
         the position doesn't already exist, this is equivalent to placing a new


### PR DESCRIPTION
MAINT: Refactored target order methods

Refactored the target order methods to separate their logic from the
other order methods.

This makes order_target the only target method that calls order()
directly.

order_target_value is passed to order_target instead of order_value.

order_target_percent is passed to order_target_value rather than
order_value.

This simplified the code and decouples the logic of target orders from
the other order methods. Allows the target order methods to be
developed independently from order_value and order_percent.
