### PR TITLE
Added record() functionality to accept dynamic names

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -98,6 +98,12 @@ class TestRecordAlgorithm(TestCase):
 
         np.testing.assert_array_equal(output['incr'].values,
                                       range(1, len(output) + 1))
+        np.testing.assert_array_equal(output['name'].values,
+                                      range(1, len(output) + 1))
+        np.testing.assert_array_equal(output['name2'].values,
+                                      [2] * len(output))
+        np.testing.assert_array_equal(output['name3'].values,
+                                      range(1, len(output) + 1))
 
 
 class TestMiscellaneousAPI(TestCase):

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from datetime import datetime
 
-from itertools import groupby
+from itertools import groupby, chain
 from six.moves import filter
 from six import iteritems, exec_
 from operator import attrgetter
@@ -467,11 +467,19 @@ class TradingAlgorithm(object):
                                            'kwargs': kwargs}
 
     @api_method
-    def record(self, **kwargs):
+    def record(self, *args, **kwargs):
         """
         Track and record local variable (i.e. attributes) each day.
         """
-        for name, value in kwargs.items():
+        # Make 2 objects both referencing the same iterator
+        args = [iter(args)] * 2
+
+        # Zip generates list entries by calling `next` on each iterator it
+        # receives.  In this case the two iterators are the same object, so the
+        # call to next on args[0] will also advance args[1], resulting in zip
+        # returning (a,b) (c,d) (e,f) rather than (a,a) (b,b) (c,c) etc.
+        positionals = zip(*args)
+        for name, value in chain(positionals, iteritems(kwargs)):
             self._recorded_vars[name] = value
 
     @api_method

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -233,6 +233,9 @@ class RecordAlgorithm(TradingAlgorithm):
     def handle_data(self, data):
         self.incr += 1
         self.record(incr=self.incr)
+        name = 'name'
+        self.record(name, self.incr)
+        record(name, self.incr, 'name2', 2, name3=self.incr)
 
 
 class TestOrderAlgorithm(TradingAlgorithm):


### PR DESCRIPTION
In response to https://github.com/quantopian/qexec/issues/3142

Added functionality for record to accept positional args of the form (str1, value1, str2, value2, ... ) before the keyword arguments. This enables the user to record values with names defined by dynamic strings rather than hardcoding.

This PR is a precursor to a qexec PR which enables full functionality of this feature through the API. I'll submit the qexec PR as soon as this PR has been merged.
