### PR TITLE
BUG: Algo no longer crashes after creating new history column.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -351,6 +351,7 @@ def initialize(context):
 
 def handle_data(context, data):
     prices = history(bar_count=2, frequency='1d', field='price')
+    prices['prices_times_two'] = prices[1] * 2
     context.last_prices = prices
 """.strip()
 

--- a/zipline/history/history_container.py
+++ b/zipline/history/history_container.py
@@ -443,7 +443,7 @@ class HistoryContainer(object):
         # Get minutes from our buffer panel to build the last row.
         buffer_frame = self.buffer_panel_minutes(
             earliest_minute=self.cur_window_starts[history_spec.frequency],
-        )[field].copy()
+        )[field]
 
         if do_ffill:
             digest_frame = ffill_digest_frame_from_prior_values(
@@ -472,4 +472,9 @@ class HistoryContainer(object):
         else:
             return_frame.ix[algo_dt] = buffer_frame.loc[algo_dt]
 
-        return return_frame
+        # Returning a copy of the DataFrame so that we don't crash if the user
+        # adds columns to the frame.  Ideally we would just drop any added
+        # columns, but pandas 0.12.0 doesn't support in-place dropping of
+        # columns.  We should re-evaluate this implementation once we're on a
+        # more up-to-date pandas.
+        return return_frame.copy()


### PR DESCRIPTION
Fixes an issue that caused a crash if a user assigned a new column into a
returned history DataFrame.  This occurred because we re-use DataFrames between
history() calls, so the new column caused an index-size mismatch on the next
attempted calculation.

Ideally we would fix this by in-place dropping the columns, but that isn't
supported in pandas 0.12.0, so instead we just return a complete copy of the
frame.  We should re-evaluate this implementation when we're on a more modern
pandas version.
