### PR TITLE
BUG: Added slippage kwarg to TestAlgorithm init.

### DIFF
--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -97,7 +97,12 @@ class TestAlgorithm(TradingAlgorithm):
     at the close of a simulation.
     """
 
-    def initialize(self, sid, amount, order_count, sid_filter=None):
+    def initialize(self,
+                   sid,
+                   amount,
+                   order_count,
+                   sid_filter=None,
+                   slippage=None):
         self.count = order_count
         self.sid = sid
         self.amount = amount
@@ -107,6 +112,9 @@ class TestAlgorithm(TradingAlgorithm):
             self.sid_filter = sid_filter
         else:
             self.sid_filter = [self.sid]
+
+        if slippage is not None:
+            self.set_slippage(slippage)
 
     def handle_data(self, data):
         # place an order for amount shares of sid


### PR DESCRIPTION
This is necessary to support correct testing architecture now that self.initialized is actually being set. Previously set_slippage was being called outside of init, that will now fail and instead slippage must be passed to the algorithm class init method.
