### PR TITLE
BUG: Fix an issue where dividends are granted a day early.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -312,15 +312,14 @@ class TestDividendPerformance(unittest.TestCase):
                 oneday,
                 self.sim_params
             )
-
             dividend = factory.create_dividend(
                 1,
                 10.00,
                 # declared date, when the algorithm finds out about
                 # the dividend
-                events[1].dt,
-                # ex_date, when the algorithm is credited with the
-                # dividend
+                events[0].dt,
+                # ex_date, the date before which the algorithm must hold stock
+                # to receive the dividend
                 events[1].dt,
                 # pay date, when the algorithm receives the dividend.
                 events[2].dt
@@ -368,9 +367,9 @@ class TestDividendPerformance(unittest.TestCase):
                 ratio=2,
                 # declared date, when the algorithm finds out about
                 # the dividend
-                declared_date=events[1].dt,
-                # ex_date, when the algorithm is credited with the
-                # dividend
+                declared_date=events[0].dt,
+                # ex_date, the date before which the algorithm must hold stock
+                # to receive the dividend
                 ex_date=events[1].dt,
                 # pay date, when the algorithm receives the dividend.
                 pay_date=events[2].dt

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -291,11 +291,6 @@ class PerformanceTracker(object):
         bench_since_open = \
             self.intraday_risk_metrics.benchmark_cumulative_returns[dt]
 
-        # if we've reached market close, check on dividends
-        if dt == self.market_close:
-            for perf_period in self.perf_periods:
-                perf_period.update_dividends(todays_date)
-
         self.cumulative_risk_metrics.update(todays_date,
                                             self.todays_performance.returns,
                                             bench_since_open)
@@ -319,8 +314,6 @@ class PerformanceTracker(object):
         self.update_performance()
         # add the return results from today to the returns series
         todays_date = normalize_date(self.market_close)
-        self.cumulative_performance.update_dividends(todays_date)
-        self.todays_performance.update_dividends(todays_date)
 
         self.returns[todays_date] = self.todays_performance.returns
 


### PR DESCRIPTION
Fixes an issue where `PerformancePeriod.update_dividends` was being called with
incorrect dates in `handle_minute_close` and `handle_market_close`, which
resulted in dividends being granted a day early.  This is primarily a problem
because it causes algorithms to incorrectly receive dividends when the stock in
question is purchased on a dividend's ex_date.  After this change, dividends
are granted only when the algorithm held stock on the market close of the day
before the dividend's ex_date.  This is in line with the following quote from
the SEC's notes on dividend ex_dates:

> If you purchase a stock on its ex-dividend date or after, you will not
> receive the next dividend payment.  Instead, the seller gets the dividend. If
> you purchase before the ex-dividend date, you get the dividend.
