### PR TITLE
ENH: Added exception for a portfolio access before setup.

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -30,6 +30,7 @@ import zipline.utils.simfactory as simfactory
 
 from zipline.errors import (
     OrderDuringInitialize,
+    PortfolioAccessInInitialize,
     RegisterTradingControlPostInit,
     TradingControlViolation,
 )
@@ -55,6 +56,7 @@ from zipline.test_algorithms import (
     api_symbol_algo,
     call_all_order_methods,
     call_order_in_init,
+    access_portfolio_in_init,
     handle_data_api,
     handle_data_noop,
     initialize_api,
@@ -613,6 +615,18 @@ def handle_data(context, data):
         with self.assertRaises(OrderDuringInitialize):
             test_algo = TradingAlgorithm(
                 script=call_order_in_init,
+                sim_params=self.sim_params,
+            )
+            set_algo_instance(test_algo)
+
+    def test_access_portfolio_in_init(self):
+        """
+        Test that accessing portfolio in initialize
+        will raise an error.
+        """
+        with self.assertRaises(PortfolioAccessInInitialize):
+            test_algo = TradingAlgorithm(
+                script=access_portfolio_in_init,
                 sim_params=self.sim_params,
             )
             set_algo_instance(test_algo)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -30,6 +30,7 @@ from zipline.errors import (
     OrderDuringInitialize,
     OverrideCommissionPostInit,
     OverrideSlippagePostInit,
+    PortfolioAccessInInitialize,
     RegisterTradingControlPostInit,
     UnsupportedCommissionModel,
     UnsupportedOrderParameters,
@@ -625,8 +626,14 @@ class TradingAlgorithm(object):
 
     def updated_portfolio(self):
         if self.portfolio_needs_update:
-            self._portfolio = self.perf_tracker.get_portfolio()
-            self.portfolio_needs_update = False
+            if self.perf_tracker is not None:
+                self._portfolio = self.perf_tracker.get_portfolio()
+                self.portfolio_needs_update = False
+            else:
+                raise PortfolioAccessInInitialize(
+                    msg="portfolio object can only be accessed in \
+                    handle_data()."
+                )
         return self._portfolio
 
     def set_logger(self, logger):

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -144,6 +144,13 @@ class OrderDuringInitialize(ZiplineError):
     msg = "{msg}"
 
 
+class PortfolioAccessInInitialize(ZiplineError):
+    """
+    Raised if portfolio is accessed before it has been set up.
+    """
+    msg = "{msg}"
+
+
 class TradingControlViolation(ZiplineError):
     """
     Raised if an order would violate a constraint set by a TradingControl.

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -961,6 +961,17 @@ def handle_data(context, data):
     pass
 """
 
+access_portfolio_in_init = """
+from zipline.api import (order)
+
+def initialize(context):
+    var = context.portfolio
+    pass
+
+def handle_data(context, data):
+    pass
+"""
+
 call_all_order_methods = """
 from zipline.api import (order,
                          order_value,


### PR DESCRIPTION
Calling portfolio in setup previously resulted in an
uninformative KeyError. It now informs the user that the
portfolio object has not been assigned at the time of access.
