### PR TITLE
BUG: Put initialization of perf_tracker back in __init__

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -34,6 +34,7 @@ from zipline.errors import (
     TradingControlViolation,
 )
 from zipline.test_algorithms import (
+    access_portfolio_in_init,
     AmbitiousStopLimitAlgorithm,
     EmptyPositionsAlgorithm,
     InvalidOrderAlgorithm,
@@ -616,6 +617,24 @@ def handle_data(context, data):
                 sim_params=self.sim_params,
             )
             set_algo_instance(test_algo)
+
+    def test_portfolio_in_init(self):
+        """
+        Test that accessing portfolio in init doesn't break.
+        """
+        test_algo = TradingAlgorithm(
+            script=access_portfolio_in_init,
+            sim_params=self.sim_params,
+        )
+        set_algo_instance(test_algo)
+
+        self.zipline_test_config['algorithm'] = test_algo
+        self.zipline_test_config['trade_count'] = 1
+
+        zipline = simfactory.create_test_zipline(
+            **self.zipline_test_config)
+
+        output, _ = drain_zipline(self, zipline)
 
 
 class TestHistory(TestCase):

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -157,9 +157,7 @@ class TradingAlgorithm(object):
             self.sim_params = create_simulation_parameters(
                 capital_base=self.capital_base
             )
-
-        # perf_tacker gets instantiated in ._create_generator()
-        self.perf_tracker = None
+        self.perf_tracker = PerformanceTracker(self.sim_params)
 
         self.blotter = kwargs.pop('blotter', None)
         if not self.blotter:
@@ -318,8 +316,8 @@ class TradingAlgorithm(object):
         skipped.
         """
         # Instantiate perf_tracker
-        if self.perf_tracker is None:
-            self.perf_tracker = PerformanceTracker(sim_params)
+        self.perf_tracker = PerformanceTracker(sim_params)
+        self.portfolio_needs_update = True
 
         self.data_gen = self._create_data_generator(source_filter, sim_params)
 

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -961,6 +961,15 @@ def handle_data(context, data):
     pass
 """
 
+access_portfolio_in_init = """
+def initialize(context):
+    var = context.portfolio.cash
+    pass
+
+def handle_data(context, data):
+    pass
+"""
+
 call_all_order_methods = """
 from zipline.api import (order,
                          order_value,


### PR DESCRIPTION
The initialization of perf_tracker had been moved from **init**
in TradingAlgorithm to _create_generator. This caused perf_tracker
to not be ready when portfolio requested it. portfolio was consequently
not ready for access in init. portfolio can now be accessed in init
again, assuming valid sim_params are passed. Otherwise it will be
available in handle_data().
