### PR TITLE
BUG: Fixed random dips in returns as shown to user.

### DIFF
--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -303,6 +303,7 @@ class PerformancePeriod(object):
         position.update(txn)
         self.ensure_position_index(txn.sid)
         self._position_amounts[txn.sid] = position.amount
+        self._position_last_sale_prices[txn.sid] = position.last_sale_price
 
         self.period_cash_flow -= txn.price * txn.amount
 

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -152,6 +152,12 @@ class Position(object):
                 total_cost = prev_cost + txn_cost
                 self.cost_basis = total_cost / total_shares
 
+            # Update the last sale price if txn is
+            # best data we have so far
+            if self.last_sale_date is None or txn.dt > self.last_sale_date:
+                self.last_sale_price = txn.price
+                self.last_sale_date = txn.dt
+
         self.amount = total_shares
 
     def adjust_commission_cost_basis(self, commission):


### PR DESCRIPTION
Previously the last sale price was not correctly being set on
positions when the transaction arrived before the trade event.
The last sale price was defaulted to zero and never updated. This resulted
in one holding stocks that were bough >>0 and now had value 0 from
the perspective of returns. The returns would display correctly again
when the next trade of that security happened. For most securities trading is
frequent enough that there's no issue, but for some illiquid ones it took
hours to fix itself.

Updated test_perf_tracking:TestPerformanceTracker.test_minute_tracker
This test was based on assuming that last_sale_price was zero,
allowing the sharpe ratio to be calculated. The sharpe ratio can no longer
be calculated for this specific tested scenario and the test has been changed
accordingly.
