### PR TITLE
symbol as an api_method

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -487,6 +487,15 @@ class TradingAlgorithm(object):
             self._recorded_vars[name] = value
 
     @api_method
+    def symbol(self, symbol_str, as_of_date=None):
+        """
+        Default symbol lookup for any source that directly maps the
+        symbol to the identifier (e.g. yahoo finance).
+        Keyword argument as_of_date is ignored.
+        """
+        return symbol_str
+
+    @api_method
     def order(self, sid, amount,
               limit_price=None,
               stop_price=None,

--- a/zipline/api.py
+++ b/zipline/api.py
@@ -30,16 +30,7 @@ from zipline.finance.slippage import (
 batch_transform = zipline.transforms.BatchTransform
 
 
-def symbol(symbol_str, as_of_date=None):
-    """Default symbol lookup for any source that directly maps the
-    symbol to the identifier (e.g. yahoo finance).
-
-    Keyword argument as_of_date is ignored.
-    """
-    return symbol_str
-
 __all__ = [
-    'symbol',
     'slippage',
     'commission',
     'math_utils',


### PR DESCRIPTION
Makes `symbol` an `api_method` so that subclasses of `TradingAlgorithm` may implement their own symbol resolution method.
