### PR TITLE
MAINT: Remove use of deprecated getchildren method on xml element

### DIFF
--- a/zipline/data/treasuries.py
+++ b/zipline/data/treasuries.py
@@ -119,8 +119,7 @@ http://data.treasury.gov/feed.svc/DailyTreasuryYieldCurveRateData\
             if tag == "entry":
                 properties = element.find(properties_xpath[0])
                 datum = {get_localname(node): node.text
-                         for node in properties.getchildren()
-                         if ET.iselement(node)}
+                         for node in properties if ET.iselement(node)}
                 # clear the element after we've dealt with it:
                 element.clear()
                 yield datum


### PR DESCRIPTION
Rather than calling getchildren on xml.etree.ElementTree elements, we're now supposed to just itegrate over the elements.
