### PR TITLE
DEV: Add tz kwarg to get_datetime.

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -746,13 +746,15 @@ class TradingAlgorithm(object):
         self.blotter.set_date(dt)
 
     @api_method
-    def get_datetime(self):
+    def get_datetime(self, tz=None):
         """
         Returns a copy of the datetime.
         """
         date_copy = copy(self.datetime)
         assert date_copy.tzinfo == pytz.utc, \
             "Algorithm should have a utc datetime"
+        if tz is not None:
+            date_copy = date_copy.tz_convert(tz)
         return date_copy
 
     def set_transact(self, transact):


### PR DESCRIPTION
Adds a `tz` kwarg to `get_datetime` to make it easier to request the current time in a particular timezone.  The existing semantics are unchanged, and  `get_datetime(tz)` is equivalent to `get_datetime().tz_convert(tz)`.

Was frustrated by the verbosity of asking "is it 10:00AM EST?" while working on a bug today.

Ping @jbredeche and @twiecki for API review.
