### PR TITLE
MAINT: minor refactor of RandomWalkSource

### DIFF
--- a/zipline/sources/simulated.py
+++ b/zipline/sources/simulated.py
@@ -35,7 +35,7 @@ class RandomWalkSource(DataSource):
     VALID_FREQS = frozenset(('daily', 'minute'))
 
     def __init__(self, start_prices=None, freq='minute', start=None,
-                 end=None, calendar=calendar_nyse):
+                 end=None, drift=0.1, sd=0.1, calendar=calendar_nyse):
         """
         :Arguments:
             start_prices : dict
@@ -48,6 +48,10 @@ class RandomWalkSource(DataSource):
                  Start dt to emit events.
             end : datetime <default=end of calendar>
                  End dt until to which emit events.
+            drift: float <default=0.1>
+                 Constant drift of the price series.
+            sd: float <default=0.1>
+                 Standard deviation of the price series.
             calendar : calendar object <default: NYSE>
                  Calendar to use.
                  See zipline.utils for different choices.
@@ -84,8 +88,8 @@ class RandomWalkSource(DataSource):
         else:
             self.end = end
 
-        self.drift = .1
-        self.sd = .1
+        self.drift = drift
+        self.sd = sd
 
         self.sids = self.start_prices.keys()
 


### PR DESCRIPTION
I made the drift and standard deviation used in RandomWalkSource
keyword args to give the user more control over the prices emitted.

The standard deviation of prices is very different at different frequencies,
users should have the ability to specify the standard deviation used.

The drift term should also be configurable to give the user more control.
