### PR TITLE
Support for setting parameters externally

### DIFF
--- a/docs/release-notes/zipline-0.7.1.md
+++ b/docs/release-notes/zipline-0.7.1.md
@@ -88,3 +88,24 @@
     > for stock in tech_stocks:
     >    order_target_percent(stock, 1/3, percent_of_fn=tech_filter)
     > ```
+
+* Forward arguments from __init__ to the user-defined initialize().
+  [PR456](https://github.com/quantopian/zipline/pull/456)
+
+  >  If you used the new way of creating an algorithm by defining an
+  `initialize()` and a `handle_data()` function that you pass to
+  `TradingAlgorithm` it was not possible to externally set variables in `initialize`. This is quite an impediment to parameter optimization where you want to be able to run the `TradingAlgorithm` many times passing in different parameter values that you set in `initialize()`.
+
+  > Example:
+  > ```python
+  > def initialize(context, param=0):
+  >     context.param = param
+  > def handle_data(context, data):
+  >     # use param in some way
+  >     ...
+  > # Instantiate algorithm, setting param to 3.
+  > algo = zipline.TradingAlgorithm(initialize,
+                                    handle_data,
+                                    param=3)
+  > perf = algo.run(data)
+  > ```

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -778,21 +778,18 @@ def handle_data(context, data):
         """Test that passing of args and kwargs to initialize via __init__ works
         as expected."""
         test_algo = TradingAlgorithm(
-            'arg',
             script="""
-def initialize(context, arg, kwarg=False):
-    context.arg = arg
+def initialize(context, kwarg=False):
     context.kwarg = kwarg
 
 def handle_data(context, data):
     pass""",
             sim_params=self.sim_params,
-            kwarg='kwarg'
+            initialize_params={'kwarg': True}
         )
         set_algo_instance(test_algo)
 
-        self.assertEqual(test_algo.arg, 'arg')
-        self.assertEqual(test_algo.kwarg, 'kwarg')
+        self.assertEqual(test_algo.kwarg, True)
 
 
 class TestHistory(TestCase):

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -774,6 +774,26 @@ def handle_data(context, data):
 
         output, _ = drain_zipline(self, zipline)
 
+    def test_passing_of_args(self):
+        """Test that passing of args and kwargs to initialize via __init__ works
+        as expected."""
+        test_algo = TradingAlgorithm(
+            'arg',
+            script="""
+def initialize(context, arg, kwarg=False):
+    context.arg = arg
+    context.kwarg = kwarg
+
+def handle_data(context, data):
+    pass""",
+            sim_params=self.sim_params,
+            kwarg='kwarg'
+        )
+        set_algo_instance(test_algo)
+
+        self.assertEqual(test_algo.arg, 'arg')
+        self.assertEqual(test_algo.kwarg, 'kwarg')
+
 
 class TestHistory(TestCase):
     @classmethod

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -246,6 +246,7 @@ Initialize sids and other state variables.
             self._handle_data = kwargs.pop('handle_data')
             self._before_trading_start = kwargs.pop('before_trading_start',
                                                     None)
+            self._analyze = kwargs.pop('analyze', None)
 
         self.event_manager.add_event(
             zipline.utils.events.Event(

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -134,7 +134,8 @@ class TradingAlgorithm(object):
     AUTO_INITIALIZE = True
 
     def __init__(self, *args, **kwargs):
-        """Initialize sids and other state variables.
+        """
+Initialize sids and other state variables.
 
         :Arguments:
         :Optional:
@@ -155,7 +156,11 @@ class TradingAlgorithm(object):
                Whether to fill orders immediately or on next bar.
             environment : str <default: 'zipline'>
                The environment that this algorithm is running in.
-        """
+
+        :Note:
+            All other *args and **kwargs passed will be forwarded to the
+            user-defined initialize() function.
+"""
         self.datetime = None
 
         self.registered_transforms = {}
@@ -166,7 +171,7 @@ class TradingAlgorithm(object):
         self.trading_controls = []
 
         self._recorded_vars = {}
-        self.namespace = kwargs.get('namespace', {})
+        self.namespace = kwargs.pop('namespace', {})
 
         self._platform = kwargs.pop('platform', 'zipline')
 
@@ -277,13 +282,13 @@ class TradingAlgorithm(object):
         functions.
         """
         with ZiplineAPI(self):
-            self._initialize(self)
+            self._initialize(self, *args, **kwargs)
 
-    def before_trading_start(self):
+    def before_trading_start(self, *args, **kwargs):
         if self._before_trading_start is None:
             return
 
-        self._before_trading_start(self)
+        self._before_trading_start(self, *args, **kwargs)
 
     def handle_data(self, data):
         self._most_recent_data = data

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -507,13 +507,14 @@ Initialize sids and other state variables.
                 perfs.append(perf)
 
             # convert perf dict to pandas dataframe
-            daily_stats = self._create_daily_stats(perfs)
+            daily_stats, risk_cumulative, risk_report = \
+                self._create_perf_and_risk_reports(perfs)
 
         self.analyze(daily_stats)
 
-        return daily_stats
+        return daily_stats, risk_cumulative, risk_report
 
-    def _create_daily_stats(self, perfs):
+    def _create_perf_and_risk_reports(self, perfs):
         # create daily and cumulative stats dataframe
         daily_perfs = []
         # TODO: the loop here could overwrite expected properties
@@ -528,13 +529,16 @@ Initialize sids and other state variables.
                 perf['daily_perf'].update(perf['cumulative_risk_metrics'])
                 daily_perfs.append(perf['daily_perf'])
             else:
-                self.risk_report = perf
+                risk_report = perf
+
+        risk_cumulative = \
+            pd.Series(self.perf_tracker.cumulative_risk_metrics.to_dict())
 
         daily_dts = [np.datetime64(perf['period_close'], utc=True)
                      for perf in daily_perfs]
         daily_stats = pd.DataFrame(daily_perfs, index=daily_dts)
 
-        return daily_stats
+        return daily_stats, risk_cumulative, risk_report
 
     @api_method
     def add_transform(self, transform, days=None):

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -281,8 +281,10 @@ Initialize sids and other state variables.
         Call self._initialize with `self` made available to Zipline API
         functions.
         """
+        initialize_params = kwargs.pop('initialize_params', {})
+
         with ZiplineAPI(self):
-            self._initialize(self, *args, **kwargs)
+            self._initialize(self, **initialize_params)
 
     def before_trading_start(self, *args, **kwargs):
         if self._before_trading_start is None:

--- a/zipline/examples/olmar_ext.conf
+++ b/zipline/examples/olmar_ext.conf
@@ -1,0 +1,5 @@
+[Defaults]
+algofile=olmar_ext.py
+symbols=CERN,DLTR,ROST,MSFT,SBUX
+start=2010-1-1
+end=2014-1-1

--- a/zipline/examples/olmar_ext.py
+++ b/zipline/examples/olmar_ext.py
@@ -1,0 +1,175 @@
+import sys
+import logbook
+import numpy as np
+
+zipline_logging = logbook.NestedSetup([
+    logbook.NullHandler(level=logbook.DEBUG, bubble=True),
+    logbook.StreamHandler(sys.stdout, level=logbook.INFO),
+    logbook.StreamHandler(sys.stderr, level=logbook.ERROR),
+])
+zipline_logging.push_application()
+
+from zipline.api import (
+    symbols,
+    schedule_function,
+    date_rules,
+    time_rules,
+    add_history,
+    history,
+    order_target_percent,
+    record,
+    get_open_orders,
+    get_datetime
+)
+
+
+def initialize(context, eps=1, window_length=30):
+    context.stocks = symbols('CERN', 'DLTR', 'ROST', 'MSFT', 'SBUX')
+    context.i = 0
+    context.m = len(context.stocks)
+    context.b_t = np.ones(context.m) / context.m
+    context.eps = eps
+    context.window_length = window_length
+    context.init = False
+    context.previous_datetime = None
+    add_history(window_length, '1d', 'price')
+    add_history(window_length, '1d', 'volume')
+    schedule_function(daily, date_rule=date_rules.every_day(),
+                      time_rule=time_rules.market_open())
+
+
+def handle_data(context, data):
+    pass
+
+
+def daily(context, data):
+    context.i += 1
+    if context.i < context.window_length:
+        return
+
+    cash = context.portfolio.cash
+    record(cash=cash)
+
+    if not context.init:
+        # Equal weighting portfolio
+        for stock, percent in zip(context.stocks, context.b_t):
+            order_target_percent(stock, percent)
+        context.init = True
+
+    # skip tic if any orders are open or any stocks did not trade
+    for stock in context.stocks:
+        if bool(get_open_orders(stock)) or \
+           data[stock].datetime < get_datetime():
+            return
+
+    # compute current portfolio allocations
+    for i, stock in enumerate(context.stocks):
+        context.b_t[i] = context.portfolio.positions[
+            stock].amount * data[stock].price
+
+    # Bring portfolio vector to unit length
+    context.b_t = context.b_t / np.sum(context.b_t)
+
+    # Compute new portfolio weights according to OLMAR algo.
+    size = context.window_length - 2
+    b_norm = np.zeros((context.m, size))
+    x_tilde = np.zeros((context.m, size))
+    for k in range(size):
+        b_norm[:, k], x_tilde[:, k] = olmar(context, k + 3)
+
+    s = np.zeros(size)
+    b_norm_opt = np.zeros(context.m)
+    s_sum = 0
+    for k in range(size):
+        s[k] = np.dot(b_norm[:, k], x_tilde[:, k])
+        b_norm[:, k] = np.multiply(s[k], b_norm[:, k])
+        b_norm_opt += b_norm[:, k]
+        s_sum += s[k]
+
+    b_norm_opt = np.divide(b_norm_opt, s_sum)
+
+    print(b_norm_opt)
+
+    # Rebalance Portfolio
+    for stock, percent in zip(context.stocks, b_norm_opt):
+        order_target_percent(stock, percent)
+
+
+def olmar(context, window):
+    """Logic of the olmar algorithm.
+
+    :Returns: b_norm : vector for new portfolio
+    """
+
+    # get history -- prices and volums of the last 5 days (at close)
+    p = history(context.window_length, '1d', 'price')
+    v = history(context.window_length, '1d', 'volume')
+
+    prices = p.ix[context.window_length - window:-1]
+    volumes = v.ix[context.window_length - window:-1]
+
+    # find relative moving volume weighted average price for each secuirty
+    x_tilde = np.zeros(context.m)
+    for i, stock in enumerate(context.stocks):
+        vwa_price = np.dot(
+            prices[stock], volumes[stock]) / np.sum(volumes[stock])
+        x_tilde[i] = vwa_price / prices[stock].ix[-1]
+
+    ###########################
+    # Inside of OLMAR (algo 2)
+    x_bar = x_tilde.mean()
+
+    # Calculate terms for lambda (lam)
+    dot_prod = np.dot(context.b_t, x_tilde)
+    num = context.eps - dot_prod
+    denom = (np.linalg.norm((x_tilde - x_bar))) ** 2
+
+    # test for divide-by-zero case
+    if denom == 0.0:
+        lam = 0  # no portolio update
+    else:
+        lam = max(0, num / denom)
+
+    b = context.b_t + lam * (x_tilde - x_bar)
+
+    b_norm = simplex_projection(b)
+
+    return b_norm, x_tilde
+
+
+def simplex_projection(v, b=1):
+    """Projection vectors to the simplex domain
+
+Implemented according to the paper: Efficient projections onto the
+l1-ball for learning in high dimensions, John Duchi, et al. ICML 2008.
+Implementation Time: 2011 June 17 by Bin@libin AT pmail.ntu.edu.sg
+Optimization Problem: min_{w}\| w - v \|_{2}^{2}
+s.t. sum_{i=1}^{m}=z, w_{i}\geq 0
+
+Input: A vector v \in R^{m}, and a scalar z > 0 (default=1)
+Output: Projection vector w
+
+:Example:
+>>> proj = simplex_projection([.4 ,.3, -.4, .5])
+>>> print proj
+array([ 0.33333333, 0.23333333, 0. , 0.43333333])
+>>> print proj.sum()
+1.0
+
+Original matlab implementation: John Duchi (jduchi@cs.berkeley.edu)
+Python-port: Copyright 2012 by Thomas Wiecki (thomas.wiecki@gmail.com).
+"""
+
+    v = np.asarray(v)
+    p = len(v)
+
+    # Sort v into u in descending order
+    v = (v > 0) * v
+    u = np.sort(v)[::-1]
+    sv = np.cumsum(u)
+
+    rho = np.where(u > (sv - b) / np.arange(1, p + 1))[0][-1]
+    theta = np.max([0, (sv[rho] - b) / (rho + 1)])
+    w = (v - theta)
+    w[w < 0] = 0
+    return w

--- a/zipline/examples/olmar_optimize.py
+++ b/zipline/examples/olmar_optimize.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+import pytz
+import numpy as np
+
+from zipline.algorithm import TradingAlgorithm
+from zipline.utils.factory import load_bars_from_yahoo
+
+import olmar_ext as olmar
+
+STOCKS = ['CERN', 'DLTR', 'ROST', 'MSFT', 'SBUX']
+
+
+def run_algo(eps=1, window_length=30):
+    start = datetime(2010, 1, 1, 0, 0, 0, 0, pytz.utc)
+    end = datetime(2014, 1, 1, 0, 0, 0, 0, pytz.utc)
+    data = load_bars_from_yahoo(
+        stocks=STOCKS, indexes={}, start=start, end=end)
+
+    initialize_params = {'eps': eps,
+                         'window_length': window_length}
+
+    algo = TradingAlgorithm(initialize=olmar.initialize,
+                            handle_data=olmar.handle_data,
+                            initialize_params=initialize_params)
+
+    perf = algo.run(data)  # flake8: noqa
+    # Minimize negative sharpe = maximize sharpe
+    return -algo.risk_report['twelve_month'][-1]['sharpe']
+
+test_eps = np.linspace(1, 20, 5)
+results_eps = map(run_algo, test_eps)
+print(results_eps)
+
+test_window_length = np.arange(10, 50, 10)
+results_window_length = map(lambda x: run_algo(window_length=x),
+                            test_window_length)
+print(results_window_length)


### PR DESCRIPTION
The reason for this change is that it was impossible to
use a TradingAlgorithm that passes in an initialize function
in a parameter optimization. This issue is discussed in #455.

It seems easy enough to just forward any left-over *args
and **kwargs to the user-defined initialize function. As these
are only passed when they are defined we do not break backwards
compatibility with this.