### PR TITLE
WIP: Lot (don't merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ benchmarks.db
 
 # Vagrant temp folder
 .vagrant
+
+#PyCharm
+.idea*

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -286,27 +286,15 @@ class PerformancePeriod(object):
                 del self.orders_by_id[order.id]
             self.orders_by_id[order.id] = order
 
-    def update_position(self, sid, amount=None, last_sale_price=None,
-                        last_sale_date=None, cost_basis=None):
+    def update_position(self, sid, amount=None,
+                        last_sale_price=None, last_sale_date=None):
         pos = self.positions[sid]
 
         if amount is not None:
-            pos.amount = amount
             self.set_position_amount(sid, amount)
-        if last_sale_price is not None:
-            pos.last_sale_price = last_sale_price
+        if last_sale_price is not None and last_sale_date is not None:
+            pos.update_last_sale(last_sale_date, last_sale_price)
             self.set_position_last_sale_price(sid, last_sale_price)
-        if last_sale_date is not None:
-            pos.last_sale_date = last_sale_date
-        if cost_basis is not None:
-            pos.cost_basis = cost_basis
-
-    def update_position(self, sid, amount=None, last_sale_price=None,
-                        last_sale_date=None, cost_basis=None):
-        pos = self.positions[sid]
-        pos.update(amount=amount, dt=last_sale_date, price=last_sale_price)
-        self.set_position_amount(sid, amount)
-
 
     def execute_transaction(self, txn):
         # Update Position

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -301,6 +301,13 @@ class PerformancePeriod(object):
         if cost_basis is not None:
             pos.cost_basis = cost_basis
 
+    def update_position(self, sid, amount=None, last_sale_price=None,
+                        last_sale_date=None, cost_basis=None):
+        pos = self.positions[sid]
+        pos.update(amount=amount, dt=last_sale_date, price=last_sale_price)
+        self.set_position_amount(sid, amount)
+
+
     def execute_transaction(self, txn):
         # Update Position
         # ----------------

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -328,9 +328,7 @@ class Position(object):
         :param dt: date
         :param price: price
         """
-        #FIXME Add commissions
-
-        total_amount = self.amount + amount
+        # FIXME Add commissions
 
         # new position
         if self.amount == 0:
@@ -372,6 +370,7 @@ class Position(object):
             'cost_basis': self.cost_basis,
             'last_sale_price': self.last_sale_price
         }
+
 
 class positiondict(dict):
 

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -225,6 +225,10 @@ class cached_property(object):
             instance._cache[self._method_name] = self._method(instance)
         return instance._cache[self._method_name]
 
+    def __set__(self, instance, val):
+        raise AttributeError(
+            'Can not set property values: {}'.format(self._method_name))
+
 
 class Position(object):
     def __init__(self, sid, amount=0, cost_basis=0.0,

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -39,12 +39,14 @@ from math import (
 )
 
 import logbook
+import pandas as pd
 import zipline.protocol as zp
+import zipline.finance.tax_lots as tax_lots
 
 log = logbook.Logger('Performance')
 
 
-class Position(object):
+class Position_OLD(object):
 
     def __init__(self, sid, amount=0, cost_basis=0.0,
                  last_sale_price=0.0, last_sale_date=None):
@@ -71,7 +73,7 @@ class Position(object):
         # cash dividend
         if dividend['net_amount']:
             out['cash_amount'] = self.amount * dividend['net_amount']
-        elif dividend['gross_amount']:
+        elif dividend['gross_amvount']:
             out['cash_amount'] = self.amount * dividend['gross_amount']
 
         payment_owed = zp.dividend_payment(out)
@@ -206,6 +208,141 @@ last_sale_price: {last_sale_price}"
             'cost_basis': self.cost_basis,
             'last_sale_price': self.last_sale_price
         }
+
+
+class cached_property(object):
+    """
+    Descriptor for caching property values in an instance's '_cache'.
+    """
+    def __init__(self, method):
+        self._method_name = method.__name__
+        self._method = method
+
+    def __get__(self, instance, owner):
+        if not hasattr(instance, '_cache'):
+            instance._cache = {}
+        if self._method_name not in instance._cache:
+            instance._cache[self._method_name] = self._method(instance)
+        return instance._cache[self._method_name]
+
+
+class Position(object):
+    def __init__(self, sid, amount=0, cost_basis=0.0,
+                 last_sale_price=0.0, last_sale_date=None,
+                 default_lot_method=None):
+
+        self.sid = sid
+        self.lots = set()
+        if default_lot_method is None:
+            default_lot_method = tax_lots.FIFO()
+        assert not isinstance(default_lot_method, tax_lots.SpecificLots)
+        self.default_lot_method = default_lot_method
+        self._cache = {}
+
+        if amount != 0:
+            self.open(amount=amount, dt=last_sale_date, price=cost_basis)
+            list(self.lots)[0].update_last_sale_price(last_sale_price)
+
+    def clear_cache(self):
+        self._cache.clear()
+
+    @cached_property
+    def closed_lots(self):
+        return filter(lambda l: l.closed, self.lots)
+
+    @cached_property
+    def open_lots(self):
+        return filter(lambda l: not l.closed, self.lots)
+
+    @cached_property
+    def amount(self):
+        return sum(l.amount for l in self.open_lots)
+
+    @cached_property
+    def total_cost(self):
+        return sum(l.total_cost for l in self.open_lots)
+
+    @cached_property
+    def cost_basis(self):
+        return self.total_cost / self.amount
+
+    @cached_property
+    def market_value(self):
+        return sum(l.market_value for l in self.open_lots)
+
+    @cached_property
+    def last_sale_price(self):
+        return next(iter(self.open_lots)).last_sale_price
+
+    def close(self, amount, dt, price, method=None, lots=None):
+
+        if lots is None:
+            lots = self.open_lots
+
+        if method is None:
+            method = self.default_lot_method
+
+        closed_lots = method.close_lots(
+            dt=dt, amount=amount, price=price, open_lots=lots)
+
+        self.lots.update(closed_lots)
+        self.clear_cache()
+
+    def open(self, amount, dt, price):
+        lot = tax_lots.Lot(
+            sid=self.sid,
+            dt=dt,
+            amount=amount,
+            cost_basis=price
+        )
+        self.lots.add(lot)
+        self.clear_cache()
+
+    def earn_dividend(self, dividend):
+        return pd.concat([l.earn_dividend(dividend) for l in self.open_lots])
+
+    def handle_split(self, split):
+        return sum(l.handle_split(split) for l in self.open_lots)
+
+    def update(self, txn):
+        if self.sid != txn.sid:
+            raise Exception('updating position with txn for a '
+                            'different sid')
+        self._update(txn.amount, txn.dt, txn.price)
+
+    def _update(self, amount, dt, price):
+        #FIXME Add commissions
+
+        total_shares = self.amount + amount
+
+        # close the entire position
+        if total_shares == 0:
+            self.close(amount=amount, dt=dt, price=price)
+
+        else:
+            prev_direction = copysign(1, self.amount)
+            txn_direction = copysign(1, amount)
+
+            # closing lots
+            if prev_direction != txn_direction:
+
+                # partial close
+                if abs(amount) < abs(self.amount):
+                    self.close(amount=amount, dt=dt, price=price)
+
+                # full close and reopen in opposite direction
+                else:
+                    self.close(amount=self.amount, dt=txn.dt, price=price)
+                    self.open(amount=self.amount - amount, dt=dt, price=price)
+
+            # opening lots
+            else:
+                self.open(amount=amount, dt=dt, price=price)
+
+        self.clear_cache()
+
+    def adjust_commission_cost_basis(self, commission):
+        raise NotImplementedError
 
 
 class positiondict(dict):

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -252,11 +252,11 @@ class Position(object):
 
     @cached_property
     def closed_lots(self):
-        return filter(lambda l: l.closed, self.lots)
+        return set(filter(lambda l: l.closed, self.lots))
 
     @cached_property
     def open_lots(self):
-        return filter(lambda l: not l.closed, self.lots)
+        return set(filter(lambda l: not l.closed, self.lots))
 
     @cached_property
     def amount(self):

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -276,7 +276,10 @@ class Position(object):
 
     @cached_property
     def last_sale_price(self):
-        return next(iter(self.open_lots)).last_sale_price
+        if self.amount == 0:
+            return 0
+        else:
+            return self.market_value / self.amount
 
     def close(self, amount, dt, price, method=None, lots=None):
 

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -234,14 +234,14 @@ class cached_property(object):
 class Position(object):
     def __init__(self, sid, amount=0, cost_basis=0.0,
                  last_sale_price=0.0, last_sale_date=None,
-                 default_lot_method=None):
+                 default_lot_instructions=None):
 
         self.sid = sid
         self.lots = set()
-        if default_lot_method is None:
-            default_lot_method = tax_lots.FIFO()
-        assert not isinstance(default_lot_method, tax_lots.SpecificLots)
-        self.default_lot_method = default_lot_method
+        if default_lot_instructions is None:
+            default_lot_instructions = tax_lots.FIFO()
+        assert not isinstance(default_lot_instructions, tax_lots.SpecificLots)
+        self.default_lot_instructions = default_lot_instructions
         self._cache = {}
 
         if amount != 0:
@@ -282,15 +282,15 @@ class Position(object):
         else:
             return self.market_value / self.amount
 
-    def close(self, amount, dt, price, method=None, lots=None):
+    def close(self, amount, dt, price, instructions=None, lots=None):
 
         if lots is None:
             lots = self.open_lots
 
-        if method is None:
-            method = self.default_lot_method
+        if instructions is None:
+            instructions = self.default_lot_instructions
 
-        closed_lots = method.close_lots(
+        closed_lots = instructions.close_lots(
             dt=dt, amount=amount, price=price, open_lots=lots)
 
         self.lots.update(closed_lots)

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -74,7 +74,7 @@ class Position_OLD(object):
         # cash dividend
         if dividend['net_amount']:
             out['cash_amount'] = self.amount * dividend['net_amount']
-        elif dividend['gross_amvount']:
+        elif dividend['gross_amount']:
             out['cash_amount'] = self.amount * dividend['gross_amount']
 
         payment_owed = zp.dividend_payment(out)

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -351,6 +351,17 @@ class Position(object):
     def adjust_commission_cost_basis(self, commission):
         raise NotImplementedError
 
+    def to_dict(self):
+        """
+        Creates a dictionary representing the state of this position.
+        Returns a dict object of the form:
+        """
+        return {
+            'sid': self.sid,
+            'amount': self.amount,
+            'cost_basis': self.cost_basis,
+            'last_sale_price': self.last_sale_price
+        }
 
 class positiondict(dict):
 

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -107,7 +107,7 @@ class Lot(object):
                 'Tried to close {new_amt} shares but this lot only '
                 'contains {amt}.'.format(new_amt=amount, amt=self.amount))
 
-        self.amount -= amount
+        self.amount += amount
 
         if self.amount == 0:
             closed_lot = self

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -251,12 +251,12 @@ class LIFO(LotMethod):
         return sorted(lots, key=lambda l: l.dt, reverse=True)
 
 
-class HighCost(LotMethod):
+class HIFO(LotMethod):
     def sort_lots(self, lots):
         return sorted(lots, key=lambda l: l.cost_basis)
 
 
-class LowCost(LotMethod):
+class LIFO(LotMethod):
     def sort_lots(self, lots):
         return sorted(lots, key=lambda l: l.cost_basis, reverse=True)
 

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -212,7 +212,7 @@ class Lot(object):
             'last_sale_price': self.last_sale_price,
             'market_value': self.market_value,
             'closed': self.closed,
-            'closed_dt': self.closed_dt
+            'close_dt': self.close_dt
         }
 
 

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -78,8 +78,9 @@ class Lot(object):
     def pnl(self):
         return self.amount * (self.last_sale_price - self.cost_basis)
 
-    def update_last_sale_price(self, price):
+    def update_last_sale(self, dt, price):
         self.last_sale_price = price
+        self.last_sale_date = dt
 
     def close(self, dt, amount, price):
         """

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -34,7 +34,10 @@ from math import (
 )
 
 import logbook
+import numpy as np
 import zipline.protocol as zp
+
+
 log = logbook.Logger('Lot')
 
 
@@ -94,7 +97,7 @@ class Lot(object):
             must be smaller in absolute value)
         :param price: the close price
         """
-        if copysign(1, amount) == copysign(1, self.amount):
+        if np.sign(amount) == np.sign(self.amount):
             raise ValueError(
                 'Close amount {new_amt} can not have the same sign as'
                 'Lot amount {amt}.'.format(new_amt=amount, amt=self.amount))
@@ -219,8 +222,8 @@ class LotMethod(object):
 
     def close_lots(self, amount, dt, price, open_lots):
         # get lots with opposite signs from amount
-        sgn = copysign(1, -amount)
-        lots = (l for l in open_lots if copysign(1, l.amount) == sgn)
+        lot_sgn = -np.sign(amount)
+        lots = (l for l in open_lots if copysign(1, l.amount) == lot_sgn)
 
         # sort lots
         sorted_lots = iter(self.sort_lots(lots))

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -149,8 +149,8 @@ class Lot(object):
     def handle_split(self, split):
         """
         Update the lot by the split ratio. If the split creates fractional
-        shares, return them to be turned into cash. If the Lot already contained
-        fractional shares, then they are maintained.
+        shares, return them to be turned into cash. If the Lot already
+        contained fractional shares, then they are maintained.
 
         Returns the unused cash.
 

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -262,8 +262,11 @@ class LIFO(LotMethod):
 
 
 class SpecificLots(LotMethod):
+    def __init__(self, lots):
+        self.lots = lots
+
     def sort_lots(self, lots):
-        return lots
+        return self.lots
 
 
 

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -216,7 +216,7 @@ class Lot(object):
         }
 
 
-class LotMethod(object):
+class LotInstructions(object):
     def sort_lots(self, lots):
         raise NotImplementedError()
 
@@ -245,32 +245,41 @@ class LotMethod(object):
         return closed_lots
 
 
-class FIFO(LotMethod):
+class FIFO(LotInstructions):
+    """
+    First In First Out
+    """
     def sort_lots(self, lots):
         return sorted(lots, key=lambda l: l.dt)
 
 
-class LIFO(LotMethod):
+class LIFO(LotInstructions):
+    """
+    Last In First Out
+    """
     def sort_lots(self, lots):
         return sorted(lots, key=lambda l: l.dt, reverse=True)
 
 
-class HIFO(LotMethod):
+class HIFO(LotInstructions):
+    """
+    Highest-cost In First Out
+    """
     def sort_lots(self, lots):
         return sorted(lots, key=lambda l: l.cost_basis)
 
 
-class LIFO(LotMethod):
+class LOFO(LotInstructions):
+    """
+    LOwest-cost in First Out
+    """
     def sort_lots(self, lots):
         return sorted(lots, key=lambda l: l.cost_basis, reverse=True)
 
 
-class SpecificLots(LotMethod):
+class SpecificLots(LotInstructions):
     def __init__(self, lots):
         self.lots = lots
 
     def sort_lots(self, lots):
         return self.lots
-
-
-

--- a/zipline/finance/tax_lots.py
+++ b/zipline/finance/tax_lots.py
@@ -1,0 +1,269 @@
+
+"""
+Position Lots
+=============
+
+    +-----------------+----------------------------------------------------+
+    | key             | value                                              |
+    +=================+====================================================+
+    | sid             | the identifier for the security held in this lot.  |
+    +-----------------+----------------------------------------------------+
+    | amount          | shares held in the lot                             |
+    +-----------------+----------------------------------------------------+
+    | dt              | date the lot was opened                            |
+    +-----------------+----------------------------------------------------+
+    | cost_basis      | cost (per share) at which the lot was opened       |
+    +-----------------+----------------------------------------------------+
+    | last_sale_price | price at last sale of the security                 |
+    +-----------------+----------------------------------------------------+
+    | closed          | whether the lot has been closed or remains open    |
+    +-----------------+----------------------------------------------------+
+    | close_dt        | the date on which the lot was closed               |
+    +-----------------+----------------------------------------------------+
+    | total_cost      | the total price paid to open the lot               |
+    +-----------------+----------------------------------------------------+
+    | market_value    | the current market value of the lot                |
+    +-----------------+----------------------------------------------------+
+
+"""
+
+from __future__ import division
+from math import (
+    copysign,
+    floor,
+)
+
+import logbook
+import zipline.protocol as zp
+log = logbook.Logger('Lot')
+
+
+class Lot(object):
+    def __init__(self, sid, dt, amount, cost_basis):
+        """
+        Note: no requirement that amount is a whole number. Fractional shares
+        are OK.
+
+        :param sid: sid
+        :param dt: open date
+        :param amount: lot shares
+        :param cost: cost per share
+        """
+        self.sid = sid
+        self.dt = dt
+        self.amount = amount
+        self.cost_basis = cost_basis
+        self.last_sale_price = cost_basis
+        self.closed = False
+        self.close_dt = None
+
+    @classmethod
+    def from_transaction(cls, txn):
+        lot = cls(
+            sid=txn.sid,
+            dt=txn.dt,
+            amount=txn.amount,
+            cost_basis=txn.price + txn.commission / txn.amount)
+        return lot
+
+    @property
+    def market_value(self):
+        return self.amount * self.last_sale_price
+
+    @property
+    def total_cost(self):
+        return self.amount * self.cost_basis
+
+    @property
+    def pnl(self):
+        return self.amount * (self.last_sale_price - self.cost_basis)
+
+    def update_last_sale_price(self, price):
+        self.last_sale_price = price
+
+    def close(self, dt, amount, price):
+        """
+        Closes some or all of the lot. In addition to modifiying this lot
+        inplace, a new Lot is returned representing the closed shares. If the
+        lot is entirely closed (amount == self.amount) then the returned lot
+        is this one.
+
+        :param dt: close date
+        :param amount: close amount (must have opposite sign of lot amount and
+            must be smaller in absolute value)
+        :param price: the close price
+        """
+        if copysign(1, amount) == copysign(1, self.amount):
+            raise ValueError(
+                'Close amount {new_amt} can not have the same sign as'
+                'Lot amount {amt}.'.format(new_amt=amount, amt=self.amount))
+
+        if abs(amount) > abs(self.amount):
+            raise ValueError(
+                'Tried to close {new_amt} shares but this lot only '
+                'contains {amt}.'.format(new_amt=amount, amt=self.amount))
+
+        self.amount -= amount
+
+        if self.amount == 0:
+            closed_lot = self
+        else:
+            closed_lot = Lot(
+                sid=self.sid,
+                dt=self.dt,
+                amount=amount,
+                cost_basis=self.cost_basis)
+
+        closed_lot.last_sale_price = price
+        closed_lot.closed = True
+        closed_lot.close_dt = dt
+
+        return closed_lot
+
+    def earn_dividend(self, dividend):
+        """
+        Register the number of shares we held at this dividend's ex date so
+        that we can pay out the correct amount on the dividend's pay date.
+        """
+        assert dividend['sid'] == self.sid
+        out = {'id': dividend['id']}
+
+        # stock dividend
+        if dividend['payment_sid']:
+            out['payment_sid'] = dividend['payment_sid']
+            out['share_count'] = floor(self.amount * float(dividend['ratio']))
+
+        # cash dividend
+        if dividend['net_amount']:
+            out['cash_amount'] = self.amount * dividend['net_amount']
+        elif dividend['gross_amvount']:
+            out['cash_amount'] = self.amount * dividend['gross_amount']
+
+        payment_owed = zp.dividend_payment(out)
+        return payment_owed
+
+    def handle_split(self, split):
+        """
+        Update the lot by the split ratio. If the split creates fractional
+        shares, return them to be turned into cash. If the Lot already contained
+        fractional shares, then they are maintained.
+
+        Returns the unused cash.
+
+        NOTE removes rounding from old Position code
+        """
+        if self.sid != split.sid:
+            raise Exception("updating split with the wrong sid!")
+
+        ratio = split.ratio
+
+        log.info("handling split for sid = " + str(split.sid) +
+                 ", ratio = " + str(split.ratio))
+        log.info("before split: " + str(self))
+
+        if floor(self.amount) == self.amount:
+            full_share_count = self.amount
+            fractional_share_count = 0
+        else:
+            # adjust the # of shares by the ratio
+            # (if we had 100 shares, and the ratio is 3,
+            #  we now have 33 shares)
+            # (old_share_count / ratio = new_share_count)
+            # (old_price * ratio = new_price)
+
+            # e.g., 33.333
+            raw_share_count = self.amount / float(ratio)
+
+            # e.g., 33
+            full_share_count = floor(raw_share_count)
+
+            # e.g., 0.333
+            fractional_share_count = raw_share_count - full_share_count
+
+        # adjust the cost_basis to the nearest cent, e.g., 60.0
+        new_cost = self.cost_basis * ratio
+
+        # adjust the last sale price
+        new_last_sale_price = self.last_sale_price * ratio
+
+        self.cost_basis = new_cost
+        self.last_sale_price = new_last_sale_price
+        self.amount = full_share_count
+
+        return_cash = fractional_share_count * new_cost
+
+        log.info("after split: " + str(self))
+        log.info("returning cash: " + str(return_cash))
+
+        # return the leftover cash, which will be converted into cash
+        return return_cash
+
+    def to_dict(self):
+        return {
+            'sid': self.sid,
+            'dt': self.dt,
+            'amount': self.amount,
+            'cost_basis': self.cost_basis,
+            'total_cost': self.total_cost,
+            'last_sale_price': self.last_sale_price,
+            'market_value': self.market_value,
+            'closed': self.closed,
+            'closed_dt': self.closed_dt
+        }
+
+
+class LotMethod(object):
+    def sort_lots(self, lots):
+        raise NotImplementedError()
+
+    def close_lots(self, amount, dt, price, open_lots):
+        # get lots with opposite signs from amount
+        sgn = copysign(1, -amount)
+        lots = (l for l in open_lots if copysign(1, l.amount) == sgn)
+
+        # sort lots
+        sorted_lots = iter(self.sort_lots(lots))
+        closed_lots = []
+
+        # close lots until shares are exhausted
+        while amount != 0:
+            try:
+                lot = next(sorted_lots)
+            except StopIteration:
+                raise ValueError(
+                    'Tried to close more lot shares than are available.')
+            abs_lot_amt = min(abs(lot.amount), abs(amount))
+            lot_amt = copysign(abs_lot_amt, amount)
+            closed_lot = lot.close(dt=dt, price=price, amount=lot_amt)
+            closed_lots.append(closed_lot)
+            amount -= lot_amt
+
+        return closed_lots
+
+
+class FIFO(LotMethod):
+    def sort_lots(self, lots):
+        return sorted(lots, key=lambda l: l.dt)
+
+
+class LIFO(LotMethod):
+    def sort_lots(self, lots):
+        return sorted(lots, key=lambda l: l.dt, reverse=True)
+
+
+class HighCost(LotMethod):
+    def sort_lots(self, lots):
+        return sorted(lots, key=lambda l: l.cost_basis)
+
+
+class LowCost(LotMethod):
+    def sort_lots(self, lots):
+        return sorted(lots, key=lambda l: l.cost_basis, reverse=True)
+
+
+class SpecificLots(LotMethod):
+    def sort_lots(self, lots):
+        return lots
+
+
+

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -199,6 +199,16 @@ class Positions(dict):
         return pos
 
 
+class Lot(object):
+    def __init__(self, sid):
+        self.sid = sid
+        self.amount = 0
+        self.cost_basis = 0.0
+        self.last_sale_price = 0.0
+        self.closed = False
+        self.close_dt = None
+
+
 class SIDData(object):
     # Cache some data on the class so that this is shared for all instances of
     # siddata.


### PR DESCRIPTION
Per conversation yesterday with @ehebert and @twiecki, this is a first cut at implementing a tax `lot` object that sits under a `position`.

As much as possible, this is supposed to be a "drop-in" replacement for the existing `Position` object, for illustrative and compatibility purposes. It _should_ work in most cases. The only non-`Position` code that was modified is the `update_position` method of the `PerformancePeriod` class. As a result there's a lot of `Position` code that is probably unnecessary but is kept for compatibility.

There is support for close instructions but I didn't change `order()` to allow them as an argument, so for the moment the default `FIFO` is always used.

Zipline makes a few assumptions that aren't really possible in a tax lot world (but are in its single-position world) like blanket adjustments of `amount` and `cost_basis`.

We can discuss further offline.
