### PR TITLE
allow order_percent to work with various market values

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -305,8 +305,8 @@ class TestTransformAlgorithm(TestCase):
         self.panel_source, self.panel = \
             factory.create_test_panel_source(self.sim_params)
 
-        self.df_2 = pd.concat([self.df] * 7, 1)
-        self.df_2.columns = range(7)
+        self.df_large = pd.concat([self.df] * 10, 1)
+        self.df_large.columns = range(10)
 
     def test_source_as_input(self):
         algo = TestRegisterTransformAlgorithm(
@@ -398,7 +398,7 @@ class TestTransformAlgorithm(TestCase):
             algo = AlgoClass(
                 sim_params=self.sim_params,
             )
-            algo.run(self.df_2)
+            algo.run(self.df_large)
 
     def test_order_method_style_forwarding(self):
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -45,11 +45,13 @@ from zipline.test_algorithms import (
     TestOrderAlgorithm,
     TestOrderInstantAlgorithm,
     TestOrderPercentAlgorithm,
+    TestOrderPercentAlgorithmPercentOf,
     TestOrderStyleForwardingAlgorithm,
     TestOrderValueAlgorithm,
     TestRegisterTransformAlgorithm,
     TestTargetAlgorithm,
     TestTargetPercentAlgorithm,
+    TestTargetPercentAlgorithmPercentOf,
     TestTargetValueAlgorithm,
     SetLongOnlyAlgorithm,
     SetMaxPositionSizeAlgorithm,
@@ -302,6 +304,9 @@ class TestTransformAlgorithm(TestCase):
         self.panel_source, self.panel = \
             factory.create_test_panel_source(self.sim_params)
 
+        self.df_2 = pd.concat([self.df] * 6, 1)
+        self.df_2.columns = range(6)
+
     def test_source_as_input(self):
         algo = TestRegisterTransformAlgorithm(
             sim_params=self.sim_params,
@@ -382,6 +387,16 @@ class TestTransformAlgorithm(TestCase):
                 sim_params=self.sim_params,
             )
             algo.run(self.df)
+
+        AlgoClasses2 = [
+            TestOrderPercentAlgorithmPercentOf,
+            TestTargetPercentAlgorithmPercentOf]
+
+        for AlgoClass in AlgoClasses2:
+            algo = AlgoClass(
+                sim_params=self.sim_params,
+            )
+            algo.run(self.df_2)
 
     def test_order_method_style_forwarding(self):
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -50,6 +50,7 @@ from zipline.test_algorithms import (
     TestOrderValueAlgorithm,
     TestRegisterTransformAlgorithm,
     TestTargetAlgorithm,
+    TestTargetAlgorithm_NonInt,
     TestTargetPercentAlgorithm,
     TestTargetPercentAlgorithmPercentOf,
     TestTargetValueAlgorithm,
@@ -378,6 +379,7 @@ class TestTransformAlgorithm(TestCase):
         AlgoClasses = [TestOrderAlgorithm,
                        TestOrderValueAlgorithm,
                        TestTargetAlgorithm,
+                       TestTargetAlgorithm_NonInt,
                        TestOrderPercentAlgorithm,
                        TestTargetPercentAlgorithm,
                        TestTargetValueAlgorithm]

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -305,8 +305,8 @@ class TestTransformAlgorithm(TestCase):
         self.panel_source, self.panel = \
             factory.create_test_panel_source(self.sim_params)
 
-        self.df_2 = pd.concat([self.df] * 6, 1)
-        self.df_2.columns = range(6)
+        self.df_2 = pd.concat([self.df] * 7, 1)
+        self.df_2.columns = range(7)
 
     def test_source_as_input(self):
         algo = TestRegisterTransformAlgorithm(

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -869,9 +869,9 @@ class TradingAlgorithm(object):
             portfolio (default): net portfolio value
             cash:                available cash
             ex_cash:             net invested capital, ex-cash
-            longs:               long invested capital plus cash
-            longs_only:          long invested capital, ex-cash
-            shorts:              short invested capital, ex-cash
+            longs:               long invested capital
+            longs_cash:          long invested capital plus cash
+            shorts:              short invested capital
 
         Alternatively, a filter_fn can be supplied. The filter_fn
         should accept a Position and return True if that Position's
@@ -896,19 +896,19 @@ class TradingAlgorithm(object):
         elif mv_type == 'ex_cash':
             mv = self.portfolio.portfolio_value - self.portfolio.cash
 
-        # long invested capital plus cash
+        # long invested capital
         elif mv_type == 'longs':
             mv = sum(
                 p.amount * p.last_sale_price
                 for p in self.portfolio.positions.values()
-                if p.amount > 0) + self.portfolio.cash
+                if p.amount > 0)
 
-        # long invested capital, excluding cash
-        elif mv_type == 'longs_only':
+        # long invested capital, plus cash
+        elif mv_type == 'longs_cash':
             mv = sum(
                 p.amount * p.last_sale_price
                 for p in self.portfolio.positions.values()
-                if p.amount > 0)
+                if p.amount > 0) + self.portfolio.cash
 
         # short invested capital
         elif mv_type == 'shorts':

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -868,9 +868,10 @@ class TradingAlgorithm(object):
         Options for mv_type are:
             portfolio (default): net portfolio value
             cash:                available cash
-            ex-cash:             net invested capital, ex-cash
-            longs:               long invested capital
-            shorts:              short invested capital
+            ex_cash:             net invested capital, ex-cash
+            longs:               long invested capital plus cash
+            longs_only:          long invested capital, ex-cash
+            shorts:              short invested capital, ex-cash
 
         Alternatively, a filter_fn can be supplied. The filter_fn
         should accept a Position and return True if that Position's
@@ -892,11 +893,18 @@ class TradingAlgorithm(object):
             mv = self.portfolio.cash
 
         # net invested capital
-        elif mv_type == 'ex-cash':
+        elif mv_type == 'ex_cash':
             mv = self.portfolio.portfolio_value - self.portfolio.cash
 
-        # long invested capital
+        # long invested capital plus cash
         elif mv_type == 'longs':
+            mv = sum(
+                p.amount * p.last_sale_price
+                for p in self.portfolio.positions.values()
+                if p.amount > 0) + self.portfolio.cash
+
+        # long invested capital, excluding cash
+        elif mv_type == 'longs_only':
             mv = sum(
                 p.amount * p.last_sale_price
                 for p in self.portfolio.positions.values()
@@ -931,8 +939,9 @@ class TradingAlgorithm(object):
             portfolio (default): net portfolio value
             cash:                available cash
             ex-cash:             net invested capital, ex-cash
-            longs:               long invested capital
-            shorts:              short invested capital
+            longs:               long invested capital plus cash
+            longs_only:          long invested capital, ex-cash
+            shorts:              short invested capital, ex-cash
 
         Alternatively, a percent_of_fn can be supplied. The percent_of_fn
         should accept a Position and return True if that Position's
@@ -1011,9 +1020,10 @@ class TradingAlgorithm(object):
         Options for percent_of are:
             portfolio (default): net portfolio value
             cash:                available cash
-            ex-cash:             net invested capital, ex-cash
-            longs:               long invested capital
-            shorts:              short invested capital
+            ex_cash:             net invested capital, ex-cash
+            longs:               long invested capital plus cash
+            longs_only:          long invested capital, ex-cash
+            shorts:              short invested capital, ex-cash
 
         Alternatively, a percent_of_fn can be supplied. The percent_of_fn
         should accept a Position and return True if that Position's

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -938,10 +938,10 @@ class TradingAlgorithm(object):
         Options for percent_of are:
             portfolio (default): net portfolio value
             cash:                available cash
-            ex-cash:             net invested capital, ex-cash
-            longs:               long invested capital plus cash
-            longs_only:          long invested capital, ex-cash
-            shorts:              short invested capital, ex-cash
+            ex_cash:             net invested capital, ex-cash
+            longs:               long invested capital
+            longs_cash:          long invested capital plus cash
+            shorts:              short invested capital
 
         Alternatively, a percent_of_fn can be supplied. The percent_of_fn
         should accept a Position and return True if that Position's
@@ -1021,9 +1021,9 @@ class TradingAlgorithm(object):
             portfolio (default): net portfolio value
             cash:                available cash
             ex_cash:             net invested capital, ex-cash
-            longs:               long invested capital plus cash
-            longs_only:          long invested capital, ex-cash
-            shorts:              short invested capital, ex-cash
+            longs:               long invested capital
+            longs_cash:          long invested capital plus cash
+            shorts:              short invested capital
 
         Alternatively, a percent_of_fn can be supplied. The percent_of_fn
         should accept a Position and return True if that Position's

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -917,14 +917,31 @@ class TradingAlgorithm(object):
 
     @api_method
     def order_percent(self, sid, percent,
-                      limit_price=None, stop_price=None, style=None):
+                      limit_price=None,
+                      stop_price=None,
+                      style=None,
+                      percent_of=None,
+                      percent_of_fn=None):
         """
         Place an order in the specified security corresponding to the given
-        percent of the current portfolio value.
+        percent of some market value. If no market value is specified (via
+        `percent_of`) then the net portfolio value is used.
+
+        Options for percent_of are:
+            portfolio (default): net portfolio value
+            cash:                available cash
+            ex-cash:             net invested capital, ex-cash
+            longs:               long invested capital
+            shorts:              short invested capital
+
+        Alternatively, a percent_of_fn can be supplied. The percent_of_fn
+        should accept a Position and return True if that Position's
+        market_value should be included in the total and False otherwise.
 
         Note that percent must expressed as a decimal (0.50 means 50\%).
         """
-        value = self.portfolio.portfolio_value * percent
+        mv = self.get_market_value(mv_type=percent_of, filter_fn=percent_of_fn)
+        value = percent * mv
         return self.order_value(sid, value,
                                 limit_price=limit_price,
                                 stop_price=stop_price,
@@ -978,17 +995,34 @@ class TradingAlgorithm(object):
 
     @api_method
     def order_target_percent(self, sid, target,
-                             limit_price=None, stop_price=None, style=None):
+                             limit_price=None,
+                             stop_price=None,
+                             style=None,
+                             percent_of=None,
+                             percent_of_fn=None):
         """
-        Place an order to adjust a position to a target percent of the
-        current portfolio value. If the position doesn't already exist, this is
+        Place an order to adjust a position to a target percent of some market
+        value. If no market value is specified (via `percent_of`) then the net
+        portfolio value is used. If the position doesn't already exist, this is
         equivalent to placing a new order. If the position does exist, this is
         equivalent to placing an order for the difference between the target
         percent and the current percent.
 
+        Options for percent_of are:
+            portfolio (default): net portfolio value
+            cash:                available cash
+            ex-cash:             net invested capital, ex-cash
+            longs:               long invested capital
+            shorts:              short invested capital
+
+        Alternatively, a percent_of_fn can be supplied. The percent_of_fn
+        should accept a Position and return True if that Position's
+        market_value should be included in the total and False otherwise.
+
         Note that target must expressed as a decimal (0.50 means 50\%).
         """
-        target_value = self.portfolio.portfolio_value * target
+        mv = self.get_market_value(mv_type=percent_of, filter_fn=percent_of_fn)
+        target_value = target * mv
         return self.order_target_value(sid, target_value,
                                        limit_price=limit_price,
                                        stop_price=stop_price,

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -973,7 +973,7 @@ class TradingAlgorithm(object):
         """
         if sid in self.portfolio.positions:
             current_position = self.portfolio.positions[sid].amount
-            req_shares = target - current_position
+            req_shares = round_shares(target) - current_position
             return self.order(sid, req_shares,
                               limit_price=limit_price,
                               stop_price=stop_price,

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -87,6 +87,21 @@ from zipline.history.history_container import HistoryContainer
 DEFAULT_CAPITAL_BASE = float("1.0e5")
 
 
+def round_if_near_integer(a, epsilon=1e-4):
+    """
+    Round a to the nearest integer if that integer is within an epsilon
+    of a.
+    """
+    if abs(a - round(a)) <= epsilon:
+        return round(a)
+    else:
+        return a
+
+
+def round_shares(shares):
+    return int(round_if_near_integer(shares))
+
+
 class TradingAlgorithm(object):
     """
     Base class for trading algorithms. Inherit and overload
@@ -633,20 +648,10 @@ class TradingAlgorithm(object):
         Place an order using the specified parameters.
         """
 
-        def round_if_near_integer(a, epsilon=1e-4):
-            """
-            Round a to the nearest integer if that integer is within an epsilon
-            of a.
-            """
-            if abs(a - round(a)) <= epsilon:
-                return round(a)
-            else:
-                return a
-
         # Truncate to the integer share count that's either within .0001 of
         # amount or closer to zero.
         # E.g. 3.9999 -> 4.0; 5.5 -> 5.0; -5.5 -> -5.0
-        amount = int(round_if_near_integer(amount))
+        amount = round_shares(amount)
 
         # Raises a ZiplineError if invalid parameters are detected.
         self.validate_order_params(sid,

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -871,12 +871,14 @@ class TradingAlgorithm(object):
         Returns the requested market value.
 
         Options for mv_type are:
-            portfolio (default): net portfolio value
-            cash:                available cash
-            ex_cash:             net invested capital, ex-cash
-            longs:               long invested capital
-            longs_cash:          long invested capital plus cash
-            shorts:              short invested capital
+            portfolio [default]:    net exposure or portfolio value
+            net:                    net exposure or portfolio value
+            gross:                  gross exposure
+            cash:                   available cash
+            ex_cash:                net invested capital, ex-cash
+            longs:                  long invested capital
+            longs_cash:             long invested capital plus cash
+            shorts:                 short invested capital
 
         Alternatively, a filter_fn can be supplied. The filter_fn
         should accept a Position and return True if that Position's
@@ -894,8 +896,11 @@ class TradingAlgorithm(object):
                 if filter_fn(p))
 
         # net portfolio value
-        elif mv_type is None or mv_type == 'portfolio':
+        elif mv_type is None or mv_type == 'portfolio' or mv_type == 'net':
             mv = period.ending_value + period.ending_cash
+
+        elif mv_type == 'gross':
+            mv = period._gross_exposure()
 
         # portfolio cash
         elif mv_type == 'cash':
@@ -936,12 +941,14 @@ class TradingAlgorithm(object):
         `percent_of`) then the net portfolio value is used.
 
         Options for percent_of are:
-            portfolio (default): net portfolio value
-            cash:                available cash
-            ex_cash:             net invested capital, ex-cash
-            longs:               long invested capital
-            longs_cash:          long invested capital plus cash
-            shorts:              short invested capital
+            portfolio [default]:    net exposure or portfolio value
+            net:                    net exposure or portfolio value
+            gross:                  gross exposure
+            cash:                   available cash
+            ex_cash:                net invested capital, ex-cash
+            longs:                  long invested capital
+            longs_cash:             long invested capital plus cash
+            shorts:                 short invested capital
 
         Alternatively, a percent_of_fn can be supplied. The percent_of_fn
         should accept a Position and return True if that Position's
@@ -1018,12 +1025,14 @@ class TradingAlgorithm(object):
         percent and the current percent.
 
         Options for percent_of are:
-            portfolio (default): net portfolio value
-            cash:                available cash
-            ex_cash:             net invested capital, ex-cash
-            longs:               long invested capital
-            longs_cash:          long invested capital plus cash
-            shorts:              short invested capital
+            portfolio [default]:    net exposure or portfolio value
+            net:                    net exposure or portfolio value
+            gross:                  gross exposure
+            cash:                   available cash
+            ex_cash:                net invested capital, ex-cash
+            longs:                  long invested capital
+            longs_cash:             long invested capital plus cash
+            shorts:                 short invested capital
 
         Alternatively, a percent_of_fn can be supplied. The percent_of_fn
         should accept a Position and return True if that Position's

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -79,7 +79,7 @@ from nose.tools import assert_raises
 from six.moves import range
 from six import itervalues
 
-from zipline.algorithm import TradingAlgorithm
+from zipline.algorithm import TradingAlgorithm, round_shares
 from zipline.api import FixedSlippage
 from zipline.errors import UnsupportedOrderParameters
 from zipline.finance.execution import (
@@ -372,14 +372,15 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
     def initialize(self):
         self.target_shares = 0
         self.sale_price = None
+        self.exp_value = 0
 
     def handle_data(self, data):
         if self.target_shares == 0:
             assert 0 not in self.portfolio.positions
             self.target_shares = 1
         else:
-            assert np.round(self.portfolio.portfolio_value * 0.002) == \
-                self.portfolio.positions[0]['amount'] * self.sale_price, \
+            value = self.portfolio.positions[0]['amount'] * self.sale_price
+            assert abs(value - self.exp_value) <= self.sale_price, \
                 "Orders not filled correctly."
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
@@ -406,7 +407,7 @@ class TestTargetValueAlgorithm(TradingAlgorithm):
                 data[0].price, "Orders not filled at current price."
 
         self.order_target_value(0, 20)
-        self.target_shares = np.round(20 / data[0].price)
+        self.target_shares = round_shares(20 / data[0].price)
 
 
 ############################

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -439,7 +439,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[3] += expected_shares(3, half * longs)
         self.target_shares[4] += expected_shares(4, half * (longs + cash))
         self.target_shares[5] += expected_shares(5, half * shorts)
-        self.target_shares[6] += expected_shares(5, half * group_val)
+        self.target_shares[6] += expected_shares(6, half * group_val)
 
 
 class TestTargetPercentAlgorithm(TradingAlgorithm):
@@ -508,7 +508,7 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[3] = expected_shares(3, half * longs)
         self.target_shares[4] = expected_shares(4, half * (longs + cash))
         self.target_shares[5] = expected_shares(5, half * shorts)
-        self.target_shares[6] = expected_shares(5, half * group_val)
+        self.target_shares[6] = expected_shares(6, half * group_val)
 
 
 class TestTargetValueAlgorithm(TradingAlgorithm):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -397,7 +397,7 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
 
 class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
     def initialize(self):
-        self.target_shares = dict([(i, 0) for i in range(6)])
+        self.target_shares = dict([(i, 0) for i in range(7)])
 
     def handle_data(self, data):
         for sid, target_shares in self.target_shares.items():
@@ -409,7 +409,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         half = 0.0005
 
         pos_values = {}
-        for i in range(6):
+        for i in range(7):
             pos_values[i] = (
                 self.portfolio.positions[i].amount
                 * self.portfolio.positions[i].last_sale_price)
@@ -465,7 +465,7 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
 
 class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
     def initialize(self):
-        self.target_shares = dict([(i, 0) for i in range(6)])
+        self.target_shares = dict([(i, 0) for i in range(7)])
 
     def handle_data(self, data):
 
@@ -478,7 +478,7 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         half = 0.0005
 
         pos_values = {}
-        for i in range(6):
+        for i in range(7):
             pos_values[i] = (
                 self.portfolio.positions[i].amount
                 * self.portfolio.positions[i].last_sale_price)

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -517,7 +517,6 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[7] = expected_shares(7, full * gross)
 
 
-
 class TestTargetValueAlgorithm(TradingAlgorithm):
     def initialize(self):
         self.target_shares = 0

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -397,7 +397,7 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
 
 class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
     def initialize(self):
-        self.target_shares = dict([(i, 0) for i in range(7)])
+        self.target_shares = dict([(i, 0) for i in range(8)])
 
     def handle_data(self, data):
         for sid, target_shares in self.target_shares.items():
@@ -409,7 +409,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         half = 0.0005
 
         pos_values = {}
-        for i in range(7):
+        for i in range(len(data.keys())):
             pos_values[i] = (
                 self.portfolio.positions[i].amount
                 * self.portfolio.positions[i].last_sale_price)
@@ -418,6 +418,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         cash = self.portfolio.cash
         longs = sum(v for v in pos_values.values() if v > 0)
         shorts = sum(v for v in pos_values.values() if v < 0)
+        gross = sum(abs(v) for v in pos_values.values())
         group = [0, 1, 2]
         group_val = sum(v for sid, v in pos_values.items() if sid in group)
 
@@ -432,6 +433,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         self.order_percent(5, half, percent_of='shorts')
         self.order_percent(
             6, half, percent_of_fn=lambda p: p.sid in group)
+        self.order_percent(7, full, percent_of='gross')
 
         self.target_shares[0] += expected_shares(0, full * port)
         self.target_shares[1] += expected_shares(1, -half * cash)
@@ -440,6 +442,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[4] += expected_shares(4, half * (longs + cash))
         self.target_shares[5] += expected_shares(5, half * shorts)
         self.target_shares[6] += expected_shares(6, half * group_val)
+        self.target_shares[7] += expected_shares(7, full * gross)
 
 
 class TestTargetPercentAlgorithm(TradingAlgorithm):
@@ -465,7 +468,7 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
 
 class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
     def initialize(self):
-        self.target_shares = dict([(i, 0) for i in range(7)])
+        self.target_shares = dict([(i, 0) for i in range(8)])
 
     def handle_data(self, data):
 
@@ -478,7 +481,7 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         half = 0.0005
 
         pos_values = {}
-        for i in range(7):
+        for i in range(len(data.keys())):
             pos_values[i] = (
                 self.portfolio.positions[i].amount
                 * self.portfolio.positions[i].last_sale_price)
@@ -487,6 +490,7 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         cash = self.portfolio.cash
         longs = sum(v for v in pos_values.values() if v > 0)
         shorts = sum(v for v in pos_values.values() if v < 0)
+        gross = sum(abs(v) for v in pos_values.values())
         group = [0, 1, 2]
         group_val = sum(v for sid, v in pos_values.items() if sid in group)
 
@@ -501,6 +505,7 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         self.order_target_percent(5, half, percent_of='shorts')
         self.order_target_percent(
             6, half, percent_of_fn=lambda p: p.sid in group)
+        self.order_target_percent(5, full, percent_of='gross')
 
         self.target_shares[0] = expected_shares(0, full * port)
         self.target_shares[1] = expected_shares(1, -half * cash)
@@ -509,6 +514,8 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[4] = expected_shares(4, half * (longs + cash))
         self.target_shares[5] = expected_shares(5, half * shorts)
         self.target_shares[6] = expected_shares(6, half * group_val)
+        self.target_shares[7] = expected_shares(7, full * gross)
+
 
 
 class TestTargetValueAlgorithm(TradingAlgorithm):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -416,8 +416,10 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
 
         port = self.portfolio.portfolio_value
         cash = self.portfolio.cash
-        longs = sum(v for sid, v in pos_values.items() if v > 0)
-        shorts = sum(v for sid, v in pos_values.items() if v < 0)
+        longs = sum(v for v in pos_values.values() if v > 0)
+        shorts = sum(v for v in pos_values.values() if v < 0)
+        group = [0, 1, 2]
+        group_val = sum(v for sid, v in pos_values.items() if sid in group)
 
         def expected_shares(sid, value):
             return round_shares(value / data[sid].price)
@@ -428,6 +430,8 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         self.order_percent(3, half, percent_of='longs')
         self.order_percent(4, half, percent_of='longs_cash')
         self.order_percent(5, half, percent_of='shorts')
+        self.order_percent(
+            6, half, percent_of_fn=lambda p: p.sid in group)
 
         self.target_shares[0] += expected_shares(0, full * port)
         self.target_shares[1] += expected_shares(1, -half * cash)
@@ -435,6 +439,7 @@ class TestOrderPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[3] += expected_shares(3, half * longs)
         self.target_shares[4] += expected_shares(4, half * (longs + cash))
         self.target_shares[5] += expected_shares(5, half * shorts)
+        self.target_shares[6] += expected_shares(5, half * group_val)
 
 
 class TestTargetPercentAlgorithm(TradingAlgorithm):
@@ -480,8 +485,10 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
 
         port = self.portfolio.portfolio_value
         cash = self.portfolio.cash
-        longs = sum(v for sid, v in pos_values.items() if v > 0)
-        shorts = sum(v for sid, v in pos_values.items() if v < 0)
+        longs = sum(v for v in pos_values.values() if v > 0)
+        shorts = sum(v for v in pos_values.values() if v < 0)
+        group = [0, 1, 2]
+        group_val = sum(v for sid, v in pos_values.items() if sid in group)
 
         def expected_shares(sid, value):
             return round_shares(value / data[sid].price)
@@ -492,6 +499,8 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         self.order_target_percent(3, half, percent_of='longs')
         self.order_target_percent(4, half, percent_of='longs_cash')
         self.order_target_percent(5, half, percent_of='shorts')
+        self.order_target_percent(
+            6, half, percent_of_fn=lambda p: p.sid in group)
 
         self.target_shares[0] = expected_shares(0, full * port)
         self.target_shares[1] = expected_shares(1, -half * cash)
@@ -499,6 +508,7 @@ class TestTargetPercentAlgorithmPercentOf(TradingAlgorithm):
         self.target_shares[3] = expected_shares(3, half * longs)
         self.target_shares[4] = expected_shares(4, half * (longs + cash))
         self.target_shares[5] = expected_shares(5, half * shorts)
+        self.target_shares[6] = expected_shares(5, half * group_val)
 
 
 class TestTargetValueAlgorithm(TradingAlgorithm):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -345,6 +345,33 @@ class TestTargetAlgorithm(TradingAlgorithm):
         self.order_target(0, self.target_shares)
 
 
+class TestTargetAlgorithm_NonInt(TradingAlgorithm):
+    def initialize(self):
+        self.target_shares = 0
+        self.sale_price = None
+        self.i = 0
+
+    def handle_data(self, data):
+        if self.target_shares == 0:
+            assert 0 not in self.portfolio.positions
+        else:
+            assert self.portfolio.positions[0]['amount'] == \
+                self.target_shares, "Orders not filled correctly."
+            assert self.portfolio.positions[0]['last_sale_price'] == \
+                data[0].price, "Orders not filled at current price."
+
+        if self.i == 0:
+            self.target_shares = 5
+            self.order_target(0, 5.1)
+        elif self.i == 1:
+            self.target_shares = 10
+            self.order_target(0, 10.1)
+        elif self.i == 2:
+            self.target_shares = 5
+            self.order_target(0, 5.1)
+        self.i += 1
+
+
 class TestOrderPercentAlgorithm(TradingAlgorithm):
     def initialize(self):
         self.target_shares = 0


### PR DESCRIPTION
Currently, `order_percent()` and `order_target_percent()` both operate as a percentage of `self.portfolio.portfolio_value`. This PR lets them operate as percentages of other important MVs.

(also adds `context.get_market_value()`, which enables this functionality)

For example:

``` python
# this is how it works today (and this still works)
# put 50% of my portfolio in AAPL
order_percent('AAPL', 0.5)
# note that if this were a fully invested portfolio, it would become 150% levered.

# take half of my available cash and buy AAPL
order_percent('AAPL', 0.5, percent_of='cash')

# rebalance my short position, as a percentage of my current short book
order_target_percent('MSFT', 0.1, percent_of='shorts')

# rebalance within a custom group of stocks
tech_stocks = ('AAPL', 'MSFT', 'GOOGL')
tech_filter = lambda p: p.sid in tech_stocks
for stock in tech_stocks:
    order_target_percent(stock, 1/3, percent_of_fn=tech_filter)
```
