### PR TITLE
Fix zipline magic

### DIFF
--- a/zipline/__init__.py
+++ b/zipline/__init__.py
@@ -34,7 +34,7 @@ from . import api
 try:
     ip = get_ipython()  # flake8: noqa
     ip.register_magic_function(utils.parse_cell_magic, "line_cell", "zipline")
-except:
+except NameError:
     pass
 
 __all__ = [

--- a/zipline/utils/cli.py
+++ b/zipline/utils/cli.py
@@ -185,10 +185,16 @@ def run_pipeline(print_algo=True, **kwargs):
         else:
             print_(algo_text)
 
-    algo = zipline.TradingAlgorithm(script=algo_text,
-                                    namespace=kwargs.get('namespace', {}),
-                                    capital_base=float(kwargs['capital_base']),
-                                    algo_filename=kwargs.get('algofile'))
+    algo_filename = kwargs.get('algofile')
+    if algo_filename is None:
+        algo_filename = '<string>'
+
+    algo = zipline.TradingAlgorithm(
+        script=algo_text,
+        namespace=kwargs.get('namespace', {}),
+        capital_base=float(kwargs['capital_base']),
+        algo_filename=algo_filename,
+    )
 
     perf = algo.run(source)
 


### PR DESCRIPTION
The %%zipline magic is currently broken if you don't pass an algofile, which is what we do in our one example .ipynb file.