### PR TITLE
Remove hardcoded volume

### DIFF
--- a/zipline/sources/data_frame_source.py
+++ b/zipline/sources/data_frame_source.py
@@ -23,6 +23,7 @@ from zipline.gens.utils import hash_args
 
 from zipline.sources.data_source import DataSource
 
+params = {'ds_volume': 1000}
 
 class DataFrameSource(DataSource):
     """
@@ -73,7 +74,7 @@ class DataFrameSource(DataSource):
                         'dt': dt,
                         'sid': sid,
                         'price': price,
-                        'volume': 1000,
+                        'volume': params['ds_volume'],
                     }
                     yield event
 

--- a/zipline/sources/data_frame_source.py
+++ b/zipline/sources/data_frame_source.py
@@ -25,6 +25,7 @@ from zipline.sources.data_source import DataSource
 
 params = {'ds_volume': 1000}
 
+
 class DataFrameSource(DataSource):
     """
     Yields all events in event_list that match the given sid_filter.


### PR DESCRIPTION
This hardcoded `volume` parameter is extremely confining. This is a quick way to let users override it.