### PR TITLE
Update test matrix to test both pandas 0.12.0 and 0.15.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.7"
   - "3.3"
+env:
+  - PANDAS_VERSION=0.15.2
+  - PANDAS_VERSION=0.12.0
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
@@ -11,7 +14,7 @@ before_install:
 install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
-  - conda install --yes -c https://conda.binstar.org/twiecki numpy=1.9.0 scipy nose matplotlib pandas Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
+  - conda install --yes -c https://conda.binstar.org/twiecki numpy=1.9.0 scipy nose matplotlib pandas=$PANDAS_VERSION Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
   - grep pyflakes== etc/requirements_dev.txt | xargs pip install
   - grep pep8== etc/requirements_dev.txt | xargs pip install
   - grep mccabe== etc/requirements_dev.txt | xargs pip install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   - python: 2.7
     env:
       - PANDAS_VERSION=0.12.0
-      - NUMPY_VERSION=1.7.1
+      - NUMPY_VERSION=1.8.0
   - python: 3.3
     env:
       - PANDAS_VERSION=0.15.2
@@ -18,7 +18,7 @@ before_install:
 install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
-  - conda install --yes -c https://conda.binstar.org/twiecki numpy=$NUMPY_VERSION scipy nose matplotlib pandas=$PANDAS_VERSION Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
+  - conda install --yes -c https://conda.binstar.org/Quantopian numpy=$NUMPY_VERSION pandas=$PANDAS_VERSION scipy nose matplotlib Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
   - grep pyflakes== etc/requirements_dev.txt | xargs pip install
   - grep pep8== etc/requirements_dev.txt | xargs pip install
   - grep mccabe== etc/requirements_dev.txt | xargs pip install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   - python: 2.7
     env:
       - PANDAS_VERSION=0.12.0
-      - NUMPY_VERSION=1.7.0
+      - NUMPY_VERSION=1.7.1
   - python: 3.3
     env:
       - PANDAS_VERSION=0.15.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-env:
-  - PANDAS_VERSION=0.15.2
-  - PANDAS_VERSION=0.12.0
+matrix:
+  include:
+  - python: 2.7
+    env:
+      - PANDAS_VERSION=0.12.0
+      - NUMPY_VERSION=1.7.0
+  - python: 3.3
+    env:
+      - PANDAS_VERSION=0.15.2
+      - NUMPY_VERSION=1.9.0
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
@@ -14,7 +18,7 @@ before_install:
 install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
-  - conda install --yes -c https://conda.binstar.org/twiecki numpy=1.9.0 scipy nose matplotlib pandas=$PANDAS_VERSION Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
+  - conda install --yes -c https://conda.binstar.org/twiecki numpy=$NUMPY_VERSION scipy nose matplotlib pandas=$PANDAS_VERSION Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
   - grep pyflakes== etc/requirements_dev.txt | xargs pip install
   - grep pep8== etc/requirements_dev.txt | xargs pip install
   - grep mccabe== etc/requirements_dev.txt | xargs pip install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ matrix:
     env:
       - PANDAS_VERSION=0.12.0
       - NUMPY_VERSION=1.8.0
+  - python: 2.7
+    env:
+      - PANDAS_VERSION=0.13.1
+      - NUMPY_VERSION=1.8.0
+  - python: 2.7
+    env:
+      - PANDAS_VERSION=0.14.1
+      - NUMPY_VERSION=1.8.0
   - python: 3.3
     env:
       - PANDAS_VERSION=0.15.2


### PR DESCRIPTION
So this will test a 2x2 matrix.

py 2.7 pandas 0.12.0
py 2.7 pandas 0.15.2
py 3.3 pandas 0.12.0
py 3.3 pandas 0.15.2

It might be overkill to test all 4. Maybe py 2.7/pandas 0.12.0 and py3.3/pandas 0.15.2 would suffice. 

Either way, if we're supporting 0.12.0 it should be in the test matrix somewhere.