### PR TITLE
BUG: Remove sid entry from open_orders when there are none.

### DIFF
--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -307,11 +307,9 @@ class FinanceTestCase(TestCase):
         cumulative_pos = tracker.cumulative_performance.positions[sid]
         self.assertEqual(total_volume, cumulative_pos.amount)
 
-        # the open orders should now be empty
+        # the open orders should not contain sid.
         oo = blotter.open_orders
-        self.assertTrue(sid in oo)
-        order_list = oo[sid]
-        self.assertEqual(0, len(order_list))
+        self.assertNotIn(sid, oo, "Entry is removed when no open orders")
 
     def test_blotter_processes_splits(self):
         sim_params = factory.create_simulation_parameters()

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -210,10 +210,15 @@ class Blotter(object):
             yield txn, order
 
         # update the open orders for the trade_event's sid
-        self.open_orders[trade_event.sid] = \
+        updated_orders = \
             [order for order
-             in self.open_orders[trade_event.sid]
-             if order.open]
+                in self.open_orders[trade_event.sid]
+                if order.open]
+
+        if updated_orders:
+            self.open_orders[trade_event.sid] = updated_orders
+        else:
+            del self.open_orders[trade_event.sid]
 
     def process_transactions(self, trade_event, current_orders):
         for order, txn in self.transact(trade_event, current_orders):


### PR DESCRIPTION
Note, this changes behavior as it removed the entry if there are no open orders. 

Technically speaking, just setting an empty list is faster than deleting the key, but checking key membership is a more common operation and faster than checking for an empty list. AFAIK, most users won't constantly alternate each tick with resting/canceling orders.