### PR TITLE
MAINT: Provide a function to create the position calc containers.

### DIFF
--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -122,9 +122,7 @@ class PerformancePeriod(object):
         self.keep_transactions = keep_transactions
         self.keep_orders = keep_orders
 
-        # Arrays for quick calculations of positions value
-        self._position_amounts = OrderedDict()
-        self._position_last_sale_prices = OrderedDict()
+        self.initialize_position_calc_arrays()
 
         self.calculate_performance()
 
@@ -141,6 +139,11 @@ class PerformancePeriod(object):
         )
 
         self.loc_map = {}
+
+    def initialize_position_calc_arrays(self):
+        # Arrays for quick calculations of positions value.
+        self._position_amounts = OrderedDict()
+        self._position_last_sale_prices = OrderedDict()
 
     def set_positions(self, positions):
         self.positions = positions


### PR DESCRIPTION
For use in a function that wraps de-serialization, to call instead of
creating the OrderedDicts from a module outside of the object.

So that the other module does not need to the internals of this object,
also to ensure that the cythonized OrderedDict is used, when available.

This need should be superseded with serialization versioning.