### PR TITLE
BUG: Initial digest frame was set with object dtype.

### DIFF
--- a/zipline/history/history_container.py
+++ b/zipline/history/history_container.py
@@ -648,7 +648,7 @@ class HistoryContainer(object):
         if bar_count == 1:
             # slicing with [1 - bar_count:] doesn't work when bar_count == 1,
             # so special-casing this.
-            res = pd.DataFrame(index=[], columns=self.sids)
+            res = pd.DataFrame(index=[], columns=self.sids, dtype=float)
             return res.values, res.index
 
         field = history_spec.field


### PR DESCRIPTION
The dtype propogates on actual history frame creation and makes certian older numpy funcs like nanmean barf. Broken in 1.8.0, works in 1.8.1