### PR TITLE
Siddata max bars

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -24,3 +24,7 @@ Cython==0.20.1
 
 # faster OrderedDict
 cyordereddict==0.2.2
+
+# faster array ops. Note once numpy gets to 1.9.1 we
+# we can bump to 1.0.0
+bottleneck==0.8.0

--- a/zipline/history/history_container.py
+++ b/zipline/history/history_container.py
@@ -648,7 +648,7 @@ class HistoryContainer(object):
         if bar_count == 1:
             # slicing with [1 - bar_count:] doesn't work when bar_count == 1,
             # so special-casing this.
-            res = pd.DataFrame(index=[], columns=self.sids)
+            res = pd.DataFrame(index=[], columns=self.sids, dtype=float)
             return res.values, res.index
 
         field = history_spec.field

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -321,6 +321,14 @@ class SIDData(object):
         point to a new function object.
 
         """
+        def daily_get_max_bars(days):
+            return days
+
+        def minute_get_max_bars(days):
+            # max number of minute. regardless of current days or short
+            # sessions
+            return days * 390
+
         def daily_get_bars(days):
             return days
 
@@ -358,28 +366,33 @@ class SIDData(object):
             self._freqstr = '1d'
             # update this method to point to the daily variant.
             self._get_bars = daily_get_bars
+            self._get_max_bars = daily_get_max_bars
         else:
             self._freqstr = '1m'
             # update this method to point to the minute variant.
             self._get_bars = minute_get_bars
+            self._get_max_bars = minute_get_max_bars
 
         # Not actually recursive because we have already cached the new method.
         return self._get_bars(days)
 
     def mavg(self, days):
         bars = self._get_bars(days)
-        prices = self._get_buffer(bars, raw=True)
+        max_bars = self._get_max_bars(days)
+        prices = self._get_buffer(max_bars, raw=True)[-bars:]
         return nanmean(prices)
 
     def stddev(self, days):
         bars = self._get_bars(days)
-        prices = self._get_buffer(bars, raw=True)
+        max_bars = self._get_max_bars(days)
+        prices = self._get_buffer(max_bars, raw=True)[-bars:]
         return nanstd(prices, ddof=1)
 
     def vwap(self, days):
         bars = self._get_bars(days)
-        prices = self._get_buffer(bars, raw=True)
-        vols = self._get_buffer(bars, field='volume', raw=True)
+        max_bars = self._get_max_bars(days)
+        prices = self._get_buffer(max_bars, raw=True)[-bars:]
+        vols = self._get_buffer(max_bars, field='volume', raw=True)[-bars:]
 
         vol_sum = nansum(vols)
         try:

--- a/zipline/utils/math_utils.py
+++ b/zipline/utils/math_utils.py
@@ -14,22 +14,21 @@
 # limitations under the License.
 
 import math
-import numpy as np
 
 
 def tolerant_equals(a, b, atol=10e-7, rtol=10e-7):
     return math.fabs(a - b) <= (atol + rtol * math.fabs(b))
 
 
-nanmean = np.nanmean
-nanstd = np.nanstd
-nansum = np.nansum
-
-
 try:
+    # fast versions
     import bottleneck as bn
     nanmean = bn.nanmean
     nanstd = bn.nanstd
     nansum = bn.nansum
 except ImportError:
-    pass
+    # slower numpy
+    import numpy as np
+    nanmean = np.nanmean
+    nanstd = np.nanstd
+    nansum = np.nansum

--- a/zipline/utils/math_utils.py
+++ b/zipline/utils/math_utils.py
@@ -14,7 +14,22 @@
 # limitations under the License.
 
 import math
+import numpy as np
 
 
 def tolerant_equals(a, b, atol=10e-7, rtol=10e-7):
     return math.fabs(a - b) <= (atol + rtol * math.fabs(b))
+
+
+nanmean = np.nanmean
+nanstd = np.nanstd
+nansum = np.nansum
+
+
+try:
+    import bottleneck as bn
+    nanmean = bn.nanmean
+    nanstd = bn.nanstd
+    nansum = bn.nansum
+except ImportError:
+    pass


### PR DESCRIPTION
Interesting. For whatever reasons my setup isn't backfilling and thus I don't get the penalty for the resize. 

So, this will request the max size from the get go thus minimizing any panel size enlargements/backfills. 

The other side of this is that the backfills should never have been occurring since no new data was requested, but that's an internal thing.

Not entirely sure how much we care about not having History specs for 290 bars. It's not as if they are user defined specs to begin with. 