### PR TITLE
BUG: Added sorting back to orders. This isn't a functional bug so much

### DIFF
--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -200,6 +200,7 @@ class Blotter(object):
             return
 
         orders = self.open_orders[trade_event.sid]
+        orders.sort(key=lambda o: o.dt)
         # Only use orders for the current day or before
         current_orders = filter(
             lambda o: o.dt <= trade_event.dt,


### PR DESCRIPTION
as it is a backwards compat. Without sorting the orders are filled by
order date. With sorting the orders are moved to back of queue after
partil fills. If all orders are fully filled, there is no
deviation. Also there is no portfolio difference as this is about
assigning fills to equivalent orders.