### PR TITLE
problem when backtesting minutes datasource with local timezone index

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -439,9 +439,9 @@ class TradingAlgorithm(object):
         # Override sim_params if params are provided by the source.
         if overwrite_sim_params:
             if hasattr(source, 'start'):
-                self.sim_params.period_start = source.start
+                self.sim_params.period_start = source.start.tz_convert("UTC")
             if hasattr(source, 'end'):
-                self.sim_params.period_end = source.end
+                self.sim_params.period_end = source.end.tz_convert("UTC")
             all_sids = [sid for s in self.sources for sid in s.sids]
             self.sim_params.sids = set(all_sids)
             # Changing period_start and period_close might require updating

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -180,22 +180,17 @@ Fetching data from Yahoo Finance.
 
     # If more than 1 trading days has elapsed since the last day where
     # we have data,then we need to update
-    if len(days_up_to_now) - last_bm_date_offset > 1:
+    if len(days_up_to_now) - 1 - last_bm_date_offset > 1:
         benchmark_returns = update_benchmarks(bm_symbol, last_bm_date)
-        if (
-            benchmark_returns.index.tz is None
-            or
-            benchmark_returns.index.tz.zone != 'UTC'
-        ):
-            benchmark_returns = benchmark_returns.tz_localize('UTC')
     else:
         benchmark_returns = saved_benchmarks
-        if (
-            benchmark_returns.index.tz is None
-            or
-            benchmark_returns.index.tz.zone != 'UTC'
-        ):
-            benchmark_returns = benchmark_returns.tz_localize('UTC')
+
+    if (
+        benchmark_returns.index.tz is None
+        or
+        benchmark_returns.index.tz.zone != 'UTC'
+    ):
+        benchmark_returns = benchmark_returns.tz_localize('UTC')
 
     # Get treasury curve module, filename & source from mapping.
     # Default to USA.
@@ -221,7 +216,7 @@ Fetching data from {0}
 
     # If more than 1 trading days has elapsed since the last day where
     # we have data,then we need to update
-    if len(days_up_to_now) - last_tr_date_offset > 1:
+    if len(days_up_to_now) - 1 - last_tr_date_offset > 1:
         treasury_curves = dump_treasury_curves(module, filename)
     else:
         treasury_curves = saved_curves.tz_localize('UTC')


### PR DESCRIPTION
  When I am trying to run my algorithm locally, every time,
zipline tried to fetch the data which was not yet available.
The problem is the len() is total numbers, but searchsorted()
returns index which is 0 based.

  Also minor refactor to remove duplicate code block.
