### PR TITLE
Fixing calendar unittest to compare with benchmark data

### DIFF
--- a/tests/test_tradingcalendar.py
+++ b/tests/test_tradingcalendar.py
@@ -26,7 +26,6 @@ from nose.tools import nottest
 
 class TestTradingCalendar(TestCase):
 
-    @nottest
     def test_calendar_vs_environment(self):
         """
         test_calendar_vs_environment checks whether the
@@ -36,11 +35,11 @@ class TestTradingCalendar(TestCase):
         """
 
         env = TradingEnvironment()
-        env_start_index = \
-            env.trading_days.searchsorted(tradingcalendar.start)
-        env_days = env.trading_days[env_start_index:]
-        cal_days = tradingcalendar.trading_days
-        self.check_days(env_days, cal_days)
+        bench_days = env.benchmark_returns[tradingcalendar.start:].index
+        bounds = env.trading_days.slice_locs(start=tradingcalendar.start,
+                                             end=bench_days[-1])
+        env_days = env.trading_days[bounds[0]:bounds[1]]
+        self.check_days(env_days, bench_days)
 
     @nottest
     def test_lse_calendar_vs_environment(self):


### PR DESCRIPTION
The test function `test_calendar_vs_environment` is currently commented out and the underlying test doesn't do what its supposed to do which is compare the calendar generated by tradingcalendar.py and the the GSPC benchmark. This PR aims to alleviate this by setting `cal_days` (renamed to `bench_days`) to be the index of the benchmark rather than `tradingcalendar.trading_days`.