### PR TITLE
Handle a ValueError on from_csv calls

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -15,7 +15,7 @@ patsy==0.3.0
 statsmodels==0.6.1
 
 # Don't use 2.4.0.
-python-dateutil==2.4.1
+python-dateutil==2.4.2
 six==1.9.0
 
 # For fetching remote data

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -1,5 +1,5 @@
 # Testing
-nose==1.3.4
+nose==1.3.6
 nose-parameterized==0.3.5
 nose-ignore-docstring==0.2
 xlrd==0.9.3

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -158,7 +158,7 @@ def load_market_data(bm_symbol='^GSPC'):
     bm_filepath = get_data_filepath(get_benchmark_filename(bm_symbol))
     try:
         saved_benchmarks = pd.Series.from_csv(bm_filepath)
-    except (OSError, IOError):
+    except (OSError, IOError, ValueError):
         print("""
 data files aren't distributed with source.
 Fetching data from Yahoo Finance.
@@ -202,7 +202,7 @@ Fetching data from Yahoo Finance.
     tr_filepath = get_data_filepath(filename)
     try:
         saved_curves = pd.DataFrame.from_csv(tr_filepath)
-    except (OSError, IOError):
+    except (OSError, IOError, ValueError):
         print("""
 data files aren't distributed with source.
 Fetching data from {0}

--- a/zipline/gens/utils.py
+++ b/zipline/gens/utils.py
@@ -60,13 +60,3 @@ def assert_trade_protocol(event):
 def assert_datasource_unframe_protocol(event):
     """Assert that an event is valid output of zp.DATASOURCE_UNFRAME."""
     assert event.type in DATASOURCE_TYPE
-
-
-def assert_sort_protocol(event):
-    """Assert that an event is valid input to zp.FEED_FRAME."""
-    assert event.type in DATASOURCE_TYPE
-
-
-def assert_sort_unframe_protocol(event):
-    """Same as above."""
-    assert event.type in DATASOURCE_TYPE


### PR DESCRIPTION
The cached market data could be corrupted. Pandas raises a ValueError in that case, and this error handles it.