### PR TITLE
ENH: Add Max Drawdown Duration as a risk parameter

### DIFF
--- a/tests/risk/test_risk_cumulative.py
+++ b/tests/risk/test_risk_cumulative.py
@@ -17,6 +17,7 @@ import unittest
 
 import datetime
 import numpy as np
+import pandas as pd
 import pytz
 import zipline.finance.risk as risk
 from zipline.utils import factory
@@ -116,3 +117,21 @@ class TestRisk(unittest.TestCase):
                 self.cumulative_metrics_06.max_drawdowns[dt],
                 value,
                 err_msg="Mismatch at %s" % (dt,))
+
+    def test_drawdown_duration(self):
+        returns = factory.create_returns_from_list(
+            [1.0, -0.5, 0.8, .17, 1.0, -0.1, -0.45], self.sim_params)
+        # 200, 100, 180, 210.6, 421.2, 379.8, 208.494
+        drawdown_duration = pd.Series(
+            [0, 2, 3, 3, 3, 3, 3], index=returns.index)
+
+        metrics = risk.RiskMetricsCumulative(self.sim_params)
+
+        for dt, value in returns.iteritems():
+            metrics.update(dt,
+                           value,
+                           0,  # benchmark used so set to zero
+                           {'leverage': 0.0})
+
+        for dt, value in drawdown_duration.iteritems():
+            self.assertEqual(metrics.max_drawdown_durations[dt], value)

--- a/tests/risk/test_risk_period.py
+++ b/tests/risk/test_risk_period.py
@@ -102,6 +102,15 @@ class TestRisk(unittest.TestCase):
                                          returns)
         self.assertEqual(metrics.max_drawdown, 0.505)
 
+    def test_drawdown_duration(self):
+        returns = factory.create_returns_from_list(
+            [1.0, -0.5, 0.8, .17, 1.0, -0.1, -0.45], self.sim_params)
+        # 200, 100, 180, 210.6, 421.2, 379.8, 208.494
+        metrics = risk.RiskMetricsPeriod(returns.index[0],
+                                         returns.index[-1],
+                                         returns)
+        self.assertEqual(metrics.max_drawdown_duration, 3)
+
     def test_benchmark_returns_06(self):
 
         np.testing.assert_almost_equal(

--- a/zipline/finance/risk/report.py
+++ b/zipline/finance/risk/report.py
@@ -51,6 +51,10 @@ Risk Report
     |                 | for the portfolio returns between self.start_date  |
     |                 | and self.end_date.                                 |
     +-----------------+----------------------------------------------------+
+    | max_drawdown\   | The longest drawdown period (must not necessarily  |
+    | _duration       | be the period that contains max_drawdown but it    |
+    |                 | can be).                                           |
+    +-----------------+----------------------------------------------------+
     | max_leverage    | The largest gross leverage between self.start_date |
     |                 | and self.end_date                                  |
     +-----------------+----------------------------------------------------+

--- a/zipline/finance/risk/risk.py
+++ b/zipline/finance/risk/risk.py
@@ -51,10 +51,13 @@ Risk Report
     |                 | for the portfolio returns between self.start_date  |
     |                 | and self.end_date.                                 |
     +-----------------+----------------------------------------------------+
+    | max_drawdown\   | The longest drawdown period (must not necessarily  |
+    | _duration       | be the period that contains max_drawdown but it    |
+    |                 | can be).                                           |
+    +-----------------+----------------------------------------------------+
     | max_leverage    | The largest gross leverage between self.start_date |
     |                 | and self.end_date                                  |
     +-----------------+----------------------------------------------------+
-
 
 """
 


### PR DESCRIPTION
As well as _Max Drawdown_ the _Max Drawdown Duration_ is also widely used to evaluate strategies and it would be a great addition to the set of risk parameters. 
To test the cumulative and period calculations of MDD I used `factory.create_returns_from_list` and gave the same array used in `test_risk_period.TestRisk.test_drawdown`. One misgiving I have is that this array is possible too short for a thorough test but unfortunately I don't know exactly how I could add an additional longer answer to the AnswerKey.
Also I have calculated everything in terms of days. Will that still hold when the algo has a frequency of minutes? Are the risk parameters still calculated on a daily basis?
Note: the  _Max Drawdown Duration_ is the duration of the longest drawdown and not the duration of the _Max Drawdown_.
