### PR TITLE
MAINT: Change expected type of treasury curves from load to DataFrame.

### DIFF
--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -229,17 +229,7 @@ def load_market_data(trading_day=trading_day_nyse,
     else:
         treasury_curves = saved_curves.tz_localize('UTC')
 
-    tr_curves = {}
-    for tr_dt, curve in treasury_curves.T.iteritems():
-        # tr_dt = tr_dt.replace(hour=0, minute=0, second=0, microsecond=0,
-        #                       tzinfo=pytz.utc)
-        tr_curves[tr_dt] = curve.to_dict()
-
-    tr_curves = OrderedDict(sorted(
-        ((dt, c) for dt, c in iteritems(tr_curves)),
-        key=lambda t: t[0]))
-
-    return benchmark_returns, tr_curves
+    return benchmark_returns, treasury_curves
 
 
 def _load_raw_yahoo_data(indexes=None, stocks=None, start=None, end=None):

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -92,6 +92,11 @@ class TradingEnvironment(object):
         max_date=None,
         env_trading_calendar=tradingcalendar
     ):
+        """
+        @load is function that returns benchmark_returns and treasury_curves
+        The treasury_curves are expected to be a DataFrame with an index of
+        dates and columns of the curve names, e.g. '10year', '1month', etc.
+        """
         self.trading_day = env_trading_calendar.trading_day.copy()
 
         # `tc_td` is short for "trading calendar trading days"
@@ -116,10 +121,9 @@ class TradingEnvironment(object):
         if not load:
             load = load_market_data
 
-        self.benchmark_returns, treasury_curves_map = \
+        self.benchmark_returns, self.treasury_curves = \
             load(self.trading_day, self.trading_days, self.bm_symbol)
 
-        self.treasury_curves = pd.DataFrame(treasury_curves_map).T
         if max_date:
             tr_c = self.treasury_curves
             # Mask the treasury curves down to the current date.


### PR DESCRIPTION
Instead of converting the curves back and forth from dictionaries to
DataFrame and back, use the DataFrame format when passing to
environment.

## Extra Notes

Ran across this while examining how curves were cached in our internal client. Looking to port over to caching just the DataFrame, and making the type expected by load the same DataFrame type that is cached by the Zipline loader is the most straight forward way to not need to store a large amount of dictionaries.