### PR TITLE
Reduce memory footprint of minute emission algorithms.

### DIFF
--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -116,7 +116,6 @@ class PerformanceTracker(object):
         if self.emission_rate == 'daily':
             self.all_benchmark_returns = pd.Series(
                 index=self.trading_days)
-            self.intraday_risk_metrics = None
             self.cumulative_risk_metrics = \
                 risk.RiskMetricsCumulative(self.sim_params)
 
@@ -124,8 +123,6 @@ class PerformanceTracker(object):
             self.all_benchmark_returns = pd.Series(index=pd.date_range(
                 self.sim_params.first_open, self.sim_params.last_close,
                 freq='Min'))
-            self.intraday_risk_metrics = \
-                risk.RiskMetricsCumulative(self.sim_params)
 
             self.cumulative_risk_metrics = \
                 risk.RiskMetricsCumulative(self.sim_params,
@@ -281,7 +278,6 @@ class PerformanceTracker(object):
             _dict.update({'daily_perf': self.todays_performance.to_dict()})
         elif emission_type == 'minute':
             _dict.update({
-                'intraday_risk_metrics': self.intraday_risk_metrics.to_dict(),
                 'minute_perf': self.todays_performance.to_dict(self.saved_dt)
             })
 
@@ -401,22 +397,10 @@ class PerformanceTracker(object):
         todays_date = normalize_date(dt)
         account = self.get_account(True)
 
-        minute_returns = self.minute_performance.returns
         self.minute_performance.rollover()
-        # the intraday risk is calculated on top of minute performance
-        # returns for the bench and the algo
-        self.intraday_risk_metrics.update(dt,
-                                          minute_returns,
-                                          self.all_benchmark_returns[dt],
-                                          account)
 
-        # Duplicate intraday_risk_metrics work of calculating the benchmark
-        # returns since open.
-        # intraday_risk_metrics is marked for removal.
-        #
-        # This redundant work is in anticipation of no longer being able to
-        # depend on the 'since open' calculations in intraday_risk_metrics.
         bench_returns = self.all_benchmark_returns.loc[todays_date:dt]
+        # cumulative returns
         bench_since_open = (1. + bench_returns).prod() - 1
 
         self.cumulative_risk_metrics.update(todays_date,
@@ -436,10 +420,6 @@ class PerformanceTracker(object):
         Function called at market close only when emitting at minutely
         frequency.
         """
-        # update_performance should have been called in handle_minute_close
-        # so it is not repeated here.
-        self.intraday_risk_metrics = \
-            risk.RiskMetricsCumulative(self.sim_params)
         # increment the day counter before we move markers forward.
         self.day_count += 1.0
         self.market_open = new_mkt_open

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -275,11 +275,10 @@ class PerformanceTracker(object):
             'cumulative_risk_metrics': self.cumulative_risk_metrics.to_dict()
         }
         if emission_type == 'daily':
-            _dict.update({'daily_perf': self.todays_performance.to_dict()})
+            _dict['daily_perf'] = self.todays_performance.to_dict()
         elif emission_type == 'minute':
-            _dict.update({
-                'minute_perf': self.todays_performance.to_dict(self.saved_dt)
-            })
+            _dict['minute_perf'] = self.todays_performance.to_dict(
+                self.saved_dt)
 
         return _dict
 

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -410,8 +410,14 @@ class PerformanceTracker(object):
                                           self.all_benchmark_returns[dt],
                                           account)
 
-        bench_since_open = \
-            self.intraday_risk_metrics.benchmark_cumulative_returns[dt]
+        # Duplicate intraday_risk_metrics work of calculating the benchmark
+        # returns since open.
+        # intraday_risk_metrics is marked for removal.
+        #
+        # This redundant work is in anticipation of no longer being able to
+        # depend on the 'since open' calculations in intraday_risk_metrics.
+        bench_returns = self.all_benchmark_returns.loc[todays_date:dt]
+        bench_since_open = (1. + bench_returns).prod() - 1
 
         self.cumulative_risk_metrics.update(todays_date,
                                             self.todays_performance.returns,


### PR DESCRIPTION
The intraday_risk_metrics is being removed since the values are not
used; cumulative risk metrics with the last value updated to the latest
close has been used for some time.

Before the removal of intraday_risk_metrics, the position trackers
passing of benchmark returns to the cumulative risk metrics needs to no
longer depend on the calculations done by the intraday stats. So instead
use the all_benchmark_returns stored in the tracker directly.

The memory issues could be further tuned ala https://github.com/quantopian/zipline/commit/00ea7b04d10f095d064256f4dedff29c095466f3, but cutting this off at the root is simpler.

Effect shown by logging RSS and VM highwater mark for a noop algo using minute emissions.
(Over two months the usage is ~200MB vs. ~750MB)

![image](https://cloud.githubusercontent.com/assets/185744/7419877/fc9c0a8c-ef45-11e4-8dfe-820302edb2f6.png)