### PR TITLE
BUG: Correct method for finding security lists directory

### DIFF
--- a/zipline/utils/security_list.py
+++ b/zipline/utils/security_list.py
@@ -8,7 +8,7 @@ import zipline
 
 
 DATE_FORMAT = "%Y%m%d"
-zipline_dir = os.path.join(*zipline.__path__)
+zipline_dir = os.path.dirname(zipline.__file__)
 SECURITY_LISTS_DIR = os.path.join(zipline_dir, 'resources', 'security_lists')
 
 


### PR DESCRIPTION
The correct thing to look at to figure out where the root of the
zipline tree is, is `zipline.__file__`, not `zipline.__path__`. The
latter could contain multiple directories in it, and is not intended
to be `os.path.join()`ed as the previous code was doing.