### PR TITLE
MAINT: Remove unused event_count from tracker.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -229,7 +229,6 @@ def check_perf_tracker_serialization(perf_tracker):
         'last_close',
         '_dividend_count',
         'period_start',
-        'event_count',
         'day_count',
         'capital_base',
         'market_close',

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -183,7 +183,6 @@ class PerformanceTracker(object):
         # one indexed so that we reach 100%
         self.day_count = 0.0
         self.txn_count = 0
-        self.event_count = 0
 
         self.account_needs_update = True
         self._account = None
@@ -283,7 +282,6 @@ class PerformanceTracker(object):
         return _dict
 
     def process_event(self, event):
-        self.event_count += 1
 
         if event.type == zp.DATASOURCE_TYPE.TRADE:
             # update last sale


### PR DESCRIPTION
event_count is not referenced anywhere, so remove extra bit of state
tracking.