### PR TITLE
PERF: Use specific methods for processing events.

### DIFF
--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -286,9 +286,11 @@ class FinanceTestCase(TestCase):
 
                     for txn, order in blotter.process_trade(event):
                         transactions.append(txn)
-                        tracker.process_event(txn)
-
-                tracker.process_event(event)
+                        tracker.process_transaction(txn)
+                elif event.type == DATASOURCE_TYPE.BENCHMARK:
+                    tracker.process_benchmark(event)
+                elif event.type == DATASOURCE_TYPE.TRADE:
+                    tracker.process_trade(event)
 
         if complete_fill:
             self.assertEqual(len(transactions), len(order_list))

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -201,17 +201,23 @@ def calculate_results(host,
 
         for txn in filter(lambda txn: txn.dt == date, txns):
             # Process txns for this date.
-            perf_tracker.process_event(txn)
+            perf_tracker.process_transaction(txn)
 
         for event in group:
 
-            perf_tracker.process_event(event)
-            if event.type == zp.DATASOURCE_TYPE.BENCHMARK:
+            if event.type == zp.DATASOURCE_TYPE.TRADE:
+                perf_tracker.process_trade(event)
+            elif event.type == zp.DATASOURCE_TYPE.DIVIDEND:
+                perf_tracker.process_dividend(event)
+            elif event.type == zp.DATASOURCE_TYPE.BENCHMARK:
+                perf_tracker.process_benchmark(event)
                 bm_updated = True
+            elif event.type == zp.DATASOURCE_TYPE.COMMISSION:
+                perf_tracker.process_commission(event)
 
         for split in filter(lambda split: split.dt == date, splits):
             # Process splits for this date.
-            perf_tracker.process_event(split)
+            perf_tracker.process_split(split)
 
         if bm_updated:
             msg = perf_tracker.handle_market_close_daily()
@@ -1770,7 +1776,14 @@ class TestPerformanceTracker(unittest.TestCase):
 
         for date, group in grouped_events:
             for event in group:
-                perf_tracker.process_event(event)
+                if event.type == zp.DATASOURCE_TYPE.TRADE:
+                    perf_tracker.process_trade(event)
+                elif event.type == zp.DATASOURCE_TYPE.ORDER:
+                    perf_tracker.process_order(event)
+                elif event.type == zp.DATASOURCE_TYPE.BENCHMARK:
+                    perf_tracker.process_benchmark(event)
+                elif event.type == zp.DATASOURCE_TYPE.TRANSACTION:
+                    perf_tracker.process_transaction(event)
             msg = perf_tracker.handle_market_close_daily()
             perf_messages.append(msg)
 
@@ -1877,7 +1890,14 @@ class TestPerformanceTracker(unittest.TestCase):
             for date, group in grouped_events:
                 tracker.set_date(date)
                 for event in group:
-                    tracker.process_event(event)
+                    if event.type == zp.DATASOURCE_TYPE.TRADE:
+                        tracker.process_trade(event)
+                    elif event.type == zp.DATASOURCE_TYPE.BENCHMARK:
+                        tracker.process_benchmark(event)
+                    elif event.type == zp.DATASOURCE_TYPE.ORDER:
+                        tracker.process_order(event)
+                    elif event.type == zp.DATASOURCE_TYPE.TRANSACTION:
+                        tracker.process_transaction(event)
                 tracker.handle_minute_close(date)
                 msg = tracker.to_dict()
                 messages[date] = msg

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -190,9 +190,11 @@ class Blotter(object):
         for order in orders_to_modify:
             order.handle_split(split_event)
 
+    def process_benchmark(self, benchmark_event):
+        return
+        yield
+
     def process_trade(self, trade_event):
-        if trade_event.type != zp.DATASOURCE_TYPE.TRADE:
-            return
 
         if trade_event.sid not in self.open_orders:
             return


### PR DESCRIPTION
By having both the trade simulation main loop route events to "process"
methods based on event type and the process methods also checking event
type, there was some duplicated effort in doing that comparison many
times.

A particular case where this was noted in profiling was for the
`process_event` function which was checking if the type was not a trade
and returning early, when in a larger universe of stocks the value
returned False 99% of the time.

Instead provide separate process functions specific to each type,
e.g. e.g. `process_trade` and `process_transaction` and route traffic to
those functions in tradesimulation.

For a universe of 160 stocks on both no-op algo and an algo that rebuys
its universe every day, saw about a 10% increase locally.