### PR TITLE
DEP: Removes use of 'count'-defined test sources

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -135,7 +135,6 @@ class TestMiscellaneousAPI(TestCase):
         )
         self.source = factory.create_minutely_trade_source(
             sids,
-            trade_count=100,
             sim_params=self.sim_params,
             concurrent=True,
         )

--- a/tests/test_algorithm_gen.py
+++ b/tests/test_algorithm_gen.py
@@ -134,7 +134,6 @@ class AlgorithmGeneratorTestCase(TestCase):
         algo = TestAlgo(self, sim_params=sim_params)
         trade_source = factory.create_daily_trade_source(
             [8229],
-            200,
             sim_params
         )
         algo.set_sources([trade_source])
@@ -205,7 +204,6 @@ class AlgorithmGeneratorTestCase(TestCase):
         algo = TestAlgo(self, sim_params=sim_params)
         trade_source = factory.create_daily_trade_source(
             [8229],
-            3,
             sim_params
         )
         algo.set_sources([trade_source])

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -72,7 +72,6 @@ class FinanceTestCase(TestCase):
         sim_params = factory.create_simulation_parameters()
         trade_source = factory.create_daily_trade_source(
             [133],
-            200,
             sim_params
         )
         prev = None

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -41,6 +41,7 @@ def handle_data_wrapper(f):
         else:
             context.mins_for_days[-1] += 1
 
+        hist = context.history(2, '1d', 'close_price')
         for n in (1, 2, 3):
             if n in data:
                 if data[n].dt == dt:
@@ -53,7 +54,7 @@ def handle_data_wrapper(f):
                 context.price_bars[n].append(np.nan)
                 context.vol_bars[n].append(0)
 
-            context.last_close_prices[n] = context.price_bars[n][-2]
+            context.last_close_prices[n] = hist[n][0]
 
         if context.warmup < 0:
             return f(context, data)
@@ -101,6 +102,7 @@ def with_algo(f):
             initialize=initialize_with(self, tfm_name, days),
             handle_data=handle_data_wrapper(f),
             sim_params=sim_params,
+            identifiers=[1, 2, 3]
         )
         algo.run(source)
 
@@ -131,12 +133,10 @@ class TransformTestCase(TestCase):
         cls.sim_and_source = {
             'minute': (minute_sim_ps, factory.create_minutely_trade_source(
                 cls.sids,
-                trade_count=45,
                 sim_params=minute_sim_ps,
             )),
             'daily': (daily_sim_ps, factory.create_trade_source(
                 cls.sids,
-                trade_count=90,
                 trade_time_increment=timedelta(days=1),
                 sim_params=daily_sim_ps,
             )),

--- a/zipline/utils/simfactory.py
+++ b/zipline/utils/simfactory.py
@@ -42,13 +42,6 @@ def create_test_zipline(**config):
     else:
         order_amount = 100
 
-    if 'trade_count' in config:
-        trade_count = config['trade_count']
-    else:
-        # to ensure all orders are filled, we provide one more
-        # trade than order
-        trade_count = 101
-
     # -------------------
     # Create the Algo
     # -------------------
@@ -72,7 +65,6 @@ def create_test_zipline(**config):
     else:
         trade_source = factory.create_daily_trade_source(
             sid_list,
-            trade_count,
             test_algo.sim_params,
             concurrent=concurrent_trades
         )


### PR DESCRIPTION
Test sources are now defined by the sim_params period_start and period_end, rather than by the period_start and a defined 'count' of bars. This allows us to consider the sim_params.period_end as the canonical definition of the end of a simulation.