### PR TITLE
ENH: allow passing of data type to DataSource

### DIFF
--- a/zipline/sources/data_source.py
+++ b/zipline/sources/data_source.py
@@ -45,11 +45,12 @@ class DataSource(with_metaclass(ABCMeta)):
         """
         Override this to hand craft conversion of row.
         """
-        row = {target: mapping_func(raw_row[source_key])
-               for target, (mapping_func, source_key)
-               in self.mapping.items()}
-        row.update({'source_id': self.get_hash()})
+        row = {}
         row.update({'type': self.event_type})
+        row.update({target: mapping_func(raw_row[source_key])
+                    for target, (mapping_func, source_key)
+                    in self.mapping.items()})
+        row.update({'source_id': self.get_hash()})
         return row
 
     @property


### PR DESCRIPTION
The way ```DataSource``` is currently implemented only ```DATASOURCE_TYPE.TRADE``` is allowed. In this PR I want to allow the type to be passed with the data and if not then ```TRADE``` is used as default.
cc @ehebert @jfkirk @ssanderson