### PR TITLE
Futures trading

### DIFF
--- a/docs/release-notes/zipline-0.8.0.md
+++ b/docs/release-notes/zipline-0.8.0.md
@@ -44,11 +44,10 @@
   > running with minute data, then this will calculate the number of minutes in
   > those days, accounting for early closes and the current time and apply the
   > transform over the set of minutes. `returns` takes no parameters and will
-  > return the daily returns of the given security.
+  > return the daily returns of the given asset.
 
   > Example:
 ```python
-# The standard deviation of the price in the last 3 days.
 data[security].stddev(3)
 ```
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1290,7 +1290,6 @@ class TestAccountControls(TestCase):
         algo = SetMaxLeverageAlgorithm(1)
         self.check_algo_succeeds(algo, handle_data)
 
-
 class TestClosePosAlgo(TestCase):
 
     def setUp(self):
@@ -1303,10 +1302,15 @@ class TestClosePosAlgo(TestCase):
                      DATASOURCE_TYPE.CLOSE_POSITION]},
             index=self.index)
         })
-
         self.data = DataPanelSource(pan)
+
+        metadata = {1: {'symbol': 'TEST',
+                        'asset_type': 'future',
+                        'notice_date': days[2],
+                        'expiration_date': days[3]}}
         self.algo = TestAlgorithm(sid=1, amount=1, order_count=1,
-                                  instant_fill=True, commission=PerShare(0))
+                                  instant_fill=True, commission=PerShare(0),
+                                  asset_metadata=metadata)
         self.results = self.run_algo()
         self.expected_positions = [1, 1, 0]
         self.expected_pnl = [0, 1, 2]

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -36,6 +36,7 @@ from zipline.errors import (
     RegisterTradingControlPostInit,
     TradingControlViolation,
     AccountControlViolation,
+    SymbolNotFound,
 )
 from zipline.test_algorithms import (
     access_account_in_init,
@@ -55,6 +56,7 @@ from zipline.test_algorithms import (
     TestTargetPercentAlgorithm,
     TestTargetValueAlgorithm,
     SetLongOnlyAlgorithm,
+    SetAssetDateBoundsAlgorithm,
     SetMaxPositionSizeAlgorithm,
     SetMaxOrderCountAlgorithm,
     SetMaxOrderSizeAlgorithm,
@@ -85,6 +87,9 @@ from zipline.sources import (SpecificEquityTrades,
                              DataFrameSource,
                              DataPanelSource,
                              RandomWalkSource)
+from zipline.assets import (
+    Equity, Future
+)
 
 from zipline.finance.execution import LimitOrder
 from zipline.finance.trading import SimulationParameters
@@ -178,12 +183,12 @@ class TestMiscellaneousAPI(TestCase):
             if algo.minute == 0:
 
                 # Should be filled by the next minute
-                algo.order(1, 1)
+                algo.order(algo.sid(1), 1)
 
                 # Won't be filled because the price is too low.
-                algo.order(2, 1, style=LimitOrder(0.01))
-                algo.order(2, 1, style=LimitOrder(0.01))
-                algo.order(2, 1, style=LimitOrder(0.01))
+                algo.order(algo.sid(2), 1, style=LimitOrder(0.01))
+                algo.order(algo.sid(2), 1, style=LimitOrder(0.01))
+                algo.order(algo.sid(2), 1, style=LimitOrder(0.01))
 
                 all_orders = algo.get_open_orders()
                 self.assertEqual(list(all_orders.keys()), [1, 2])
@@ -293,6 +298,58 @@ class TestMiscellaneousAPI(TestCase):
 
         self.assertIs(composer, zipline.utils.events.ComposedRule.lazy_and)
 
+    def test_asset_lookup(self):
+        metadata = {0: {'symbol': 'PLAY',
+                        'asset_type': 'equity',
+                        'start_date': '2002-01-01',
+                        'end_date': '2004-01-01'},
+                    1: {'symbol': 'PLAY',
+                        'asset_type': 'equity',
+                        'start_date': '2005-01-01',
+                        'end_date': '2006-01-01'},
+                    2: {'symbol': 'OMG15',
+                        'asset_type': 'future'}}
+        algo = TradingAlgorithm(asset_metadata=metadata)
+
+        # Test before either PLAY existed
+        algo.datetime = pd.Timestamp('2001-12-01', tz='UTC')
+        self.assertEqual(2, algo.symbol('OMG15'))
+        with self.assertRaises(SymbolNotFound):
+            algo.symbol('PLAY')
+        with self.assertRaises(SymbolNotFound):
+            algo.symbols('PLAY', 'OMG15')
+
+        # Test when first PLAY exists
+        algo.datetime = pd.Timestamp('2002-12-01', tz='UTC')
+        self.assertEqual(2, algo.symbol('OMG15'))
+        self.assertEqual(0, algo.symbol('PLAY'))
+        list_result = algo.symbols('PLAY', 'OMG15')
+        self.assertEqual(0, list_result[0])
+        self.assertEqual(2, list_result[1])
+
+        # Test after first PLAY ends
+        algo.datetime = pd.Timestamp('2004-12-01', tz='UTC')
+        self.assertEqual(2, algo.symbol('OMG15'))
+        self.assertEqual(0, algo.symbol('PLAY'))
+
+        # Test after second PLAY begins
+        algo.datetime = pd.Timestamp('2005-12-01', tz='UTC')
+        self.assertEqual(2, algo.symbol('OMG15'))
+        self.assertEqual(1, algo.symbol('PLAY'))
+
+        # Test after second PLAY ends
+        algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
+        self.assertEqual(2, algo.symbol('OMG15'))
+        self.assertEqual(1, algo.symbol('PLAY'))
+        list_result = algo.symbols('PLAY', 'OMG15')
+        self.assertEqual(1, list_result[0])
+        self.assertEqual(2, list_result[1])
+
+        # Test lookup SID
+        self.assertIsInstance(algo.sid(0), Equity)
+        self.assertIsInstance(algo.sid(1), Equity)
+        self.assertIsInstance(algo.sid(2), Future)
+
 
 class TestTransformAlgorithm(TestCase):
     def setUp(self):
@@ -384,19 +441,36 @@ class TestTransformAlgorithm(TestCase):
         )
         self.assertEqual(algo.sim_params.data_frequency, 'minute')
 
-    def test_order_methods(self):
-        AlgoClasses = [TestOrderAlgorithm,
-                       TestOrderValueAlgorithm,
-                       TestTargetAlgorithm,
-                       TestOrderPercentAlgorithm,
-                       TestTargetPercentAlgorithm,
-                       TestTargetValueAlgorithm]
+    @parameterized.expand([
+        (TestOrderAlgorithm,),
+        (TestOrderValueAlgorithm,),
+        (TestTargetAlgorithm,),
+        (TestOrderPercentAlgorithm,),
+        (TestTargetPercentAlgorithm,),
+        (TestTargetValueAlgorithm,),
+    ])
+    def test_order_methods(self, algo_class):
+        algo = algo_class(
+            sim_params=self.sim_params,
+        )
+        algo.run(self.df)
 
-        for AlgoClass in AlgoClasses:
-            algo = AlgoClass(
-                sim_params=self.sim_params,
-            )
-            algo.run(self.df)
+    @parameterized.expand([
+        (TestOrderAlgorithm,),
+        (TestOrderValueAlgorithm,),
+        (TestTargetAlgorithm,),
+        (TestOrderPercentAlgorithm,),
+        (TestTargetValueAlgorithm,),
+    ])
+    def test_order_methods_for_future(self, algo_class):
+        metadata = {0: {'asset_type': 'future',
+                        'contract_multiplier': 10}}
+
+        algo = algo_class(
+            sim_params=self.sim_params,
+            asset_metadata=metadata
+        )
+        algo.run(self.df)
 
     def test_order_method_style_forwarding(self):
 
@@ -493,7 +567,8 @@ class TestAlgoScript(TestCase):
             self.sim_params
         )
 
-        self.source = SpecificEquityTrades(event_list=trade_history)
+        self.source = SpecificEquityTrades(sids=[133],
+                                           event_list=trade_history)
         self.df_source, self.df = \
             factory.create_test_df_source(self.sim_params)
 
@@ -543,7 +618,8 @@ from zipline.api import (slippage,
                          set_slippage,
                          set_commission,
                          order,
-                         record)
+                         record,
+                         sid)
 
 def initialize(context):
     model = slippage.FixedSlippage(spread=0.10)
@@ -554,7 +630,7 @@ def initialize(context):
 
 def handle_data(context, data):
     if context.incr < context.count:
-        order(0, -1000)
+        order(sid(0), -1000)
     record(price=data[0].price)
 
     context.incr += 1""",
@@ -607,7 +683,7 @@ def handle_data(context, data):
     if context.incr < context.count:
         # order small lots to be sure the
         # order will fill in a single transaction
-        order(0, 5000)
+        order(sid(0), 5000)
     record(price=data[0].price)
     record(volume=data[0].volume)
     record(incr=context.incr)
@@ -877,6 +953,7 @@ class TestGetDatetime(TestCase):
         algo = TradingAlgorithm(
             script=algo,
             sim_params=sim_params,
+            identifiers=[1]
         )
         algo.run(source)
         self.assertFalse(algo.first_bar)
@@ -923,7 +1000,7 @@ class TestTradingControls(TestCase):
 
         # Buy one share four times.  Should be fine.
         def handle_data(algo, data):
-            algo.order(self.sid, 1)
+            algo.order(algo.sid(self.sid), 1)
             algo.order_count += 1
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid,
                                            max_shares=10,
@@ -933,7 +1010,7 @@ class TestTradingControls(TestCase):
         # Buy three shares four times.  Should bail on the fourth before it's
         # placed.
         def handle_data(algo, data):
-            algo.order(self.sid, 3)
+            algo.order(algo.sid(self.sid), 3)
             algo.order_count += 1
 
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid,
@@ -944,7 +1021,7 @@ class TestTradingControls(TestCase):
         # Buy two shares four times. Should bail due to max_notional on the
         # third attempt.
         def handle_data(algo, data):
-            algo.order(self.sid, 3)
+            algo.order(algo.sid(self.sid), 3)
             algo.order_count += 1
 
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid,
@@ -955,7 +1032,7 @@ class TestTradingControls(TestCase):
         # Set the trading control to a different sid, then BUY ALL THE THINGS!.
         # Should continue normally.
         def handle_data(algo, data):
-            algo.order(self.sid, 10000)
+            algo.order(algo.sid(self.sid), 10000)
             algo.order_count += 1
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid + 1,
                                            max_shares=10,
@@ -965,7 +1042,7 @@ class TestTradingControls(TestCase):
         # Set the trading control sid to None, then BUY ALL THE THINGS!. Should
         # fail because setting sid to None makes the control apply to all sids.
         def handle_data(algo, data):
-            algo.order(self.sid, 10000)
+            algo.order(algo.sid(self.sid), 10000)
             algo.order_count += 1
         algo = SetMaxPositionSizeAlgorithm(max_shares=10, max_notional=61.0)
         self.check_algo_fails(algo, handle_data, 0)
@@ -977,7 +1054,7 @@ class TestTradingControls(TestCase):
             restricted_list=[self.sid])
 
         def handle_data(algo, data):
-            algo.order(self.sid, 100)
+            algo.order(algo.sid(self.sid), 100)
             algo.order_count += 1
 
         self.check_algo_fails(algo, handle_data, 0)
@@ -988,7 +1065,7 @@ class TestTradingControls(TestCase):
             restricted_list=[134, 135, 136])
 
         def handle_data(algo, data):
-            algo.order(self.sid, 100)
+            algo.order(algo.sid(self.sid), 100)
             algo.order_count += 1
 
         self.check_algo_succeeds(algo, handle_data)
@@ -997,7 +1074,7 @@ class TestTradingControls(TestCase):
 
         # Buy one share.
         def handle_data(algo, data):
-            algo.order(self.sid, 1)
+            algo.order(algo.sid(self.sid), 1)
             algo.order_count += 1
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid,
                                         max_shares=10,
@@ -1007,7 +1084,7 @@ class TestTradingControls(TestCase):
         # Buy 1, then 2, then 3, then 4 shares.  Bail on the last attempt
         # because we exceed shares.
         def handle_data(algo, data):
-            algo.order(self.sid, algo.order_count + 1)
+            algo.order(algo.sid(self.sid), algo.order_count + 1)
             algo.order_count += 1
 
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid,
@@ -1018,7 +1095,7 @@ class TestTradingControls(TestCase):
         # Buy 1, then 2, then 3, then 4 shares.  Bail on the last attempt
         # because we exceed notional.
         def handle_data(algo, data):
-            algo.order(self.sid, algo.order_count + 1)
+            algo.order(algo.sid(self.sid), algo.order_count + 1)
             algo.order_count += 1
 
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid,
@@ -1029,7 +1106,7 @@ class TestTradingControls(TestCase):
         # Set the trading control to a different sid, then BUY ALL THE THINGS!.
         # Should continue normally.
         def handle_data(algo, data):
-            algo.order(self.sid, 10000)
+            algo.order(algo.sid(self.sid), 10000)
             algo.order_count += 1
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid + 1,
                                         max_shares=1,
@@ -1040,7 +1117,7 @@ class TestTradingControls(TestCase):
         # Should fail because not specifying a sid makes the trading control
         # apply to all sids.
         def handle_data(algo, data):
-            algo.order(self.sid, 10000)
+            algo.order(algo.sid(self.sid), 10000)
             algo.order_count += 1
         algo = SetMaxOrderSizeAlgorithm(max_shares=1,
                                         max_notional=1.0)
@@ -1061,7 +1138,7 @@ class TestTradingControls(TestCase):
 
         def handle_data(algo, data):
             for i in range(5):
-                algo.order(self.sid, 1)
+                algo.order(algo.sid(self.sid), 1)
                 algo.order_count += 1
 
         algo = SetMaxOrderCountAlgorithm(3)
@@ -1080,7 +1157,7 @@ class TestTradingControls(TestCase):
     def test_long_only(self):
         # Sell immediately -> fail immediately.
         def handle_data(algo, data):
-            algo.order(self.sid, -1)
+            algo.order(algo.sid(self.sid), -1)
             algo.order_count += 1
         algo = SetLongOnlyAlgorithm()
         self.check_algo_fails(algo, handle_data, 0)
@@ -1089,9 +1166,9 @@ class TestTradingControls(TestCase):
         # should succeed.
         def handle_data(algo, data):
             if (algo.order_count % 2) == 0:
-                algo.order(self.sid, 1)
+                algo.order(algo.sid(self.sid), 1)
             else:
-                algo.order(self.sid, -1)
+                algo.order(algo.sid(self.sid), -1)
             algo.order_count += 1
         algo = SetLongOnlyAlgorithm()
         self.check_algo_succeeds(algo, handle_data)
@@ -1099,7 +1176,7 @@ class TestTradingControls(TestCase):
         # Buy on first three days, then sell off holdings.  Should succeed.
         def handle_data(algo, data):
             amounts = [1, 1, 1, -3]
-            algo.order(self.sid, amounts[algo.order_count])
+            algo.order(algo.sid(self.sid), amounts[algo.order_count])
             algo.order_count += 1
         algo = SetLongOnlyAlgorithm()
         self.check_algo_succeeds(algo, handle_data)
@@ -1108,7 +1185,7 @@ class TestTradingControls(TestCase):
         # Should fail on the last sale.
         def handle_data(algo, data):
             amounts = [1, 1, 1, -4]
-            algo.order(self.sid, amounts[algo.order_count])
+            algo.order(algo.sid(self.sid), amounts[algo.order_count])
             algo.order_count += 1
         algo = SetLongOnlyAlgorithm()
         self.check_algo_fails(algo, handle_data, 3)
@@ -1134,14 +1211,42 @@ class TestTradingControls(TestCase):
         algo.run(self.source)
         self.source.rewind()
 
+    def test_asset_date_bounds(self):
+
+        # Run the algorithm with a sid that ends far in the future
+        df_source, _ = factory.create_test_df_source(self.sim_params)
+        metadata = {0: {'start_date': '1990-01-01',
+                        'end_date': '2020-01-01'}}
+        algo = SetAssetDateBoundsAlgorithm(asset_metadata=metadata,
+                                           sim_params=self.sim_params,)
+        algo.run(df_source)
+
+        # Run the algorithm with a sid that has already ended
+        df_source, _ = factory.create_test_df_source(self.sim_params)
+        metadata = {0: {'start_date': '1989-01-01',
+                        'end_date': '1990-01-01'}}
+        algo = SetAssetDateBoundsAlgorithm(asset_metadata=metadata,
+                                           sim_params=self.sim_params,)
+        with self.assertRaises(TradingControlViolation):
+            algo.run(df_source)
+
+        # Run the algorithm with a sid that has not started
+        df_source, _ = factory.create_test_df_source(self.sim_params)
+        metadata = {0: {'start_date': '2020-01-01',
+                        'end_date': '2021-01-01'}}
+        algo = SetAssetDateBoundsAlgorithm(asset_metadata=metadata,
+                                           sim_params=self.sim_params,)
+        with self.assertRaises(TradingControlViolation):
+            algo.run(df_source)
+
 
 class TestAccountControls(TestCase):
 
     def setUp(self):
         self.sim_params = factory.create_simulation_parameters(num_days=4)
-        self.sid = 133
+        self.sidint = 133
         self.trade_history = factory.create_trade_history(
-            self.sid,
+            self.sidint,
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(days=1),
@@ -1173,14 +1278,14 @@ class TestAccountControls(TestCase):
 
         # Set max leverage to 0 so buying one share fails.
         def handle_data(algo, data):
-            algo.order(self.sid, 1)
+            algo.order(algo.sid(self.sidint), 1)
 
         algo = SetMaxLeverageAlgorithm(0)
         self.check_algo_fails(algo, handle_data)
 
         # Set max leverage to 1 so buying one share passes
         def handle_data(algo, data):
-            algo.order(self.sid, 1)
+            algo.order(algo.sid(self.sidint), 1)
 
         algo = SetMaxLeverageAlgorithm(1)
         self.check_algo_succeeds(algo, handle_data)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1290,6 +1290,7 @@ class TestAccountControls(TestCase):
         algo = SetMaxLeverageAlgorithm(1)
         self.check_algo_succeeds(algo, handle_data)
 
+
 class TestClosePosAlgo(TestCase):
 
     def setUp(self):

--- a/tests/test_algorithm_gen.py
+++ b/tests/test_algorithm_gen.py
@@ -62,7 +62,7 @@ class TestAlgo(TradingAlgorithm):
         self.latest_date = None
 
         self.set_slippage(RecordDateSlippage(spread=0.05))
-        self.stocks = [8229]
+        self.stocks = [self.sid(8229)]
         self.ordered = False
         self.num_bars = 0
 
@@ -105,7 +105,7 @@ class AlgorithmGeneratorTestCase(TestCase):
                 start=datetime(2012, 5, 1, tzinfo=pytz.utc),
                 end=datetime(2012, 6, 30, tzinfo=pytz.utc)
             )
-            algo = TestAlgo(self, sim_params=sim_params)
+            algo = TestAlgo(self, identifiers=[8229], sim_params=sim_params)
             trade_source = factory.create_daily_trade_source(
                 [8229],
                 200,
@@ -131,7 +131,7 @@ class AlgorithmGeneratorTestCase(TestCase):
             start=datetime(2011, 7, 30, tzinfo=pytz.utc),
             end=datetime(2012, 7, 30, tzinfo=pytz.utc)
         )
-        algo = TestAlgo(self, sim_params=sim_params)
+        algo = TestAlgo(self, identifiers=[8229], sim_params=sim_params)
         trade_source = factory.create_daily_trade_source(
             [8229],
             sim_params
@@ -158,8 +158,7 @@ class AlgorithmGeneratorTestCase(TestCase):
             period_end=datetime(2012, 7, 30, tzinfo=pytz.utc),
             data_frequency='minute'
         )
-        algo = TestAlgo(self,
-                        sim_params=sim_params)
+        algo = TestAlgo(self, identifiers=[8229], sim_params=sim_params)
 
         midnight_custom_source = [Event({
             'custom_field': 42.0,
@@ -223,6 +222,6 @@ class AlgorithmGeneratorTestCase(TestCase):
         """
         sim_params = create_simulation_parameters(num_days=1,
                                                   data_frequency='minute')
-        algo = TestAlgo(self, sim_params=sim_params)
+        algo = TestAlgo(self, sim_params=sim_params, identifiers=[8229])
         algo.run(source=[], overwrite_sim_params=False)
         self.assertEqual(algo.datetime, sim_params.last_close)

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -20,7 +20,177 @@ Tests for the zipline.assets package
 import sys
 from unittest import TestCase
 
-from zipline.assets._assets import Asset, Future
+from datetime import (
+    datetime,
+    timedelta,
+)
+import pickle
+import pprint
+import pytz
+import uuid
+
+import pandas as pd
+
+from nose_parameterized import parameterized
+
+from zipline.finance.trading import with_environment
+from zipline.assets import Asset, Future, AssetFinder
+from zipline.errors import (
+    SymbolNotFound,
+    MultipleSymbolsFound,
+)
+
+
+class FakeTable(object):
+    def __init__(self, name, count, dt, fuzzy_str):
+        self.name = name
+        self.count = count
+        self.dt = dt
+        self.fuzzy_str = fuzzy_str
+        self.df = pd.DataFrame.from_records(
+            [
+                {
+                    'sid': i,
+                    'file_name':  'TEST%s%s' % (self.fuzzy_str, i),
+                    'company_name': self.name + str(i),
+                    'start_date_nano': pd.Timestamp(dt, tz='UTC').value,
+                    'end_date_nano': pd.Timestamp(dt, tz='UTC').value,
+                    'exchange': self.name,
+                }
+                for i in range(1, self.count + 1)
+            ]
+        )
+
+    def read(self, *args, **kwargs):
+        return self.df.to_records()
+
+
+class FakeTableIdenticalSymbols(object):
+    def __init__(self, name, as_of_dates):
+        self.name = name
+        self.as_of_dates = as_of_dates
+        self.df = pd.DataFrame.from_records(
+            [
+                {
+                    'sid': i,
+                    'file_name':  self.name,
+                    'company_name': self.name,
+                    'start_date_nano': date.value,
+                    'end_date_nano': (date + timedelta(days=1)).value,
+                    'exchange': self.name,
+                }
+                for i, date in enumerate(self.as_of_dates)
+            ]
+        )
+
+    def read(self, *args, **kwargs):
+        return self.df.to_records()
+
+
+class FakeTableFromRecords(object):
+
+    def __init__(self, records):
+        self.records = records
+        self.df = pd.DataFrame.from_records(self.records)
+
+    def read(self, *args, **kwargs):
+        return self.df.to_records()
+
+
+@with_environment()
+def build_lookup_generic_cases(env=None):
+    """
+    Generate test cases for AssetFinder test_lookup_generic.
+    """
+
+    unique_start = pd.Timestamp('2013-01-01', tz='UTC')
+    unique_end = pd.Timestamp('2014-01-01', tz='UTC')
+
+    dupe_0_start = pd.Timestamp('2013-01-01', tz='UTC')
+    dupe_0_end = dupe_0_start + timedelta(days=1)
+
+    dupe_1_start = pd.Timestamp('2013-01-03', tz='UTC')
+    dupe_1_end = dupe_1_start + timedelta(days=1)
+
+    table = FakeTableFromRecords(
+        [
+            {
+                'sid': 0,
+                'file_name':  'duplicated',
+                'company_name': 'duplicated_0',
+                'start_date_nano': dupe_0_start.value,
+                'end_date_nano': dupe_0_end.value,
+                'exchange': '',
+            },
+            {
+                'sid': 1,
+                'file_name':  'duplicated',
+                'company_name': 'duplicated_1',
+                'start_date_nano': dupe_1_start.value,
+                'end_date_nano': dupe_1_end.value,
+                'exchange': '',
+            },
+            {
+                'sid': 2,
+                'file_name':  'unique',
+                'company_name': 'unique',
+                'start_date_nano': unique_start.value,
+                'end_date_nano': unique_end.value,
+                'exchange': '',
+            },
+        ],
+    )
+    env.update_asset_finder(asset_metadata=table.df)
+    dupe_0, dupe_1, unique = assets = [
+        env.asset_finder.retrieve_asset(i)
+        for i in range(3)
+    ]
+
+    # This expansion code is run at module import time, which means we have to
+    # clear the AssetFinder here or else it will interfere with the cache
+    # for other tests.
+    env.update_asset_finder(clear_metadata=True)
+
+    dupe_0_start = dupe_0.start_date
+    dupe_1_start = dupe_1.start_date
+    cases = [
+        ##
+        # Scalars
+
+        # Asset object
+        (table, assets[0], None, assets[0]),
+        (table, assets[1], None, assets[1]),
+        (table, assets[2], None, assets[2]),
+        # int
+        (table, 0, None, assets[0]),
+        (table, 1, None, assets[1]),
+        (table, 2, None, assets[2]),
+        # Duplicated symbol with resolution date
+        (table, 'duplicated', dupe_0_start, dupe_0),
+        (table, 'duplicated', dupe_1_start, dupe_1),
+        # Unique symbol, with or without resolution date.
+        (table, 'unique', unique_start, unique),
+        (table, 'unique', None, unique),
+
+        ##
+        # Iterables
+
+        # Iterables of Asset objects.
+        (table, assets, None, assets),
+        (table, iter(assets), None, assets),
+        # Iterables of ints
+        (table, (0, 1), None, assets[:-1]),
+        (table, iter((0, 1)), None, assets[:-1]),
+        # Iterables of symbols.
+        (table, ('duplicated', 'unique'), dupe_0_start, [dupe_0, unique]),
+        (table, ('duplicated', 'unique'), dupe_1_start, [dupe_1, unique]),
+        # Mixed types
+        (table,
+         ('duplicated', 2, 'unique', 1, dupe_1),
+         dupe_0_start,
+         [dupe_0, assets[2], unique, assets[1], dupe_1]),
+    ]
+    return cases
 
 
 class AssetTestCase(TestCase):
@@ -35,8 +205,53 @@ class AssetTestCase(TestCase):
 
         self.assertEquals(str(Asset(5061)), 'Asset(5061)')
 
+    def test_asset_is_pickleable(self):
 
-class TestAssetRichCmp(TestCase):
+        # Very wow
+        s = Asset(
+            1337,
+            symbol="DOGE",
+            asset_name="DOGECOIN",
+            start_date=pd.Timestamp('2013-12-08 9:31AM', tz='UTC'),
+            end_date=pd.Timestamp('2014-06-25 11:21AM', tz='UTC'),
+            first_traded=pd.Timestamp('2013-12-08 9:31AM', tz='UTC'),
+            exchange='THE MOON',
+        )
+        s_unpickled = pickle.loads(pickle.dumps(s))
+
+        attrs_to_check = ['end_date',
+                          'exchange',
+                          'first_traded',
+                          'asset_end_date',
+                          'asset_name',
+                          'asset_start_date',
+                          'sid',
+                          'start_date',
+                          'symbol']
+
+        for attr in attrs_to_check:
+            self.assertEqual(getattr(s, attr), getattr(s_unpickled, attr))
+
+    def test_asset_comparisons(self):
+
+        s_23 = Asset(23)
+        s_24 = Asset(24)
+
+        self.assertEqual(s_23, s_23)
+        self.assertEqual(s_23, 23)
+        self.assertEqual(23, s_23)
+
+        self.assertNotEqual(s_23, s_24)
+        self.assertNotEqual(s_23, 24)
+        self.assertNotEqual(s_23, "23")
+        self.assertNotEqual(s_23, 23.5)
+        self.assertNotEqual(s_23, [])
+        self.assertNotEqual(s_23, None)
+
+        self.assertLess(s_23, s_24)
+        self.assertLess(s_23, 24)
+        self.assertGreater(24, s_23)
+        self.assertGreater(s_24, s_23)
 
     def test_lt(self):
         self.assertTrue(Asset(3) < Asset(4))
@@ -74,16 +289,279 @@ class TestAssetRichCmp(TestCase):
                 'a' < Asset(3)
 
 
-class testFuture(TestCase):
+class TestFuture(TestCase):
+
+    future = Future(2468,
+                    symbol='OMK15',
+                    notice_date='2014-01-20',
+                    expiration_date='2014-02-20',
+                    contract_multiplier=500)
+
+    def test_str(self):
+        strd = self.future.__str__()
+        self.assertEqual("Future(2468 [OMK15])", strd)
 
     def test_repr(self):
+        reprd = self.future.__repr__()
+        self.assertTrue("Future" in reprd)
+        self.assertTrue("2468" in reprd)
+        self.assertTrue("OMK15" in reprd)
+        self.assertTrue("notice_date='2014-01-20'" in reprd)
+        self.assertTrue("expiration_date='2014-02-20'" in reprd)
+        self.assertTrue("contract_multiplier=500" in reprd)
 
-        future = Future(2468,
-                        notice_date='2014-01-20',
-                        expiration_date='2014-02-20')
-        rep = future.__repr__()
+    def test_reduce(self):
+        reduced = self.future.__reduce__()
+        self.assertEqual(Future, reduced[0])
 
-        self.assertTrue("Future" in rep)
-        self.assertTrue("2468" in rep)
-        self.assertTrue("notice_date='2014-01-20'" in rep)
-        self.assertTrue("expiration_date='2014-02-20'" in rep)
+    def test_to_and_from_dict(self):
+        dictd = self.future.to_dict()
+        self.assertTrue('notice_date' in dictd)
+        self.assertTrue('expiration_date' in dictd)
+        self.assertTrue('contract_multiplier' in dictd)
+
+        from_dict = Future.from_dict(dictd)
+        self.assertTrue(isinstance(from_dict, Future))
+        self.assertEqual(self.future, from_dict)
+
+
+class AssetFinderTestCase(TestCase):
+
+    @with_environment()
+    def test_lookup_symbol_fuzzy(self, env=None):
+        fuzzy_str = '@'
+        as_of_date = datetime(2013, 1, 1, tzinfo=pytz.utc)
+        table = FakeTable(uuid.uuid4().hex, 2, as_of_date,
+                          fuzzy_str)
+        env.update_asset_finder(asset_metadata=table.df)
+        sf = env.asset_finder
+
+        try:
+            for i in range(2):  # we do it twice to test for caching bugs
+                self.assertIsNone(sf.lookup_symbol('test', as_of_date))
+                self.assertIsNotNone(sf.lookup_symbol(
+                    'test%s%s' % (fuzzy_str, 1), as_of_date))
+                self.assertIsNone(sf.lookup_symbol('test%s' % 1, as_of_date))
+
+                self.assertIsNone(sf.lookup_symbol(table.name, as_of_date,
+                                                   fuzzy=fuzzy_str))
+                self.assertIsNotNone(sf.lookup_symbol(
+                    'test%s%s' % (fuzzy_str, 1), as_of_date, fuzzy=fuzzy_str))
+                self.assertIsNotNone(sf.lookup_symbol(
+                    'test%s' % 1, as_of_date, fuzzy=fuzzy_str))
+        finally:
+            env.update_asset_finder(clear_metadata=True)
+
+    @with_environment()
+    def test_lookup_symbol_resolve_multiple(self, env=None):
+
+        as_of_dates = [
+            pd.Timestamp('2013-01-01', tz='UTC') + timedelta(days=i)
+            # Incrementing by two so that start and end dates for each
+            # generated Asset don't overlap (each Asset's end_date is the
+            # day after its start date.)
+            for i in range(0, 10, 2)
+        ]
+
+        table = FakeTableIdenticalSymbols(
+            name='existing',
+            as_of_dates=as_of_dates,
+        )
+        env.update_asset_finder(asset_metadata=table.df)
+        sf = env.asset_finder
+
+        try:
+            for _ in range(2):  # we do it twice to test for caching bugs
+                with self.assertRaises(SymbolNotFound):
+                    sf.lookup_symbol_resolve_multiple('non_existing',
+                                                      as_of_dates[0])
+                with self.assertRaises(MultipleSymbolsFound):
+                    sf.lookup_symbol_resolve_multiple('existing',
+                                                      None)
+
+                for i, date in enumerate(as_of_dates):
+                    # Verify that we correctly resolve multiple symbols using
+                    # the supplied date
+                    result = sf.lookup_symbol_resolve_multiple(
+                        'existing',
+                        date,
+                    )
+                    self.assertEqual(result.symbol, 'existing')
+                    self.assertEqual(result.sid, i)
+
+        finally:
+            env.update_asset_finder(clear_metadata=True)
+
+    @with_environment()
+    def test_lookup_symbol_nasdaq_underscore_collisions(self, env=None):
+        """
+        Ensure that each NASDAQ symbol without underscores maps back to the
+        original symbol when using fuzzy matching.
+        """
+        sf = env.asset_finder
+        fuzzy_str = '_'
+        collisions = []
+
+        try:
+            for sid in sf.sids:
+                sec = sf.retrieve_asset(sid)
+                if sec.exchange.startswith('NASDAQ'):
+                    found = sf.lookup_symbol(sec.symbol.replace(fuzzy_str, ''),
+                                             sec.end_date, fuzzy=fuzzy_str)
+                    if found != sec:
+                        collisions.append((found, sec))
+
+            # KNOWN BUG: Filter out assets that have intersections in their
+            # start and end dates.  We can't correctly resolve these.
+            unexpected_errors = []
+            for first, second in collisions:
+                overlapping_dates = (
+                    first.end_date >= second.start_date or
+                    second.end_date >= first.end_date
+                )
+                if not overlapping_dates:
+                    unexpected_errors.append((first, second))
+
+            self.assertFalse(
+                unexpected_errors,
+                pprint.pformat(unexpected_errors),
+            )
+        finally:
+            env.update_asset_finder(clear_metadata=True)
+
+    @parameterized.expand(
+        build_lookup_generic_cases()
+    )
+    @with_environment()
+    def test_lookup_generic(self, table, symbols, reference_date, expected,
+                            env=None):
+        """
+        Ensure that lookup_generic works with various permutations of inputs.
+        """
+        try:
+            env.update_asset_finder(asset_metadata=table.df)
+            finder = env.asset_finder
+            results, missing = finder.lookup_generic(symbols, reference_date)
+            self.assertEqual(results, expected)
+            self.assertEqual(missing, [])
+        finally:
+            env.update_asset_finder(clear_metadata=True)
+
+    @with_environment()
+    def test_lookup_generic_handle_missing(self, env=None):
+        try:
+            table = FakeTableFromRecords(
+                [
+                    # Sids that will be found when we do lookups.
+                    {
+                        'sid': 0,
+                        'file_name': 'real',
+                        'company_name': 'real',
+                        'start_date_nano': pd.Timestamp('2013-1-1', tz='UTC'),
+                        'end_date_nano': pd.Timestamp('2014-1-1', tz='UTC'),
+                        'exchange': '',
+                    },
+                    {
+                        'sid': 1,
+                        'file_name': 'also_real',
+                        'company_name': 'also_real',
+                        'start_date_nano': pd.Timestamp('2013-1-1', tz='UTC'),
+                        'end_date_nano': pd.Timestamp('2014-1-1', tz='UTC'),
+                        'exchange': '',
+                    },
+                    # Sid whose end date is before our query date.  We should
+                    # still correctly find it.
+                    {
+                        'sid': 2,
+                        'file_name': 'real_but_old',
+                        'company_name': 'real_but_old',
+                        'start_date_nano': pd.Timestamp('2002-1-1', tz='UTC'),
+                        'end_date_nano': pd.Timestamp('2003-1-1', tz='UTC'),
+                        'exchange': '',
+                    },
+                    # Sid whose end date is before our query date.  We should
+                    # still correctly find it.
+                    {
+                        'sid': 3,
+                        'file_name': 'real_but_in_the_future',
+                        'company_name': 'real_but_in_the_future',
+                        'start_date_nano': pd.Timestamp('2014-1-1', tz='UTC'),
+                        'end_date_nano': pd.Timestamp('2020-1-1', tz='UTC'),
+                        'exchange': 'THE FUTURE',
+                    },
+                ]
+            )
+            env.update_asset_finder(asset_metadata=table.df)
+            symbols = [
+                'real', 1, 'fake', 'real_but_old', 'real_but_in_the_future',
+            ]
+
+            results, missing = env.asset_finder.lookup_generic(
+                symbols,
+                pd.Timestamp('2013-02-01', tz='UTC'),
+            )
+
+            self.assertEqual(len(results), 3)
+            self.assertEqual(results[0].symbol, 'real')
+            self.assertEqual(results[0].sid, 0)
+            self.assertEqual(results[1].symbol, 'also_real')
+            self.assertEqual(results[1].sid, 1)
+
+            self.assertEqual(len(missing), 2)
+            self.assertEqual(missing[0], 'fake')
+            self.assertEqual(missing[1], 'real_but_in_the_future')
+
+        finally:
+            env.update_asset_finder(clear_metadata=True)
+
+    def test_insert_metadata(self):
+        finder = AssetFinder()
+        finder.insert_metadata(0,
+                               asset_type='equity',
+                               start_date='2014-01-01',
+                               end_date='2015-01-01',
+                               symbol="PLAY",
+                               foo_data="FOO",)
+
+        # Test proper insertion
+        self.assertEqual('equity', finder.metadata_cache[0]['asset_type'])
+        self.assertEqual('PLAY', finder.metadata_cache[0]['symbol'])
+        self.assertEqual('2015-01-01', finder.metadata_cache[0]['end_date'])
+
+        # Test invalid field
+        self.assertFalse('foo_data' in finder.metadata_cache[0])
+
+        # Test updating fields
+        finder.insert_metadata(0,
+                               asset_type='equity',
+                               start_date='2014-01-01',
+                               end_date='2015-02-01',
+                               symbol="PLAY",
+                               exchange="NYSE",)
+        self.assertEqual('2015-02-01', finder.metadata_cache[0]['end_date'])
+        self.assertEqual('NYSE', finder.metadata_cache[0]['exchange'])
+
+        # Check that old data survived
+        self.assertEqual('PLAY', finder.metadata_cache[0]['symbol'])
+
+    def test_consume_metadata(self):
+
+        # Test dict consumption
+        finder = AssetFinder({0: {'asset_type': 'equity'}})
+        dict_to_consume = {0: {'symbol': 'PLAY'},
+                           1: {'symbol': 'MSFT'}}
+        finder.consume_metadata(dict_to_consume)
+        self.assertEqual('equity', finder.metadata_cache[0]['asset_type'])
+        self.assertEqual('PLAY', finder.metadata_cache[0]['symbol'])
+
+        # Test dataframe consumption
+        df = pd.DataFrame(columns=['asset_name', 'exchange'], index=[0, 1])
+        df['asset_name'][0] = "Dave'N'Busters"
+        df['exchange'][0] = "NASDAQ"
+        df['asset_name'][1] = "Microsoft"
+        df['exchange'][1] = "NYSE"
+        finder.consume_metadata(df)
+        self.assertEqual('NASDAQ', finder.metadata_cache[0]['exchange'])
+        self.assertEqual('Microsoft', finder.metadata_cache[1]['asset_name'])
+        # Check that old data survived
+        self.assertEqual('equity', finder.metadata_cache[0]['asset_type'])

--- a/tests/test_batchtransform.py
+++ b/tests/test_batchtransform.py
@@ -112,7 +112,10 @@ class TestChangeOfSids(TestCase):
         )
 
     def test_all_sids_passed(self):
-        algo = BatchTransformAlgorithmSetSid(sim_params=self.sim_params)
+        algo = BatchTransformAlgorithmSetSid(
+            sim_params=self.sim_params,
+            identifiers=[i for i in range(0, 90)]
+        )
         source = DifferentSidSource()
         algo.run(source)
         for i, (df, date) in enumerate(zip(algo.history, source.trading_days)):

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -18,6 +18,7 @@ from nose_parameterized import parameterized
 from unittest import TestCase
 
 from zipline.finance.blotter import Blotter, ORDER_STATUS
+from zipline.finance.trading import with_environment
 from zipline.finance.execution import (
     LimitOrder,
     MarketOrder,
@@ -34,8 +35,10 @@ from zipline.utils.test_utils import(
 
 class BlotterTestCase(TestCase):
 
-    def setUp(self):
+    @with_environment()
+    def setUp(self, env=None):
         setup_logger(self)
+        env.update_asset_finder(identifiers=[24])
 
     def tearDown(self):
         teardown_logger(self)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,8 @@ start=1990-1-1
             self.assertEqual(args['algofile'], 'test.py')
             self.assertEqual(args['symbols'], 'test_symbols')
             self.assertEqual(args['start'], '1990-1-1')
-            self.assertEqual(args['end'], cli.DEFAULTS['end'])
+            self.assertEqual(args['data_frequency'],
+                             cli.DEFAULTS['data_frequency'])
         finally:
             os.remove('test.conf')
 
@@ -63,6 +64,7 @@ start=1990-1-1
             # Non-overwritten values
             self.assertEqual(args['symbols'], 'test_symbols')
             # Default values
-            self.assertEqual(args['end'], cli.DEFAULTS['end'])
+            self.assertEqual(args['data_frequency'],
+                             cli.DEFAULTS['data_frequency'])
         finally:
             os.remove('test.conf')

--- a/tests/test_events_through_risk.py
+++ b/tests/test_events_through_risk.py
@@ -37,7 +37,7 @@ class BuyAndHoldAlgorithm(TradingAlgorithm):
 
     def handle_data(self, data):
         if not self.holding:
-            self.order(self.SID_TO_BUY_AND_HOLD, 100)
+            self.order(self.sid(self.SID_TO_BUY_AND_HOLD), 100)
             self.holding = True
 
 
@@ -68,6 +68,7 @@ class TestEventsThroughRisk(unittest.TestCase):
         )
 
         algo = BuyAndHoldAlgorithm(
+            identifiers=[1],
             sim_params=sim_params)
 
         first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
@@ -188,6 +189,7 @@ class TestEventsThroughRisk(unittest.TestCase):
                 data_frequency='minute')
 
             algo = BuyAndHoldAlgorithm(
+                identifiers=[1],
                 sim_params=sim_params)
 
             first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -509,7 +509,8 @@ def handle_data(context, data):
         test_algo = TradingAlgorithm(
             script=algo_text,
             data_frequency='minute',
-            sim_params=sim_params
+            sim_params=sim_params,
+            identifiers=[0]
         )
 
         source = RandomWalkSource(start=start,

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -43,7 +43,7 @@ from zipline.gens.composites import date_sorted_sources
 from zipline.finance.trading import SimulationParameters
 from zipline.finance.blotter import Order
 from zipline.finance.commission import PerShare, PerTrade, PerDollar
-from zipline.finance import trading
+from zipline.finance.trading import with_environment
 from zipline.utils.factory import create_random_simulation_parameters
 import zipline.protocol as zp
 from zipline.protocol import Event, DATASOURCE_TYPE
@@ -127,7 +127,8 @@ def create_txn(trade_event, price, amount):
     return create_transaction(trade_event, mock_order, price, amount)
 
 
-def benchmark_events_in_range(sim_params):
+@with_environment()
+def benchmark_events_in_range(sim_params, env=None):
     return [
         Event({'dt': dt,
                'returns': ret,
@@ -135,7 +136,7 @@ def benchmark_events_in_range(sim_params):
                # We explicitly rely on the behavior that benchmarks sort before
                # any other events.
                'source_id': '1Abenchmarks'})
-        for dt, ret in trading.environment.benchmark_returns.iteritems()
+        for dt, ret in env.benchmark_returns.iteritems()
         if dt.date() >= sim_params.period_start.date() and
         dt.date() <= sim_params.period_end.date()
     ]
@@ -368,79 +369,78 @@ class TestCommissionEvents(unittest.TestCase):
         self.benchmark_events = benchmark_events_in_range(self.sim_params)
 
     def test_commission_event(self):
-        with trading.TradingEnvironment():
-            events = factory.create_trade_history(
-                1,
-                [10, 10, 10, 10, 10],
-                [100, 100, 100, 100, 100],
-                oneday,
-                self.sim_params
-            )
+        events = factory.create_trade_history(
+            1,
+            [10, 10, 10, 10, 10],
+            [100, 100, 100, 100, 100],
+            oneday,
+            self.sim_params
+        )
 
-            # Test commission models and validate result
-            # Expected commission amounts:
-            # PerShare commission:  1.00, 1.00, 1.50 = $3.50
-            # PerTrade commission:  5.00, 5.00, 5.00 = $15.00
-            # PerDollar commission: 1.50, 3.00, 4.50 = $9.00
-            # Total commission = $3.50 + $15.00 + $9.00 = $27.50
+        # Test commission models and validate result
+        # Expected commission amounts:
+        # PerShare commission:  1.00, 1.00, 1.50 = $3.50
+        # PerTrade commission:  5.00, 5.00, 5.00 = $15.00
+        # PerDollar commission: 1.50, 3.00, 4.50 = $9.00
+        # Total commission = $3.50 + $15.00 + $9.00 = $27.50
 
-            # Create 3 transactions:  50, 100, 150 shares traded @ $20
-            transactions = [create_txn(events[0], 20, i)
-                            for i in [50, 100, 150]]
+        # Create 3 transactions:  50, 100, 150 shares traded @ $20
+        transactions = [create_txn(events[0], 20, i)
+                        for i in [50, 100, 150]]
 
-            # Create commission models and validate that produce expected
-            # commissions.
-            models = [PerShare(cost=0.01, min_trade_cost=1.00),
-                      PerTrade(cost=5.00),
-                      PerDollar(cost=0.0015)]
-            expected_results = [3.50, 15.0, 9.0]
+        # Create commission models and validate that produce expected
+        # commissions.
+        models = [PerShare(cost=0.01, min_trade_cost=1.00),
+                  PerTrade(cost=5.00),
+                  PerDollar(cost=0.0015)]
+        expected_results = [3.50, 15.0, 9.0]
 
-            for model, expected in zip(models, expected_results):
-                total_commission = 0
-                for trade in transactions:
-                    total_commission += model.calculate(trade)[1]
-                self.assertEqual(total_commission, expected)
+        for model, expected in zip(models, expected_results):
+            total_commission = 0
+            for trade in transactions:
+                total_commission += model.calculate(trade)[1]
+            self.assertEqual(total_commission, expected)
 
-            # Verify that commission events are handled correctly by
-            # PerformanceTracker.
-            cash_adj_dt = events[0].dt
-            cash_adjustment = factory.create_commission(1, 300.0, cash_adj_dt)
-            events.append(cash_adjustment)
+        # Verify that commission events are handled correctly by
+        # PerformanceTracker.
+        cash_adj_dt = events[0].dt
+        cash_adjustment = factory.create_commission(1, 300.0, cash_adj_dt)
+        events.append(cash_adjustment)
 
-            # Insert a purchase order.
-            txns = [create_txn(events[0], 20, 1)]
-            results = calculate_results(self, events, txns=txns)
+        # Insert a purchase order.
+        txns = [create_txn(events[0], 20, 1)]
+        results = calculate_results(self, events, txns=txns)
 
-            # Validate that we lost 320 dollars from our cash pool.
-            self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
-                             9680)
-            # Validate that the cost basis of our position changed.
-            self.assertEqual(results[-1]['daily_perf']['positions']
-                             [0]['cost_basis'], 320.0)
-            # Validate that the account attributes were updated.
-            account = results[1]['account']
-            self.assertEqual(float('inf'), account['day_trades_remaining'])
-            np.testing.assert_allclose(0.001, account['leverage'], rtol=1e-3,
-                                       atol=1e-4)
-            np.testing.assert_allclose(9680, account['regt_equity'], rtol=1e-3)
-            self.assertEqual(float('inf'), account['regt_margin'])
-            np.testing.assert_allclose(9680, account['available_funds'],
-                                       rtol=1e-3)
-            self.assertEqual(0, account['maintenance_margin_requirement'])
-            np.testing.assert_allclose(9690,
-                                       account['equity_with_loan'], rtol=1e-3)
-            self.assertEqual(float('inf'), account['buying_power'])
-            self.assertEqual(0, account['initial_margin_requirement'])
-            np.testing.assert_allclose(9680, account['excess_liquidity'],
-                                       rtol=1e-3)
-            np.testing.assert_allclose(9680, account['settled_cash'],
-                                       rtol=1e-3)
-            np.testing.assert_allclose(9690, account['net_liquidation'],
-                                       rtol=1e-3)
-            np.testing.assert_allclose(0.999, account['cushion'], rtol=1e-3)
-            np.testing.assert_allclose(10, account['total_positions_value'],
-                                       rtol=1e-3)
-            self.assertEqual(0, account['accrued_interest'])
+        # Validate that we lost 320 dollars from our cash pool.
+        self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
+                         9680)
+        # Validate that the cost basis of our position changed.
+        self.assertEqual(results[-1]['daily_perf']['positions']
+                         [0]['cost_basis'], 320.0)
+        # Validate that the account attributes were updated.
+        account = results[1]['account']
+        self.assertEqual(float('inf'), account['day_trades_remaining'])
+        np.testing.assert_allclose(0.001, account['leverage'], rtol=1e-3,
+                                   atol=1e-4)
+        np.testing.assert_allclose(9680, account['regt_equity'], rtol=1e-3)
+        self.assertEqual(float('inf'), account['regt_margin'])
+        np.testing.assert_allclose(9680, account['available_funds'],
+                                   rtol=1e-3)
+        self.assertEqual(0, account['maintenance_margin_requirement'])
+        np.testing.assert_allclose(9690,
+                                   account['equity_with_loan'], rtol=1e-3)
+        self.assertEqual(float('inf'), account['buying_power'])
+        self.assertEqual(0, account['initial_margin_requirement'])
+        np.testing.assert_allclose(9680, account['excess_liquidity'],
+                                   rtol=1e-3)
+        np.testing.assert_allclose(9680, account['settled_cash'],
+                                   rtol=1e-3)
+        np.testing.assert_allclose(9690, account['net_liquidation'],
+                                   rtol=1e-3)
+        np.testing.assert_allclose(0.999, account['cushion'], rtol=1e-3)
+        np.testing.assert_allclose(10, account['total_positions_value'],
+                                   rtol=1e-3)
+        self.assertEqual(0, account['accrued_interest'])
 
     def test_commission_zero_position(self):
         """
@@ -476,24 +476,23 @@ class TestCommissionEvents(unittest.TestCase):
         """
         Ensure no position-not-found or sid-not-found errors.
         """
-        with trading.TradingEnvironment():
-            events = factory.create_trade_history(
-                1,
-                [10, 10, 10, 10, 10],
-                [100, 100, 100, 100, 100],
-                oneday,
-                self.sim_params
-            )
+        events = factory.create_trade_history(
+            1,
+            [10, 10, 10, 10, 10],
+            [100, 100, 100, 100, 100],
+            oneday,
+            self.sim_params
+        )
 
-            # Add a cash adjustment at the time of event[3].
-            cash_adj_dt = events[3].dt
-            cash_adjustment = factory.create_commission(1, 300.0, cash_adj_dt)
-            events.append(cash_adjustment)
+        # Add a cash adjustment at the time of event[3].
+        cash_adj_dt = events[3].dt
+        cash_adjustment = factory.create_commission(1, 300.0, cash_adj_dt)
+        events.append(cash_adjustment)
 
-            results = calculate_results(self, events)
-            # Validate that we lost 300 dollars from our cash pool.
-            self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
-                             9700)
+        results = calculate_results(self, events)
+        # Validate that we lost 300 dollars from our cash pool.
+        self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
+                         9700)
 
 
 class TestDividendPerformance(unittest.TestCase):
@@ -508,117 +507,114 @@ class TestDividendPerformance(unittest.TestCase):
         self.benchmark_events = benchmark_events_in_range(self.sim_params)
 
     def test_market_hours_calculations(self):
-        with trading.TradingEnvironment():
-            # DST in US/Eastern began on Sunday March 14, 2010
-            before = datetime(2010, 3, 12, 14, 31, tzinfo=pytz.utc)
-            after = factory.get_next_trading_dt(
-                before,
-                timedelta(days=1)
-            )
-            self.assertEqual(after.hour, 13)
+        # DST in US/Eastern began on Sunday March 14, 2010
+        before = datetime(2010, 3, 12, 14, 31, tzinfo=pytz.utc)
+        after = factory.get_next_trading_dt(
+            before,
+            timedelta(days=1)
+        )
+        self.assertEqual(after.hour, 13)
 
     def test_long_position_receives_dividend(self):
-        with trading.TradingEnvironment():
-            # post some trades in the market
-            events = factory.create_trade_history(
-                1,
-                [10, 10, 10, 10, 10],
-                [100, 100, 100, 100, 100],
-                oneday,
-                self.sim_params
-            )
-            dividend = factory.create_dividend(
-                1,
-                10.00,
-                # declared date, when the algorithm finds out about
-                # the dividend
-                events[0].dt,
-                # ex_date, the date before which the algorithm must hold stock
-                # to receive the dividend
-                events[1].dt,
-                # pay date, when the algorithm receives the dividend.
-                events[2].dt
-            )
+        # post some trades in the market
+        events = factory.create_trade_history(
+            1,
+            [10, 10, 10, 10, 10],
+            [100, 100, 100, 100, 100],
+            oneday,
+            self.sim_params
+        )
+        dividend = factory.create_dividend(
+            1,
+            10.00,
+            # declared date, when the algorithm finds out about
+            # the dividend
+            events[0].dt,
+            # ex_date, the date before which the algorithm must hold stock
+            # to receive the dividend
+            events[1].dt,
+            # pay date, when the algorithm receives the dividend.
+            events[2].dt
+        )
 
-            # Simulate a transaction being filled prior to the ex_date.
-            txns = [create_txn(events[0], 10.0, 100)]
-            results = calculate_results(
-                self,
-                events,
-                dividend_events=[dividend],
-                txns=txns,
-            )
+        # Simulate a transaction being filled prior to the ex_date.
+        txns = [create_txn(events[0], 10.0, 100)]
+        results = calculate_results(
+            self,
+            events,
+            dividend_events=[dividend],
+            txns=txns,
+        )
 
-            self.assertEqual(len(results), 5)
-            cumulative_returns = \
-                [event['cumulative_perf']['returns'] for event in results]
-            self.assertEqual(cumulative_returns, [0.0, 0.0, 0.1, 0.1, 0.1])
-            daily_returns = [event['daily_perf']['returns']
-                             for event in results]
-            self.assertEqual(daily_returns, [0.0, 0.0, 0.10, 0.0, 0.0])
-            cash_flows = [event['daily_perf']['capital_used']
-                          for event in results]
-            self.assertEqual(cash_flows, [-1000, 0, 1000, 0, 0])
-            cumulative_cash_flows = \
-                [event['cumulative_perf']['capital_used'] for event in results]
-            self.assertEqual(cumulative_cash_flows, [-1000, -1000, 0, 0, 0])
-            cash_pos = \
-                [event['cumulative_perf']['ending_cash'] for event in results]
-            self.assertEqual(cash_pos, [9000, 9000, 10000, 10000, 10000])
+        self.assertEqual(len(results), 5)
+        cumulative_returns = \
+            [event['cumulative_perf']['returns'] for event in results]
+        self.assertEqual(cumulative_returns, [0.0, 0.0, 0.1, 0.1, 0.1])
+        daily_returns = [event['daily_perf']['returns']
+                         for event in results]
+        self.assertEqual(daily_returns, [0.0, 0.0, 0.10, 0.0, 0.0])
+        cash_flows = [event['daily_perf']['capital_used']
+                      for event in results]
+        self.assertEqual(cash_flows, [-1000, 0, 1000, 0, 0])
+        cumulative_cash_flows = \
+            [event['cumulative_perf']['capital_used'] for event in results]
+        self.assertEqual(cumulative_cash_flows, [-1000, -1000, 0, 0, 0])
+        cash_pos = \
+            [event['cumulative_perf']['ending_cash'] for event in results]
+        self.assertEqual(cash_pos, [9000, 9000, 10000, 10000, 10000])
 
     def test_long_position_receives_stock_dividend(self):
-        with trading.TradingEnvironment():
-            # post some trades in the market
-            events = []
-            for sid in (1, 2):
-                events.extend(
-                    factory.create_trade_history(
-                        sid,
-                        [10, 10, 10, 10, 10],
-                        [100, 100, 100, 100, 100],
-                        oneday,
-                        self.sim_params)
-                )
-
-            dividend = factory.create_stock_dividend(
-                1,
-                payment_sid=2,
-                ratio=2,
-                # declared date, when the algorithm finds out about
-                # the dividend
-                declared_date=events[0].dt,
-                # ex_date, the date before which the algorithm must hold stock
-                # to receive the dividend
-                ex_date=events[1].dt,
-                # pay date, when the algorithm receives the dividend.
-                pay_date=events[2].dt
+        # post some trades in the market
+        events = []
+        for sid in (1, 2):
+            events.extend(
+                factory.create_trade_history(
+                    sid,
+                    [10, 10, 10, 10, 10],
+                    [100, 100, 100, 100, 100],
+                    oneday,
+                    self.sim_params)
             )
 
-            txns = [create_txn(events[0], 10.0, 100)]
+        dividend = factory.create_stock_dividend(
+            1,
+            payment_sid=2,
+            ratio=2,
+            # declared date, when the algorithm finds out about
+            # the dividend
+            declared_date=events[0].dt,
+            # ex_date, the date before which the algorithm must hold stock
+            # to receive the dividend
+            ex_date=events[1].dt,
+            # pay date, when the algorithm receives the dividend.
+            pay_date=events[2].dt
+        )
 
-            results = calculate_results(
-                self,
-                events,
-                dividend_events=[dividend],
-                txns=txns,
-            )
+        txns = [create_txn(events[0], 10.0, 100)]
 
-            self.assertEqual(len(results), 5)
-            cumulative_returns = \
-                [event['cumulative_perf']['returns'] for event in results]
-            self.assertEqual(cumulative_returns, [0.0, 0.0, 0.2, 0.2, 0.2])
-            daily_returns = [event['daily_perf']['returns']
-                             for event in results]
-            self.assertEqual(daily_returns, [0.0, 0.0, 0.2, 0.0, 0.0])
-            cash_flows = [event['daily_perf']['capital_used']
-                          for event in results]
-            self.assertEqual(cash_flows, [-1000, 0, 0, 0, 0])
-            cumulative_cash_flows = \
-                [event['cumulative_perf']['capital_used'] for event in results]
-            self.assertEqual(cumulative_cash_flows, [-1000] * 5)
-            cash_pos = \
-                [event['cumulative_perf']['ending_cash'] for event in results]
-            self.assertEqual(cash_pos, [9000] * 5)
+        results = calculate_results(
+            self,
+            events,
+            dividend_events=[dividend],
+            txns=txns,
+        )
+
+        self.assertEqual(len(results), 5)
+        cumulative_returns = \
+            [event['cumulative_perf']['returns'] for event in results]
+        self.assertEqual(cumulative_returns, [0.0, 0.0, 0.2, 0.2, 0.2])
+        daily_returns = [event['daily_perf']['returns']
+                         for event in results]
+        self.assertEqual(daily_returns, [0.0, 0.0, 0.2, 0.0, 0.0])
+        cash_flows = [event['daily_perf']['capital_used']
+                      for event in results]
+        self.assertEqual(cash_flows, [-1000, 0, 0, 0, 0])
+        cumulative_cash_flows = \
+            [event['cumulative_perf']['capital_used'] for event in results]
+        self.assertEqual(cumulative_cash_flows, [-1000] * 5)
+        cash_pos = \
+            [event['cumulative_perf']['ending_cash'] for event in results]
+        self.assertEqual(cash_pos, [9000] * 5)
 
     def test_long_position_purchased_on_ex_date_receives_no_dividend(self):
         # post some trades in the market
@@ -1831,112 +1827,115 @@ class TestPerformanceTracker(unittest.TestCase):
             else:
                 yield event
 
-    def test_minute_tracker(self):
+    @with_environment()
+    def test_minute_tracker(self, env=None):
         """ Tests minute performance tracking."""
-        with trading.TradingEnvironment():
-            start_dt = trading.environment.exchange_dt_in_utc(
-                datetime(2013, 3, 1, 9, 31))
-            end_dt = trading.environment.exchange_dt_in_utc(
-                datetime(2013, 3, 1, 16, 0))
+        start_dt = env.exchange_dt_in_utc(datetime(2013, 3, 1, 9, 31))
+        end_dt = env.exchange_dt_in_utc(datetime(2013, 3, 1, 16, 0))
 
-            sim_params = SimulationParameters(
-                period_start=start_dt,
-                period_end=end_dt,
-                emission_rate='minute'
-            )
-            tracker = perf.PerformanceTracker(sim_params)
+        sim_params = SimulationParameters(
+            period_start=start_dt,
+            period_end=end_dt,
+            emission_rate='minute'
+        )
+        tracker = perf.PerformanceTracker(sim_params)
 
-            foo_event_1 = factory.create_trade('foo', 10.0, 20, start_dt)
-            order_event_1 = Order(sid=foo_event_1.sid,
+        foosid = 1
+        barsid = 2
+
+        env.update_asset_finder(identifiers=[foosid, barsid])
+
+        foo_event_1 = factory.create_trade(foosid, 10.0, 20, start_dt)
+        order_event_1 = Order(sid=foo_event_1.sid,
+                              amount=-25,
+                              dt=foo_event_1.dt)
+        bar_event_1 = factory.create_trade(barsid, 100.0, 200, start_dt)
+        txn_event_1 = Transaction(sid=foo_event_1.sid,
                                   amount=-25,
-                                  dt=foo_event_1.dt)
-            bar_event_1 = factory.create_trade('bar', 100.0, 200, start_dt)
-            txn_event_1 = Transaction(sid=foo_event_1.sid,
-                                      amount=-25,
-                                      dt=foo_event_1.dt,
-                                      price=10.0,
-                                      commission=0.50,
-                                      order_id=order_event_1.id)
-            benchmark_event_1 = Event({
-                'dt': start_dt,
-                'returns': 0.01,
-                'type': zp.DATASOURCE_TYPE.BENCHMARK
-            })
+                                  dt=foo_event_1.dt,
+                                  price=10.0,
+                                  commission=0.50,
+                                  order_id=order_event_1.id)
+        benchmark_event_1 = Event({
+            'dt': start_dt,
+            'returns': 0.01,
+            'type': zp.DATASOURCE_TYPE.BENCHMARK
+        })
 
-            foo_event_2 = factory.create_trade(
-                'foo', 11.0, 20, start_dt + timedelta(minutes=1))
-            bar_event_2 = factory.create_trade(
-                'bar', 11.0, 20, start_dt + timedelta(minutes=1))
-            benchmark_event_2 = Event({
-                'dt': start_dt + timedelta(minutes=1),
-                'returns': 0.02,
-                'type': zp.DATASOURCE_TYPE.BENCHMARK
-            })
+        foo_event_2 = factory.create_trade(
+            foosid, 11.0, 20, start_dt + timedelta(minutes=1))
+        bar_event_2 = factory.create_trade(
+            barsid, 11.0, 20, start_dt + timedelta(minutes=1))
+        benchmark_event_2 = Event({
+            'dt': start_dt + timedelta(minutes=1),
+            'returns': 0.02,
+            'type': zp.DATASOURCE_TYPE.BENCHMARK
+        })
 
-            events = [
-                foo_event_1,
-                order_event_1,
-                benchmark_event_1,
-                txn_event_1,
-                bar_event_1,
-                foo_event_2,
-                benchmark_event_2,
-                bar_event_2,
-            ]
+        events = [
+            foo_event_1,
+            order_event_1,
+            benchmark_event_1,
+            txn_event_1,
+            bar_event_1,
+            foo_event_2,
+            benchmark_event_2,
+            bar_event_2,
+        ]
 
-            grouped_events = itertools.groupby(
-                events, operator.attrgetter('dt'))
+        grouped_events = itertools.groupby(
+            events, operator.attrgetter('dt'))
 
-            messages = {}
-            for date, group in grouped_events:
-                tracker.set_date(date)
-                for event in group:
-                    if event.type == zp.DATASOURCE_TYPE.TRADE:
-                        tracker.process_trade(event)
-                    elif event.type == zp.DATASOURCE_TYPE.BENCHMARK:
-                        tracker.process_benchmark(event)
-                    elif event.type == zp.DATASOURCE_TYPE.ORDER:
-                        tracker.process_order(event)
-                    elif event.type == zp.DATASOURCE_TYPE.TRANSACTION:
-                        tracker.process_transaction(event)
-                tracker.handle_minute_close(date)
-                msg = tracker.to_dict()
-                messages[date] = msg
+        messages = {}
+        for date, group in grouped_events:
+            tracker.set_date(date)
+            for event in group:
+                if event.type == zp.DATASOURCE_TYPE.TRADE:
+                    tracker.process_trade(event)
+                elif event.type == zp.DATASOURCE_TYPE.BENCHMARK:
+                    tracker.process_benchmark(event)
+                elif event.type == zp.DATASOURCE_TYPE.ORDER:
+                    tracker.process_order(event)
+                elif event.type == zp.DATASOURCE_TYPE.TRANSACTION:
+                    tracker.process_transaction(event)
+            tracker.handle_minute_close(date)
+            msg = tracker.to_dict()
+            messages[date] = msg
 
-            self.assertEquals(2, len(messages))
+        self.assertEquals(2, len(messages))
 
-            msg_1 = messages[foo_event_1.dt]
-            msg_2 = messages[foo_event_2.dt]
+        msg_1 = messages[foo_event_1.dt]
+        msg_2 = messages[foo_event_2.dt]
 
-            self.assertEquals(1, len(msg_1['minute_perf']['transactions']),
-                              "The first message should contain one "
-                              "transaction.")
-            # Check that transactions aren't emitted for previous events.
-            self.assertEquals(0, len(msg_2['minute_perf']['transactions']),
-                              "The second message should have no "
-                              "transactions.")
+        self.assertEquals(1, len(msg_1['minute_perf']['transactions']),
+                          "The first message should contain one "
+                          "transaction.")
+        # Check that transactions aren't emitted for previous events.
+        self.assertEquals(0, len(msg_2['minute_perf']['transactions']),
+                          "The second message should have no "
+                          "transactions.")
 
-            self.assertEquals(1, len(msg_1['minute_perf']['orders']),
-                              "The first message should contain one orders.")
-            # Check that orders aren't emitted for previous events.
-            self.assertEquals(0, len(msg_2['minute_perf']['orders']),
-                              "The second message should have no orders.")
+        self.assertEquals(1, len(msg_1['minute_perf']['orders']),
+                          "The first message should contain one orders.")
+        # Check that orders aren't emitted for previous events.
+        self.assertEquals(0, len(msg_2['minute_perf']['orders']),
+                          "The second message should have no orders.")
 
-            # Ensure that period_close moves through time.
-            # Also, ensure that the period_closes are the expected dts.
-            self.assertEquals(foo_event_1.dt,
-                              msg_1['minute_perf']['period_close'])
-            self.assertEquals(foo_event_2.dt,
-                              msg_2['minute_perf']['period_close'])
+        # Ensure that period_close moves through time.
+        # Also, ensure that the period_closes are the expected dts.
+        self.assertEquals(foo_event_1.dt,
+                          msg_1['minute_perf']['period_close'])
+        self.assertEquals(foo_event_2.dt,
+                          msg_2['minute_perf']['period_close'])
 
-            # In this test event1 transactions arrive on the first bar.
-            # This leads to no returns as the price is constant.
-            # Sharpe ratio cannot be computed and is None.
-            # In the second bar we can start establishing a sharpe ratio.
-            self.assertIsNone(msg_1['cumulative_risk_metrics']['sharpe'])
-            self.assertIsNotNone(msg_2['cumulative_risk_metrics']['sharpe'])
+        # In this test event1 transactions arrive on the first bar.
+        # This leads to no returns as the price is constant.
+        # Sharpe ratio cannot be computed and is None.
+        # In the second bar we can start establishing a sharpe ratio.
+        self.assertIsNone(msg_1['cumulative_risk_metrics']['sharpe'])
+        self.assertIsNotNone(msg_2['cumulative_risk_metrics']['sharpe'])
 
-            check_perf_tracker_serialization(tracker)
+        check_perf_tracker_serialization(tracker)
 
     def test_close_position_event(self):
         pt = perf.PositionTracker()
@@ -2021,9 +2020,12 @@ class TestPositionTracker(unittest.TestCase):
         stats = [
             'calculate_positions_value',
             '_net_exposure',
+            '_gross_value',
             '_gross_exposure',
+            '_short_value',
             '_short_exposure',
             '_shorts_count',
+            '_long_value',
             '_long_exposure',
             '_longs_count',
         ]
@@ -2033,15 +2035,82 @@ class TestPositionTracker(unittest.TestCase):
             self.assertEquals(val, 0)
             self.assertNotIsInstance(val, (bool, np.bool_))
 
-    def test_serializaition(self):
+    @with_environment()
+    def test_update_last_sale(self, env=None):
+        metadata = {1: {'asset_type': 'equity'},
+                    2: {'asset_type': 'future',
+                        'contract_multiplier': 1000}}
+        env.update_asset_finder(asset_metadata=metadata)
         pt = perf.PositionTracker()
         dt = pd.Timestamp("1984/03/06 3:00PM")
-        pos1 = perf.Position('AAPL', amount=np.float64(120.0),
+        pos1 = perf.Position(1, amount=np.float64(100.0),
+                             last_sale_date=dt, last_sale_price=10)
+        pos2 = perf.Position(2, amount=np.float64(100.0),
+                             last_sale_date=dt, last_sale_price=10)
+        pt.update_positions({1: pos1, 2: pos2})
+
+        event1 = Event({'sid': 1,
+                        'price': 11,
+                        'dt': dt})
+        event2 = Event({'sid': 2,
+                        'price': 11,
+                        'dt': dt})
+
+        # Check cash-adjustment return value
+        self.assertEqual(0, pt.update_last_sale(event1))
+        self.assertEqual(100000, pt.update_last_sale(event2))
+
+    @with_environment()
+    def test_position_values_and_exposures(self, env=None):
+        metadata = {1: {'asset_type': 'equity'},
+                    2: {'asset_type': 'equity'},
+                    3: {'asset_type': 'future',
+                        'contract_multiplier': 1000},
+                    4: {'asset_type': 'future',
+                        'contract_multiplier': 1000}}
+        env.update_asset_finder(asset_metadata=metadata)
+        pt = perf.PositionTracker()
+        dt = pd.Timestamp("1984/03/06 3:00PM")
+        pos1 = perf.Position(1, amount=np.float64(10.0),
+                             last_sale_date=dt, last_sale_price=10)
+        pos2 = perf.Position(2, amount=np.float64(-20.0),
+                             last_sale_date=dt, last_sale_price=10)
+        pos3 = perf.Position(3, amount=np.float64(30.0),
+                             last_sale_date=dt, last_sale_price=10)
+        pos4 = perf.Position(4, amount=np.float64(-40.0),
+                             last_sale_date=dt, last_sale_price=10)
+        pt.update_positions({1: pos1, 2: pos2, 3: pos3, 4: pos4})
+
+        # Test long-only methods
+        self.assertEqual(100, pt._long_value())
+        self.assertEqual(100 + 300000, pt._long_exposure())
+
+        # Test short-only methods
+        self.assertEqual(-200, pt._short_value())
+        self.assertEqual(-200 - 400000, pt._short_exposure())
+
+        # Test gross and net values
+        self.assertEqual(100 + 200, pt._gross_value())
+        self.assertEqual(100 - 200, pt._net_value())
+
+        # Test gross and net exposures
+        self.assertEqual(100 + 200 + 300000 + 400000, pt._gross_exposure())
+        self.assertEqual(100 - 200 + 300000 - 400000, pt._net_exposure())
+
+    @with_environment()
+    def test_serialization(self, env=None):
+        metadata = {1: {'asset_type': 'equity'},
+                    2: {'asset_type': 'future',
+                        'contract_multiplier': 1000}}
+        env.update_asset_finder(asset_metadata=metadata)
+        pt = perf.PositionTracker()
+        dt = pd.Timestamp("1984/03/06 3:00PM")
+        pos1 = perf.Position(1, amount=np.float64(120.0),
                              last_sale_date=dt, last_sale_price=3.4)
-        pos2 = perf.Position('IBM', amount=np.float64(100.0),
+        pos2 = perf.Position(2, amount=np.float64(100.0),
                              last_sale_date=dt, last_sale_price=3.4)
 
-        pt.update_positions({'AAPL': pos1, 'IBM': pos2})
+        pt.update_positions({1: pos1, 2: pos2})
         p_string = pickle.dumps(pt)
         test = pickle.loads(p_string)
         nt.assert_dict_equal(test._position_amounts, pt._position_amounts)

--- a/tests/test_security_list.py
+++ b/tests/test_security_list.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from zipline.algorithm import TradingAlgorithm
 from zipline.errors import TradingControlViolation
 from zipline.sources import SpecificEquityTrades
+from zipline.finance.trading import with_environment
 from zipline.utils.test_utils import (
     setup_logger, teardown_logger, security_list_copy, add_security_data)
 from zipline.utils import factory
@@ -16,11 +17,11 @@ LEVERAGED_ETFS = load_from_directory('leveraged_etf_list')
 
 
 class RestrictedAlgoWithCheck(TradingAlgorithm):
-    def initialize(self, sid):
+    def initialize(self, symbol):
             self.rl = SecurityListSet(self.get_datetime)
             self.set_do_not_order_list(self.rl.leveraged_etf_list)
             self.order_count = 0
-            self.sid = sid
+            self.sid = self.symbol(symbol)
 
     def handle_data(self, data):
         if not self.order_count:
@@ -31,11 +32,11 @@ class RestrictedAlgoWithCheck(TradingAlgorithm):
 
 
 class RestrictedAlgoWithoutCheck(TradingAlgorithm):
-    def initialize(self, sid):
+    def initialize(self, symbol):
         self.rl = SecurityListSet(self.get_datetime)
         self.set_do_not_order_list(self.rl.leveraged_etf_list)
         self.order_count = 0
-        self.sid = sid
+        self.sid = self.symbol(symbol)
 
     def handle_data(self, data):
         self.order(self.sid, 100)
@@ -43,11 +44,11 @@ class RestrictedAlgoWithoutCheck(TradingAlgorithm):
 
 
 class IterateRLAlgo(TradingAlgorithm):
-    def initialize(self, sid):
+    def initialize(self, symbol):
             self.rl = SecurityListSet(self.get_datetime)
             self.set_do_not_order_list(self.rl.leveraged_etf_list)
             self.order_count = 0
-            self.sid = sid
+            self.sid = self.symbol(symbol)
             self.found = False
 
     def handle_data(self, data):
@@ -58,11 +59,17 @@ class IterateRLAlgo(TradingAlgorithm):
 
 class SecurityListTestCase(TestCase):
 
-    def setUp(self):
+    @with_environment()
+    def setUp(self, env=None):
         self.extra_knowledge_date = \
             datetime(2015, 1, 27, 0, 0, tzinfo=pytz.utc)
         self.trading_day_before_first_kd = datetime(
             2015, 1, 23, 0, 0, tzinfo=pytz.utc)
+
+        env.update_asset_finder(
+            clear_metadata=True,
+            identifiers=["BZQ", "URTY", "JFT", "AAPL", "GOOG"]
+        )
 
         setup_logger(self)
 
@@ -81,11 +88,12 @@ class SecurityListTestCase(TestCase):
             sim_params
         )
         self.source = SpecificEquityTrades(event_list=trade_history)
-        algo = IterateRLAlgo(sid='BZQ', sim_params=sim_params)
+        algo = IterateRLAlgo(symbol='BZQ', sim_params=sim_params)
         algo.run(self.source)
         self.assertTrue(algo.found)
 
-    def test_security_list(self):
+    @with_environment()
+    def test_security_list(self, env=None):
 
         # set the knowledge date to the first day of the
         # leveraged etf knowledge date.
@@ -94,27 +102,43 @@ class SecurityListTestCase(TestCase):
 
         rl = SecurityListSet(get_datetime)
         # assert that a sample from the leveraged list are in restricted
-
-        self.assertIn("BZQ", rl.leveraged_etf_list)
-        self.assertIn("URTY", rl.leveraged_etf_list)
-        self.assertIn("JFT", rl.leveraged_etf_list)
+        should_exist = [
+            asset.sid for asset in
+            [env.asset_finder.lookup_symbol(
+                symbol,
+                as_of_date=self.extra_knowledge_date)
+             for symbol in ["BZQ", "URTY", "JFT"]]
+        ]
+        for sid in should_exist:
+            self.assertIn(sid, rl.leveraged_etf_list)
 
         # assert that a sample of allowed stocks are not in restricted
-        # AAPL
-        self.assertNotIn("AAPL", rl.leveraged_etf_list)
-        # GOOG
-        self.assertNotIn("GOOG", rl.leveraged_etf_list)
+        shouldnt_exist = [
+            asset.sid for asset in
+            [env.asset_finder.lookup_symbol(
+                symbol,
+                as_of_date=self.extra_knowledge_date)
+             for symbol in ["AAPL", "GOOG"]]
+        ]
+        for sid in shouldnt_exist:
+            self.assertNotIn(sid, rl.leveraged_etf_list)
 
-    def test_security_add(self):
+    @with_environment()
+    def test_security_add(self, env=None):
         def get_datetime():
             return datetime(2015, 1, 27, tzinfo=pytz.utc)
         with security_list_copy():
             add_security_data(['AAPL', 'GOOG'], [])
             rl = SecurityListSet(get_datetime)
-            self.assertIn("AAPL", rl.leveraged_etf_list)
-            self.assertIn("GOOG", rl.leveraged_etf_list)
-            self.assertIn("BZQ", rl.leveraged_etf_list)
-            self.assertIn("URTY", rl.leveraged_etf_list)
+            should_exist = [
+                asset.sid for asset in
+                [env.asset_finder.lookup_symbol(
+                    symbol,
+                    as_of_date=self.extra_knowledge_date
+                ) for symbol in ["AAPL", "GOOG", "BZQ", "URTY"]]
+            ]
+            for sid in should_exist:
+                self.assertIn(sid, rl.leveraged_etf_list)
 
     def test_security_add_delete(self):
         with security_list_copy():
@@ -138,7 +162,7 @@ class SecurityListTestCase(TestCase):
         )
         self.source = SpecificEquityTrades(event_list=trade_history)
 
-        algo = RestrictedAlgoWithCheck(sid='BZQ', sim_params=sim_params)
+        algo = RestrictedAlgoWithCheck(symbol='BZQ', sim_params=sim_params)
         algo.run(self.source)
 
     def test_algo_without_rl_violation(self):
@@ -153,7 +177,7 @@ class SecurityListTestCase(TestCase):
             sim_params
         )
         self.source = SpecificEquityTrades(event_list=trade_history)
-        algo = RestrictedAlgoWithoutCheck(sid='AAPL', sim_params=sim_params)
+        algo = RestrictedAlgoWithoutCheck(symbol='AAPL', sim_params=sim_params)
         algo.run(self.source)
 
     def test_algo_with_rl_violation(self):
@@ -169,10 +193,7 @@ class SecurityListTestCase(TestCase):
         )
         self.source = SpecificEquityTrades(event_list=trade_history)
 
-        self.df_source, self.df = \
-            factory.create_test_df_source(sim_params)
-
-        algo = RestrictedAlgoWithoutCheck(sid='BZQ', sim_params=sim_params)
+        algo = RestrictedAlgoWithoutCheck(symbol='BZQ', sim_params=sim_params)
         with self.assertRaises(TradingControlViolation) as ctx:
             algo.run(self.source)
 
@@ -189,10 +210,7 @@ class SecurityListTestCase(TestCase):
         )
         self.source = SpecificEquityTrades(event_list=trade_history)
 
-        self.df_source, self.df = \
-            factory.create_test_df_source(sim_params)
-
-        algo = RestrictedAlgoWithoutCheck(sid='JFT', sim_params=sim_params)
+        algo = RestrictedAlgoWithoutCheck(symbol='JFT', sim_params=sim_params)
         with self.assertRaises(TradingControlViolation) as ctx:
             algo.run(self.source)
 
@@ -211,7 +229,7 @@ class SecurityListTestCase(TestCase):
             sim_params
         )
         self.source = SpecificEquityTrades(event_list=trade_history)
-        algo = RestrictedAlgoWithoutCheck(sid='BZQ', sim_params=sim_params)
+        algo = RestrictedAlgoWithoutCheck(symbol='BZQ', sim_params=sim_params)
         with self.assertRaises(TradingControlViolation) as ctx:
             algo.run(self.source)
 
@@ -238,7 +256,7 @@ class SecurityListTestCase(TestCase):
             )
             self.source = SpecificEquityTrades(event_list=trade_history)
             algo = RestrictedAlgoWithoutCheck(
-                sid='BZQ', sim_params=sim_params)
+                symbol='BZQ', sim_params=sim_params)
             with self.assertRaises(TradingControlViolation) as ctx:
                 algo.run(self.source)
 
@@ -261,7 +279,8 @@ class SecurityListTestCase(TestCase):
             )
             self.source = SpecificEquityTrades(event_list=trade_history)
             algo = RestrictedAlgoWithoutCheck(
-                sid='BZQ', sim_params=sim_params)
+                symbol='BZQ', sim_params=sim_params
+            )
             algo.run(self.source)
 
     def test_algo_with_rl_violation_after_add(self):
@@ -278,7 +297,7 @@ class SecurityListTestCase(TestCase):
             )
             self.source = SpecificEquityTrades(event_list=trade_history)
             algo = RestrictedAlgoWithoutCheck(
-                sid='AAPL', sim_params=sim_params)
+                symbol='AAPL', sim_params=sim_params)
             with self.assertRaises(TradingControlViolation) as ctx:
                 algo.run(self.source)
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -26,6 +26,7 @@ from zipline.sources import (DataFrameSource,
                              DataPanelSource,
                              RandomWalkSource)
 from zipline.utils import tradingcalendar as calendar_nyse
+from zipline.finance.trading import with_environment
 
 
 class TestDataFrameSource(TestCase):
@@ -62,7 +63,8 @@ class TestDataFrameSource(TestCase):
             self.assertTrue(isinstance(event['volume'], int))
             self.assertTrue(isinstance(event['arbitrary'], float))
 
-    def test_yahoo_bars_to_panel_source(self):
+    @with_environment()
+    def test_yahoo_bars_to_panel_source(self, env=None):
         stocks = ['AAPL', 'GE']
         start = pd.datetime(1993, 1, 1, 0, 0, 0, 0, pytz.utc)
         end = pd.datetime(2002, 1, 1, 0, 0, 0, 0, pytz.utc)
@@ -74,45 +76,58 @@ class TestDataFrameSource(TestCase):
         check_fields = ['sid', 'open', 'high', 'low', 'close',
                         'volume', 'price']
         source = DataPanelSource(data)
-        stocks_iter = cycle(stocks)
+        sids = [
+            asset.sid for asset in
+            [env.asset_finder.lookup_symbol(symbol, as_of_date=end)
+             for symbol in stocks]
+        ]
+        stocks_iter = cycle(sids)
         for event in source:
             for check_field in check_fields:
                 self.assertIn(check_field, event)
             self.assertTrue(isinstance(event['volume'], (integer_types)))
             self.assertEqual(next(stocks_iter), event['sid'])
 
-    def test_nan_filter_dataframe(self):
+    @with_environment()
+    def test_nan_filter_dataframe(self, env=None):
+        env.update_asset_finder(identifiers=[4, 5])
         dates = pd.date_range('1/1/2000', periods=2, freq='B', tz='UTC')
         df = pd.DataFrame(np.random.randn(2, 2),
                           index=dates,
-                          columns=['A', 'B'])
-        df.loc[dates[0], 'A'] = np.nan  # should be filtered
-        df.loc[dates[1], 'B'] = np.nan  # should not be filtered
+                          columns=[4, 5])
+        # should be filtered
+        df.loc[dates[0], 4] = np.nan
+        # should not be filtered, should have been ffilled
+        df.loc[dates[1], 5] = np.nan
         source = DataFrameSource(df)
         event = next(source)
-        self.assertEqual('B', event.sid)
+        self.assertEqual(5, event.sid)
         event = next(source)
-        self.assertEqual('A', event.sid)
+        self.assertEqual(4, event.sid)
         event = next(source)
-        self.assertEqual('B', event.sid)
-        self.assertTrue(np.isnan(event.price))
+        self.assertEqual(5, event.sid)
+        self.assertFalse(np.isnan(event.price))
 
-    def test_nan_filter_panel(self):
+    @with_environment()
+    def test_nan_filter_panel(self, env=None):
+        env.update_asset_finder(identifiers=[4, 5])
         dates = pd.date_range('1/1/2000', periods=2, freq='B', tz='UTC')
         df = pd.Panel(np.random.randn(2, 2, 2),
                       major_axis=dates,
-                      items=['A', 'B'],
+                      items=[4, 5],
                       minor_axis=['price', 'volume'])
-        df.loc['A', dates[0], 'price'] = np.nan  # should be filtered
-        df.loc['B', dates[1], 'price'] = np.nan  # should not be filtered
+        # should be filtered
+        df.loc[4, dates[0], 'price'] = np.nan
+        # should not be filtered, should have been ffilled
+        df.loc[5, dates[1], 'price'] = np.nan
         source = DataPanelSource(df)
         event = next(source)
-        self.assertEqual('B', event.sid)
+        self.assertEqual(5, event.sid)
         event = next(source)
-        self.assertEqual('A', event.sid)
+        self.assertEqual(4, event.sid)
         event = next(source)
-        self.assertEqual('B', event.sid)
-        self.assertTrue(np.isnan(event.price))
+        self.assertEqual(5, event.sid)
+        self.assertFalse(np.isnan(event.price))
 
 
 class TestRandomWalkSource(TestCase):

--- a/zipline/assets/__init__.py
+++ b/zipline/assets/__init__.py
@@ -12,3 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from ._assets import (
+    Asset,
+    Equity,
+    Future,
+    make_asset_array,
+    CACHE_FILE_TEMPLATE
+)
+from .assets import (
+    AssetFinder,
+    AssetConvertible
+)
+
+__all__ = [
+    'Asset',
+    'Equity',
+    'Future',
+    'AssetFinder',
+    'AssetConvertible',
+    'make_asset_array',
+    'CACHE_FILE_TEMPLATE'
+]

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -1,0 +1,541 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABCMeta
+from itertools import chain
+from numbers import Integral
+import numpy as np
+import operator
+
+from logbook import Logger
+import pandas as pd
+from pandas.tseries.tools import normalize_date
+from six import with_metaclass, string_types
+
+from zipline.errors import (
+    SymbolNotFound,
+    MultipleSymbolsFound,
+    SidNotFound,
+    IdentifierNotFound,
+    ConsumeAssetMetaDataError,
+    InvalidAssetType,
+)
+from zipline.utils import tradingcalendar
+from zipline.assets._assets import (
+    Asset, Equity, Future
+)
+
+log = Logger('assets.py')
+
+# Expected fields for an Asset's metadata
+ASSET_FIELDS = [
+    'sid',
+    'asset_type',
+    'symbol',
+    'asset_name',
+    'start_date',
+    'end_date',
+    'first_traded',
+    'exchange',
+    'notice_date',
+    'expiration_date',
+    'contract_multiplier',
+    # The following fields are for compatibility with other systems
+    'file_name',  # Used as symbol
+    'company_name',  # Used as asset_name
+    'start_date_nano',  # Used as start_date
+    'end_date_nano',  # Used as end_date
+]
+
+
+class AssetFinder(object):
+
+    def __init__(self,
+                 metadata=None,
+                 trading_calendar=tradingcalendar):
+
+        # Any particular instance of AssetFinder should be
+        # consistent throughout its lifetime, so we grab a reference
+        # to our cache now. That way, if the cache is refreshed later,
+        # our instance will continue to use the old one.
+        self.cache = {}
+        self.sym_cache = {}
+        self.identifier_cache = {}
+        self.fuzzy_match = {}
+
+        # The AssetFinder also holds a nested-dict of all metadata for
+        # reference when building Assets
+        self.metadata_cache = {}
+        if metadata:
+            self.consume_metadata(metadata)
+
+        self.trading_calendar = trading_calendar
+        self.populate_cache()
+
+    def _next_free_sid(self):
+        if len(self.cache) > 0:
+            return max(self.cache.keys()) + 1
+        return 0
+
+    def _assign_sid(self, identifier):
+        if hasattr(identifier, '__int__'):
+            return identifier.__int__()
+        if isinstance(identifier, string_types):
+            return self._next_free_sid()
+
+    def retrieve_asset(self, sid, default_none=False):
+        if isinstance(sid, Asset):
+            return sid
+        asset = self.cache.get(sid)
+        if asset is not None:
+            return asset
+        elif default_none:
+            return None
+        else:
+            raise SidNotFound(sid=sid)
+
+    def retrieve_asset_by_identifier(self, identifier):
+        if isinstance(identifier, Asset):
+            return identifier
+        asset = self.identifier_cache.get(identifier)
+        if asset is not None:
+            return asset
+        else:
+            raise IdentifierNotFound(identifier=identifier)
+
+    @staticmethod
+    def _lookup_symbol_in_infos(infos, as_of_date):
+        """
+        Search a list of symbols matching a given asset for the most recent
+        known symbol as of as_of_date.
+
+        Returns a pair of (Asset, bool), representing the best match we
+        found for as_of_date, and whether or not that match was actually
+        trading at as_of_date.
+
+        If no entry in infos started before as_of_date, return (None, False).
+        """
+        # Sort entries by end_date before iterating.  If asset start and end
+        # dates were always disjoint, then we could sort by either start or
+        # end_date and get the same sorting.
+        infos = sorted(infos, key=operator.attrgetter('end_date'))
+
+        # Find the newest asset that started before as_of_date.
+        candidates = [i for i in infos
+                      if (i.start_date is None or i.start_date <= as_of_date)
+                      and (i.end_date is None or as_of_date <= i.end_date)]
+
+        # If one SID exists for symbol, return that symbol
+        if len(candidates) == 1:
+            return candidates[0], True
+
+        # If no SID exists for symbol, return SID with the
+        # highest-but-not-over end_date
+        if len(candidates) == 0:
+            candidates = [i for i in infos
+                          if i.end_date < as_of_date]
+            return (candidates[-1], False) if candidates else (None, False)
+
+        # If multiple SIDs exist for symbol, return latest start_date with
+        # end_date as a tie-breaker
+        if len(candidates) > 1:
+            best_candidate = sorted(
+                candidates,
+                key=lambda x: (x.start_date, x.end_date)
+            )[-1]
+            return best_candidate, True
+
+    def lookup_symbol_resolve_multiple(self, symbol, as_of_date=None):
+        """
+        Return matching Asset of name symbol in database.
+
+        If multiple Assets are found and as_of_date is not set,
+        raises MultipleSymbolsFound.
+
+        If no Asset was active at as_of_date, and allow_expired is False
+        raises SymbolNotFound.
+        """
+        if as_of_date is not None:
+            as_of_date = normalize_date(as_of_date)
+
+        if symbol not in self.sym_cache:
+            raise SymbolNotFound(symbol=symbol)
+
+        infos = self.sym_cache[symbol]
+        if as_of_date is None:
+            if len(infos) == 1:
+                return infos[0]
+            else:
+                raise MultipleSymbolsFound(symbol=symbol,
+                                           options=str(infos))
+
+        # Try to find symbol matching as_of_date
+        asset, _ = self._lookup_symbol_in_infos(infos, as_of_date)
+        if asset is None:
+            raise SymbolNotFound(symbol=symbol)
+        return asset
+
+    def lookup_symbol(self, symbol, as_of_date, fuzzy=None):
+        """
+        If a fuzzy string is provided, then we try various symbols based on
+        the provided symbol.  This is to facilitate mapping from a broker's
+        symbol to ours in cases where mapping to the broker's symbol loses
+        information. For example, if we have CMCS_A, but a broker has CMCSA,
+        when the broker provides CMCSA, it can also provide fuzzy='_',
+        so we can find a match by inserting an underscore.
+        """
+        symbol = symbol.upper()
+        as_of_date = normalize_date(as_of_date)
+
+        if not fuzzy:
+            try:
+                return self.lookup_symbol_resolve_multiple(symbol, as_of_date)
+            except SymbolNotFound:
+                return None
+        else:
+            try:
+                return self.fuzzy_match[(symbol, fuzzy, as_of_date)]
+            except KeyError:
+                # if symbol is CMCSA and fuzzy is '_', then
+                # try CMCSA, then CMCS_A, then CMC_SA, etc.
+                for fuzzy_symbol in chain(
+                        (symbol,),
+                        (symbol[:i] + fuzzy + symbol[i:]
+                         for i in range(len(symbol) - 1, 0, -1))):
+
+                    infos = self.sym_cache.get(fuzzy_symbol)
+                    if infos:
+                        info, date_match = self._lookup_symbol_in_infos(
+                            infos,
+                            as_of_date,
+                        )
+
+                        if info is not None and date_match:
+                            self.fuzzy_match[(symbol, fuzzy, as_of_date)] = \
+                                info
+                            return info
+                else:
+                    self.fuzzy_match[(symbol, fuzzy, as_of_date)] = None
+
+    def populate_cache(self):
+        """
+        Populates the asset cache with all values in the assets
+        collection.
+        """
+
+        # Wipe caches before repopulating
+        self.cache = {}
+        self.sym_cache = {}
+        self.identifier_cache = {}
+        self.fuzzy_match = {}
+
+        counter = 0
+        for identifier, row in self.metadata_cache.items():
+            self.spawn_asset(identifier=identifier, **row)
+            counter += 1
+
+    def spawn_asset(self, identifier, **kwargs):
+
+        # Check if the sid is declared
+        try:
+            kwargs['sid']
+            pass
+        except KeyError:
+            # Assign the identifier as the sid, if applicable
+            if isinstance(identifier, int):
+                kwargs['sid'] = identifier
+            # If the identifier is not a sid, assign one
+            else:
+                kwargs['sid'] = self._assign_sid(identifier)
+                # Update the metadata object with the new sid
+                self.insert_metadata(identifier=identifier, sid=kwargs['sid'])
+
+        # If the file_name is in the kwargs, it may be the symbol
+        try:
+            file_name = kwargs.pop('file_name')
+            try:
+                kwargs['symbol']
+            except KeyError:
+                kwargs['symbol'] = file_name
+        except KeyError:
+            pass
+
+        # If the identifier coming in was a string and there is no defined
+        # symbol yet, set the symbol to the incoming identifier
+        try:
+            kwargs['symbol']
+            pass
+        except KeyError:
+            if isinstance(identifier, string_types):
+                kwargs['symbol'] = identifier
+
+        # If the company_name is in the kwargs, it may be the asset_name
+        try:
+            company_name = kwargs.pop('company_name')
+            try:
+                kwargs['asset_name']
+            except KeyError:
+                kwargs['asset_name'] = company_name
+        except KeyError:
+            pass
+
+        # If dates are given as nanos, pop them
+        try:
+            kwargs['start_date'] = kwargs.pop('start_date_nano')
+        except KeyError:
+            pass
+        try:
+            kwargs['end_date'] = kwargs.pop('end_date_nano')
+        except KeyError:
+            pass
+        try:
+            kwargs['notice_date'] = kwargs.pop('notice_date_nano')
+        except KeyError:
+            pass
+        try:
+            kwargs['expiration_date'] = kwargs.pop('expiration_date_nano')
+        except KeyError:
+            pass
+
+        # Process dates to Timestamps
+        try:
+            kwargs['start_date'] = pd.Timestamp(kwargs['start_date'], tz='UTC')
+        except KeyError:
+            pass
+        try:
+            kwargs['end_date'] = pd.Timestamp(kwargs['end_date'], tz='UTC')
+        except KeyError:
+            pass
+        try:
+            kwargs['notice_date'] = pd.Timestamp(kwargs['notice_date'],
+                                                 tz='UTC')
+        except KeyError:
+            pass
+        try:
+            kwargs['expiration_date'] = pd.Timestamp(kwargs['expiration_date'],
+                                                     tz='UTC')
+        except KeyError:
+            pass
+
+        # Build an Asset of the appropriate type
+        asset_type = kwargs.pop('asset_type', 'equity')
+        if asset_type.lower() == 'equity':
+            asset = Equity(**kwargs)
+        elif asset_type.lower() == 'future':
+            asset = Future(**kwargs)
+        else:
+            raise InvalidAssetType(asset_type=asset_type)
+
+        self.cache[asset.sid] = asset
+        self.identifier_cache[identifier] = asset
+        if asset.symbol is not "":
+            self.sym_cache.setdefault(asset.symbol, []).append(asset)
+
+        return asset
+
+    @property
+    def sids(self):
+        return self.cache.keys()
+
+    @property
+    def assets(self):
+        return self.cache.values()
+
+    def _lookup_generic_scalar(self,
+                               asset_convertible,
+                               as_of_date,
+                               matches,
+                               missing):
+        """
+        Convert asset_convertible to an asset.
+
+        On success, append to matches.
+        On failure, append to missing.
+        """
+        try:
+            if isinstance(asset_convertible, Asset):
+                matches.append(asset_convertible)
+
+            elif isinstance(asset_convertible, Integral):
+                result = self.retrieve_asset(int(asset_convertible))
+                if result is None:
+                    raise SymbolNotFound(symbol=asset_convertible)
+                matches.append(result)
+
+            elif isinstance(asset_convertible, string_types):
+                # Throws SymbolNotFound on failure to match.
+                matches.append(
+                    self.lookup_symbol_resolve_multiple(
+                        asset_convertible,
+                        as_of_date,
+                    )
+                )
+            else:
+                raise NotAssetConvertible(
+                    "Input was %s, not AssetConvertible."
+                    % asset_convertible
+                )
+
+        except SymbolNotFound:
+            missing.append(asset_convertible)
+            return None
+
+    def lookup_generic(self,
+                       asset_convertible_or_iterable,
+                       as_of_date):
+        """
+        Convert a AssetConvertible or iterable of AssetConvertibles into
+        a list of Asset objects.
+
+        This method exists primarily as a convenience for implementing
+        user-facing APIs that can handle multiple kinds of input.  It should
+        not be used for internal code where we already know the expected types
+        of our inputs.
+
+        Returns a pair of objects, the first of which is the result of the
+        conversion, and the second of which is a list containing any values
+        that couldn't be resolved.
+        """
+        matches = []
+        missing = []
+
+        # Interpret input as scalar.
+        if isinstance(asset_convertible_or_iterable, AssetConvertible):
+            self._lookup_generic_scalar(
+                asset_convertible=asset_convertible_or_iterable,
+                as_of_date=as_of_date,
+                matches=matches,
+                missing=missing,
+            )
+            try:
+                return matches[0], missing
+            except IndexError:
+                if hasattr(asset_convertible_or_iterable, '__int__'):
+                    raise SidNotFound(sid=asset_convertible_or_iterable)
+                else:
+                    raise SymbolNotFound(symbol=asset_convertible_or_iterable)
+
+        # Interpret input as iterable.
+        try:
+            iterator = iter(asset_convertible_or_iterable)
+        except TypeError:
+            raise NotAssetConvertible(
+                "Input was not a AssetConvertible "
+                "or iterable of AssetConvertible."
+            )
+
+        for obj in iterator:
+            self._lookup_generic_scalar(obj, as_of_date, matches, missing)
+        return matches, missing
+
+    def insert_metadata(self, identifier, **kwargs):
+        """
+        Inserts the given metadata kwargs to the entry for the given
+        identifier. Matching fields in the existing entry will be overwritten.
+        :param identifier: The identifier for which to insert metadata
+        :param kwargs: The keyed metadata to insert
+        """
+        entry = self.metadata_cache.get(identifier, {})
+
+        for key, value in kwargs.items():
+            # Do not accept invalid fields
+            if key not in ASSET_FIELDS:
+                continue
+            # Do not accept Nones
+            if value is None:
+                continue
+            # Do not accept nans from dataframes
+            if isinstance(value, float) and np.isnan(value):
+                continue
+            entry[key] = value
+
+        self.metadata_cache[identifier] = entry
+
+    def consume_identifiers(self, identifiers):
+        for identifier in identifiers:
+            self.insert_metadata(identifier)
+
+    def consume_metadata(self, metadata):
+        """
+        Consumes the provided metadata in to the metadata cache. The
+        existing values in the cache will be overwritten when there
+        is a conflict.
+        :param metadata: The metadata to be consumed
+        """
+        # Handle dicts
+        if isinstance(metadata, dict):
+            self._insert_metadata_dict(metadata)
+        # Handle DataFrames
+        elif isinstance(metadata, pd.DataFrame):
+            self._insert_metadata_dataframe(metadata)
+        # Handle readables
+        elif hasattr(metadata, 'read'):
+            self._insert_metadata_readable(metadata)
+        else:
+            raise ConsumeAssetMetaDataError(obj=metadata)
+
+    def clear_metadata(self):
+        self.metadata_cache = {}
+
+    def _insert_metadata_dataframe(self, dataframe):
+        for identifier, row in dataframe.iterrows():
+            self.insert_metadata(identifier, **row)
+
+    def _insert_metadata_dict(self, dict):
+        for identifier, entry in dict.items():
+            self.insert_metadata(identifier, **entry)
+
+    def _insert_metadata_readable(self, readable):
+        for row in readable.read():
+            # Parse out the row of the readable object
+            metadata_dict = {}
+            for field in ASSET_FIELDS:
+                try:
+                    row_value = row[field]
+                    # Avoid passing placeholders
+                    if row_value and (row_value is not 'None'):
+                        metadata_dict[field] = row[field]
+                except KeyError:
+                    continue
+                except IndexError:
+                    continue
+            # Locate the identifier, fail if not found
+            if 'sid' in metadata_dict:
+                identifier = metadata_dict['sid']
+            elif 'symbol' in metadata_dict:
+                identifier = metadata_dict['symbol']
+            else:
+                raise ConsumeAssetMetaDataError(obj=row)
+            self.insert_metadata(identifier, **metadata_dict)
+
+
+class AssetConvertible(with_metaclass(ABCMeta)):
+    """
+    ABC for types that are convertible to integer-representations of
+    Assets.
+
+    Includes Asset, six.string_types, and Integral
+    """
+    pass
+
+AssetConvertible.register(Integral)
+AssetConvertible.register(Asset)
+# Use six.string_types for Python2/3 compatibility
+for type in string_types:
+    AssetConvertible.register(type)
+
+
+class NotAssetConvertible(ValueError):
+    pass

--- a/zipline/data/__init__.py
+++ b/zipline/data/__init__.py
@@ -1,4 +1,8 @@
 from . import loader
-from .loader import load_from_yahoo, load_bars_from_yahoo
+from .loader import (
+    load_from_yahoo, load_bars_from_yahoo, load_prices_from_csv,
+    load_prices_from_csv_folder
+)
 
-__all__ = ['loader', 'load_from_yahoo', 'load_bars_from_yahoo']
+__all__ = ['loader', 'load_from_yahoo', 'load_bars_from_yahoo',
+           'load_prices_from_csv', 'load_prices_from_csv_folder']

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -294,7 +294,7 @@ def load_from_yahoo(indexes=None,
                     adjusted=True):
     """
     Loads price data from Yahoo into a dataframe for each of the indicated
-    securities.  By default, 'price' is taken from Yahoo's 'Adjusted Close',
+    assets.  By default, 'price' is taken from Yahoo's 'Adjusted Close',
     which removes the impact of splits and dividends. If the argument
     'adjusted' is False, then the non-adjusted 'close' field is used instead.
 
@@ -367,3 +367,24 @@ def load_bars_from_yahoo(indexes=None,
             for col in adj_cols:
                 panel[ticker][col] *= ratio_filtered
     return panel
+
+
+def load_prices_from_csv(filepath, identifier_col, tz='UTC'):
+    data = pd.read_csv(filepath, index_col=identifier_col)
+    data.index = pd.DatetimeIndex(data.index, tz=tz)
+    data.sort_index(inplace=True)
+    return data
+
+
+def load_prices_from_csv_folder(folderpath, identifier_col, tz='UTC'):
+    data = None
+    for file in os.listdir(folderpath):
+        if '.csv' not in file:
+            continue
+        raw = load_prices_from_csv(os.path.join(folderpath, file),
+                                   identifier_col, tz)
+        if data is None:
+            data = raw
+        else:
+            data = pd.concat([data, raw], axis=1)
+    return data

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -175,7 +175,8 @@ class TradingControlViolation(ZiplineError):
     Raised if an order would violate a constraint set by a TradingControl.
     """
     msg = """
-Order for {amount} shares of {sid} violates trading constraint {constraint}.
+Order for {amount} shares of {asset} at {datetime} violates trading constraint
+{constraint}.
 """.strip()
 
 
@@ -187,4 +188,96 @@ class IncompatibleHistoryFrequency(ZiplineError):
     msg = """
 Requested history at frequency '{frequency}' cannot be created with data
 at frequency '{data_frequency}'.
+""".strip()
+
+
+class MultipleSymbolsFound(ZiplineError):
+    """
+    Raised when a symbol() call contains a symbol that changed over
+    time and is thus not resolvable without additional information
+    provided via as_of_date.
+    """
+    msg = """
+Multiple symbols with the name '{symbol}' found. Use the
+as_of_date' argument to to specify when the date symbol-lookup
+should be valid.
+
+Possible options:{options}
+    """.strip()
+
+
+class SymbolNotFound(ZiplineError):
+    """
+    Raised when a symbol() call contains a non-existant symbol.
+    """
+    msg = """
+Symbol '{symbol}' was not found.
+""".strip()
+
+
+class SidNotFound(ZiplineError):
+    """
+    Raised when a retrieve_asset() call contains a non-existent sid.
+    """
+    msg = """
+Asset with sid '{sid}' was not found.
+""".strip()
+
+
+class IdentifierNotFound(ZiplineError):
+    """
+    Raised when a retrieve_asset_by_identifier() call contains a non-existent
+    identifier.
+    """
+    msg = """
+Asset with identifier '{identifier}' was not found.
+""".strip()
+
+
+class InvalidAssetType(ZiplineError):
+    """
+    Raised when an AssetFinder tries to build an Asset with an invalid
+    AssetType.
+    """
+    msg = """
+AssetMetaData contained an invalid Asset type: '{asset_type}'.
+""".strip()
+
+
+class UpdateAssetFinderTypeError(ZiplineError):
+    """
+    Raised when TradingEnvironment.update_asset_finder() gets an asset_finder
+    arg that is not of AssetFinder class.
+    """
+    msg = """
+TradingEnvironment can not set asset_finder to object of class {cls}.
+""".strip()
+
+
+class ConsumeAssetMetaDataError(ZiplineError):
+    """
+    Raised when AssetMetaData.consume() is called on an invalid object.
+    """
+    msg = """
+AssetMetaData can not consume {obj}. MetaData must be a dict, a DataFrame, or
+""".strip()
+
+
+class NoSourceError(ZiplineError):
+    """
+    Raised when no source is given to the pipeline
+    """
+    msg = """
+No data source given.
+""".strip()
+
+
+class PipelineDateError(ZiplineError):
+    """
+    Raised when only one date is passed to the pipeline
+    """
+    msg = """
+Only one simulation date given. Please specify both the 'start' and 'end' for
+the simulation, or neither. If neither is given, the start and end of the
+DataSource will be used. Given start = '{start}', end = '{end}'
 """.strip()

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -263,6 +263,16 @@ AssetMetaData can not consume {obj}. MetaData must be a dict, a DataFrame, or
 """.strip()
 
 
+class SidAssignmentError(ZiplineError):
+    """
+    Raised when an AssetFinder tries to build an Asset that does not have a sid
+    and that AssetFinder is not permitted to assign sids.
+    """
+    msg = """
+AssetFinder metadata is missing a SID for identifier '{identifier}'.
+""".strip()
+
+
 class NoSourceError(ZiplineError):
     """
     Raised when no source is given to the pipeline

--- a/zipline/examples/dual_ema_talib.py
+++ b/zipline/examples/dual_ema_talib.py
@@ -29,7 +29,7 @@ from zipline.transforms.ta import EMA
 
 
 def initialize(context):
-    context.security = symbol('AAPL')
+    context.asset = symbol('AAPL')
 
     # Add 2 mavg transforms, one with a long window, one with a short window.
     context.short_ema_trans = EMA(timeperiod=20)
@@ -49,17 +49,17 @@ def handle_data(context, data):
     sell = False
 
     if (short_ema > long_ema).all() and not context.invested:
-        order(context.security, 100)
+        order(context.asset, 100)
         context.invested = True
         buy = True
     elif (short_ema < long_ema).all() and context.invested:
-        order(context.security, -100)
+        order(context.asset, -100)
         context.invested = False
         sell = True
 
-    record(AAPL=data[context.security].price,
-           short_ema=short_ema[context.security],
-           long_ema=long_ema[context.security],
+    record(AAPL=data[context.asset].price,
+           short_ema=short_ema[context.asset],
+           long_ema=long_ema[context.asset],
            buy=buy,
            sell=sell)
 
@@ -77,7 +77,8 @@ if __name__ == '__main__':
     data = load_from_yahoo(stocks=['AAPL'], indexes={}, start=start,
                            end=end)
 
-    algo = TradingAlgorithm(initialize=initialize, handle_data=handle_data)
+    algo = TradingAlgorithm(initialize=initialize, handle_data=handle_data,
+                            identifiers=['AAPL'])
     results = algo.run(data).dropna()
 
     fig = plt.figure()

--- a/zipline/examples/dual_moving_average.py
+++ b/zipline/examples/dual_moving_average.py
@@ -31,6 +31,8 @@ def initialize(context):
     add_history(100, '1d', 'price')
     add_history(300, '1d', 'price')
 
+    context.sym = symbol('AAPL')
+
     context.i = 0
 
 
@@ -46,17 +48,15 @@ def handle_data(context, data):
     short_mavg = history(100, '1d', 'price').mean()
     long_mavg = history(300, '1d', 'price').mean()
 
-    sym = symbol('AAPL')
-
     # Trading logic
-    if short_mavg[sym] > long_mavg[sym]:
+    if short_mavg[context.sym] > long_mavg[context.sym]:
         # order_target orders as many shares as needed to
         # achieve the desired number of shares.
-        order_target(sym, 100)
-    elif short_mavg[sym] < long_mavg[sym]:
-        order_target(sym, 0)
+        order_target(context.sym, 100)
+    elif short_mavg[context.sym] < long_mavg[context.sym]:
+        order_target(context.sym, 0)
 
     # Save values for later inspection
-    record(AAPL=data[sym].price,
-           short_mavg=short_mavg[sym],
-           long_mavg=long_mavg[sym])
+    record(AAPL=data[context.sym].price,
+           short_mavg=short_mavg[context.sym],
+           long_mavg=long_mavg[context.sym])

--- a/zipline/examples/olmar.py
+++ b/zipline/examples/olmar.py
@@ -24,6 +24,7 @@ STOCKS = ['AMD', 'CERN', 'COST', 'DELL', 'GPS', 'INTC', 'MMM']
 # http://icml.cc/2012/papers/168.pdf
 def initialize(algo, eps=1, window_length=5):
     algo.stocks = STOCKS
+    algo.sids = [algo.symbol(symbol) for symbol in algo.stocks]
     algo.m = len(algo.stocks)
     algo.price = {}
     algo.b_t = np.ones(algo.m) / algo.m
@@ -52,11 +53,11 @@ def handle_data(algo, data):
     x_tilde = np.zeros(m)
     b = np.zeros(m)
 
-    # find relative moving average price for each security
-    for i, stock in enumerate(algo.stocks):
-        price = data[stock].price
+    # find relative moving average price for each asset
+    for i, sid in enumerate(algo.sids):
+        price = data[sid].price
         # Relative mean deviation
-        x_tilde[i] = data[stock].mavg(algo.window_length) / price
+        x_tilde[i] = data[sid].mavg(algo.window_length) / price
 
     ###########################
     # Inside of OLMAR (algo 2)
@@ -98,17 +99,17 @@ def rebalance_portfolio(algo, data, desired_port):
         positions_value = algo.portfolio.positions_value + \
             algo.portfolio.cash
 
-    for i, stock in enumerate(algo.stocks):
-        current_amount[i] = algo.portfolio.positions[stock].amount
-        prices[i] = data[stock].price
+    for i, sid in enumerate(algo.sids):
+        current_amount[i] = algo.portfolio.positions[sid].amount
+        prices[i] = data[sid].price
 
     desired_amount = np.round(desired_port * positions_value / prices)
 
     algo.last_desired_port = desired_port
     diff_amount = desired_amount - current_amount
 
-    for i, stock in enumerate(algo.stocks):
-        algo.order(stock, diff_amount[i])
+    for i, sid in enumerate(algo.sids):
+        algo.order(sid, diff_amount[i])
 
 
 def simplex_projection(v, b=1):
@@ -154,7 +155,9 @@ if __name__ == '__main__':
     end = datetime(2008, 1, 1, 0, 0, 0, 0, pytz.utc)
     data = load_from_yahoo(stocks=STOCKS, indexes={}, start=start, end=end)
     data = data.dropna()
-    olmar = TradingAlgorithm(handle_data=handle_data, initialize=initialize)
+    olmar = TradingAlgorithm(handle_data=handle_data,
+                             initialize=initialize,
+                             identifiers=STOCKS)
     results = olmar.run(data)
     results.portfolio_value.plot()
     pl.show()

--- a/zipline/examples/pairtrade.py
+++ b/zipline/examples/pairtrade.py
@@ -23,6 +23,7 @@ import pytz
 from zipline.algorithm import TradingAlgorithm
 from zipline.transforms import batch_transform
 from zipline.utils.factory import load_from_yahoo
+from zipline.sources.data_frame_source import DataFrameSource
 
 
 @batch_transform
@@ -59,11 +60,13 @@ class Pairtrade(TradingAlgorithm):
         self.window_length = window_length
         self.ols_transform = ols_transform(refresh_period=self.window_length,
                                            window_length=self.window_length)
+        self.PEP = self.symbol('PEP')
+        self.KO = self.symbol('KO')
 
     def handle_data(self, data):
         ######################################################
         # 1. Compute regression coefficients between PEP and KO
-        params = self.ols_transform.handle_data(data, 'PEP', 'KO')
+        params = self.ols_transform.handle_data(data, self.PEP, self.KO)
         if params is None:
             return
         intercept, slope = params
@@ -81,7 +84,8 @@ class Pairtrade(TradingAlgorithm):
         """1. Compute the spread given slope and intercept.
            2. zscore the spread.
         """
-        spread = (data['PEP'].price - (slope * data['KO'].price + intercept))
+        spread = (data[self.PEP].price -
+                  (slope * data[self.KO].price + intercept))
         self.spreads.append(spread)
         spread_wind = self.spreads[-self.window_length:]
         zscore = (spread - np.mean(spread_wind)) / np.std(spread_wind)
@@ -91,12 +95,12 @@ class Pairtrade(TradingAlgorithm):
         """Buy spread if zscore is > 2, sell if zscore < .5.
         """
         if zscore >= 2.0 and not self.invested:
-            self.order('PEP', int(100 / data['PEP'].price))
-            self.order('KO', -int(100 / data['KO'].price))
+            self.order(self.PEP, int(100 / data[self.PEP].price))
+            self.order(self.KO, -int(100 / data[self.KO].price))
             self.invested = True
         elif zscore <= -2.0 and not self.invested:
-            self.order('PEP', -int(100 / data['PEP'].price))
-            self.order('KO', int(100 / data['KO'].price))
+            self.order(self.PEP, -int(100 / data[self.PEP].price))
+            self.order(self.KO, int(100 / data[self.KO].price))
             self.invested = True
         elif abs(zscore) < .5 and self.invested:
             self.sell_spread()
@@ -107,23 +111,25 @@ class Pairtrade(TradingAlgorithm):
         decrease exposure, regardless of position long/short.
         buy for a short position, sell for a long.
         """
-        ko_amount = self.portfolio.positions['KO'].amount
-        self.order('KO', -1 * ko_amount)
-        pep_amount = self.portfolio.positions['PEP'].amount
-        self.order('PEP', -1 * pep_amount)
+        ko_amount = self.portfolio.positions[self.KO].amount
+        self.order(self.KO, -1 * ko_amount)
+        pep_amount = self.portfolio.positions[self.PEP].amount
+        self.order(self.PEP, -1 * pep_amount)
 
 if __name__ == '__main__':
     start = datetime(2000, 1, 1, 0, 0, 0, 0, pytz.utc)
     end = datetime(2002, 1, 1, 0, 0, 0, 0, pytz.utc)
     data = load_from_yahoo(stocks=['PEP', 'KO'], indexes={},
                            start=start, end=end)
+    source = DataFrameSource(data)
 
     pairtrade = Pairtrade()
-    results = pairtrade.run(data)
+    results = pairtrade.run(source)
     data['spreads'] = np.nan
 
     ax1 = plt.subplot(211)
-    data[['PEP', 'KO']].plot(ax=ax1)
+    # TODO Bugged - indices are out of bounds
+    # data[[pairtrade.PEPsid, pairtrade.KOsid]].plot(ax=ax1)
     plt.ylabel('price')
     plt.setp(ax1.get_xticklabels(), visible=False)
 

--- a/zipline/examples/quantopian_buy_apple.py
+++ b/zipline/examples/quantopian_buy_apple.py
@@ -19,15 +19,16 @@ import pytz
 from zipline import TradingAlgorithm
 from zipline.utils.factory import load_from_yahoo
 
-from zipline.api import order
+from zipline.api import order, symbol
 
 
 def initialize(context):
     context.test = 10
+    context.aapl = symbol('AAPL')
 
 
 def handle_date(context, data):
-    order('AAPL', 10)
+    order(context.aapl, 10)
     print(context.test)
 
 
@@ -39,7 +40,8 @@ if __name__ == '__main__':
                            end=end)
     data = data.dropna()
     algo = TradingAlgorithm(initialize=initialize,
-                            handle_data=handle_date)
+                            handle_data=handle_date,
+                            identifiers=['AAPL'])
     results = algo.run(data)
     results.portfolio_value.plot()
     pl.show()

--- a/zipline/finance/controls.py
+++ b/zipline/finance/controls.py
@@ -37,7 +37,7 @@ class TradingControl(with_metaclass(abc.ABCMeta)):
 
     @abc.abstractmethod
     def validate(self,
-                 sid,
+                 asset,
                  amount,
                  portfolio,
                  algo_datetime,
@@ -46,21 +46,22 @@ class TradingControl(with_metaclass(abc.ABCMeta)):
         Before any order is executed by TradingAlgorithm, this method should be
         called *exactly once* on each registered TradingControl object.
 
-        If the specified sid and amount do not violate this TradingControl's
+        If the specified asset and amount do not violate this TradingControl's
         restraint given the information in `portfolio`, this method should
         return None and have no externally-visible side-effects.
 
         If the desired order violates this TradingControl's contraint, this
-        method should call self.fail(sid, amount).
+        method should call self.fail(asset, amount).
         """
         raise NotImplementedError
 
-    def fail(self, sid, amount):
+    def fail(self, asset, amount, datetime):
         """
         Raise a TradingControlViolation with information about the failure.
         """
-        raise TradingControlViolation(sid=sid,
+        raise TradingControlViolation(asset=asset,
                                       amount=amount,
+                                      datetime=datetime,
                                       constraint=repr(self))
 
     def __repr__(self):
@@ -82,7 +83,7 @@ class MaxOrderCount(TradingControl):
         self.current_date = None
 
     def validate(self,
-                 sid,
+                 asset,
                  amount,
                  _portfolio,
                  algo_datetime,
@@ -98,13 +99,13 @@ class MaxOrderCount(TradingControl):
         self.current_date = algo_date
 
         if self.orders_placed >= self.max_count:
-            self.fail(sid, amount)
+            self.fail(asset, amount, algo_datetime)
         self.orders_placed += 1
 
 
 class RestrictedListOrder(TradingControl):
     """
-    TradingControl representing a restricted list of securities that
+    TradingControl representing a restricted list of assets that
     cannot be ordered by the algorithm.
     """
 
@@ -119,30 +120,30 @@ class RestrictedListOrder(TradingControl):
         self.restricted_list = restricted_list
 
     def validate(self,
-                 sid,
+                 asset,
                  amount,
                  _portfolio,
                  _algo_datetime,
                  _algo_current_data):
         """
-        Fail if the sid is in the restricted_list.
+        Fail if the asset is in the restricted_list.
         """
-        if sid in self.restricted_list:
-            self.fail(sid, amount)
+        if asset in self.restricted_list:
+            self.fail(asset, amount, _algo_datetime)
 
 
 class MaxOrderSize(TradingControl):
     """
     TradingControl representing a limit on the magnitude of any single order
-    placed with the given security.  Can be specified by share or by dollar
+    placed with the given asset.  Can be specified by share or by dollar
     value.
     """
 
-    def __init__(self, sid=None, max_shares=None, max_notional=None):
-        super(MaxOrderSize, self).__init__(sid=sid,
+    def __init__(self, asset=None, max_shares=None, max_notional=None):
+        super(MaxOrderSize, self).__init__(asset=asset,
                                            max_shares=max_shares,
                                            max_notional=max_notional)
-        self.sid = sid
+        self.asset = asset
         self.max_shares = max_shares
         self.max_notional = max_notional
 
@@ -162,7 +163,7 @@ class MaxOrderSize(TradingControl):
             )
 
     def validate(self,
-                 sid,
+                 asset,
                  amount,
                  portfolio,
                  _algo_datetime,
@@ -172,33 +173,33 @@ class MaxOrderSize(TradingControl):
         or self.max_notional.
         """
 
-        if self.sid is not None and self.sid != sid:
+        if self.asset is not None and self.asset != asset:
             return
 
         if self.max_shares is not None and abs(amount) > self.max_shares:
-            self.fail(sid, amount)
+            self.fail(asset, amount, _algo_datetime)
 
-        current_sid_price = algo_current_data[sid].price
-        order_value = amount * current_sid_price
+        current_asset_price = algo_current_data[asset].price
+        order_value = amount * current_asset_price
 
         too_much_value = (self.max_notional is not None and
                           abs(order_value) > self.max_notional)
 
         if too_much_value:
-            self.fail(sid, amount)
+            self.fail(asset, amount, _algo_datetime)
 
 
 class MaxPositionSize(TradingControl):
     """
     TradingControl representing a limit on the maximum position size that can
-    be held by an algo for a given security.
+    be held by an algo for a given asset.
     """
 
-    def __init__(self, sid=None, max_shares=None, max_notional=None):
-        super(MaxPositionSize, self).__init__(sid=sid,
+    def __init__(self, asset=None, max_shares=None, max_notional=None):
+        super(MaxPositionSize, self).__init__(asset=asset,
                                               max_shares=max_shares,
                                               max_notional=max_notional)
-        self.sid = sid
+        self.asset = asset
         self.max_shares = max_shares
         self.max_notional = max_notional
 
@@ -218,7 +219,7 @@ class MaxPositionSize(TradingControl):
             )
 
     def validate(self,
-                 sid,
+                 asset,
                  amount,
                  portfolio,
                  algo_datetime,
@@ -229,25 +230,25 @@ class MaxPositionSize(TradingControl):
         self.max_notional.
         """
 
-        if self.sid is not None and self.sid != sid:
+        if self.asset is not None and self.asset != asset:
             return
 
-        current_share_count = portfolio.positions[sid].amount
+        current_share_count = portfolio.positions[asset].amount
         shares_post_order = current_share_count + amount
 
         too_many_shares = (self.max_shares is not None and
                            abs(shares_post_order) > self.max_shares)
         if too_many_shares:
-            self.fail(sid, amount)
+            self.fail(asset, amount, algo_datetime)
 
-        current_price = algo_current_data[sid].price
+        current_price = algo_current_data[asset].price
         value_post_order = shares_post_order * current_price
 
         too_much_value = (self.max_notional is not None and
                           abs(value_post_order) > self.max_notional)
 
         if too_much_value:
-            self.fail(sid, amount)
+            self.fail(asset, amount, algo_datetime)
 
 
 class LongOnly(TradingControl):
@@ -256,17 +257,41 @@ class LongOnly(TradingControl):
     """
 
     def validate(self,
-                 sid,
+                 asset,
                  amount,
                  portfolio,
                  _algo_datetime,
                  _algo_current_data):
         """
-        Fail if we would hold negative shares of sid after completing this
+        Fail if we would hold negative shares of asset after completing this
         order.
         """
-        if portfolio.positions[sid].amount + amount < 0:
-            self.fail(sid, amount)
+        if portfolio.positions[asset].amount + amount < 0:
+            self.fail(asset, amount, _algo_datetime)
+
+
+class AssetDateBounds(TradingControl):
+    """
+    TradingControl representing a prohibition against ordering an asset before
+    its start_date, or after its end_date.
+    """
+
+    def validate(self,
+                 asset,
+                 amount,
+                 portfolio,
+                 algo_datetime,
+                 algo_current_data):
+        """
+        Fail if the algo has passed this Asset's end_date, or before the
+        Asset's start date.
+        """
+        # Fail if the algo is before this Asset's start_date
+        if asset.start_date and (algo_datetime < asset.start_date):
+            self.fail(asset, amount, algo_datetime)
+        # Fail if the algo has passed this Asset's end_date
+        if asset.end_date and (algo_datetime >= asset.end_date):
+            self.fail(asset, amount, algo_datetime)
 
 
 class AccountControl(with_metaclass(abc.ABCMeta)):

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -20,12 +20,11 @@ Position Tracking
     +-----------------+----------------------------------------------------+
     | key             | value                                              |
     +=================+====================================================+
-    | sid             | the identifier for the security held in this       |
-    |                 | position.                                          |
+    | sid             | the sid for the asset held in this position        |
     +-----------------+----------------------------------------------------+
     | amount          | whole number of shares in the position             |
     +-----------------+----------------------------------------------------+
-    | last_sale_price | price at last sale of the security on the exchange |
+    | last_sale_price | price at last sale of the asset on the exchange    |
     +-----------------+----------------------------------------------------+
     | cost_basis      | the volume weighted average price paid per share   |
     +-----------------+----------------------------------------------------+

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -92,8 +92,8 @@ class PositionTracker(object):
         self._invalidate_cache()
 
         # Calculate cash adjustment on assets with multipliers
-        return (price - old_price) * self._position_payout_multipliers[sid] \
-               * pos.amount
+        return ((price - old_price) * self._position_payout_multipliers[sid]
+                * pos.amount)
 
     def update_positions(self, positions):
         # update positions in batch

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -337,6 +337,11 @@ class PerformanceTracker(object):
         self.all_benchmark_returns[midnight] = event.returns
 
     def process_close_position(self, event):
+
+        # CLOSE_POSITION events contain prices that must be handled as a final
+        # trade event
+        self.process_trade(event)
+
         txn = self.position_tracker.create_close_position_transaction(event)
         if txn:
             self.process_transaction(txn)

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -23,6 +23,8 @@ import numpy as np
 
 from zipline.data.loader import load_market_data
 from zipline.utils import tradingcalendar
+from zipline.assets import AssetFinder
+from zipline.errors import UpdateAssetFinderTypeError
 
 
 log = logbook.Logger('Trading')
@@ -134,6 +136,8 @@ class TradingEnvironment(object):
 
         self.exchange_tz = exchange_tz
 
+        self.asset_finder = AssetFinder(trading_calendar=env_trading_calendar)
+
     def __enter__(self, *args, **kwargs):
         global environment
         self.prev_environment = environment
@@ -148,6 +152,52 @@ class TradingEnvironment(object):
         # signal that any exceptions need to be propagated up the
         # stack.
         return False
+
+    def update_asset_finder(self,
+                            clear_metadata=False,
+                            asset_finder=None,
+                            asset_metadata=None,
+                            identifiers=None):
+        """
+        Updates the AssetFinder using the provided asset metadata and
+        identifiers.
+        If clear_metadata is True, all metadata and assets held in the
+        asset_finder will be erased before new metadata is provided.
+        If asset_finder is provided, the existing asset_finder will be replaced
+        outright with the new asset_finder.
+        If asset_metadata is provided, the existing metadata will be cleared
+        and replaced with the provided metadata.
+        All identifiers will be inserted in the asset metadata if they are not
+        already present.
+
+        :param clear_metadata: A boolean
+        :param asset_finder: An AssetFinder object to replace the environment's
+        existing asset_finder
+        :param asset_metadata: A dict, DataFrame, or readable object
+        :param identifiers: A list of identifiers to be inserted
+        :return:
+        """
+        populate = False
+        if clear_metadata:
+            self.asset_finder.clear_metadata()
+            populate = True
+
+        if asset_finder is not None:
+            if not isinstance(asset_finder, AssetFinder):
+                raise UpdateAssetFinderTypeError(cls=asset_finder.__class__)
+            self.asset_finder = asset_finder
+
+        if asset_metadata is not None:
+            self.asset_finder.clear_metadata()
+            self.asset_finder.consume_metadata(asset_metadata)
+            populate = True
+
+        if identifiers is not None:
+            self.asset_finder.consume_identifiers(identifiers)
+            populate = True
+
+        if populate:
+            self.asset_finder.populate_cache()
 
     def normalize_date(self, test_date):
         test_date = pd.Timestamp(test_date, tz='UTC')

--- a/zipline/history/history_container.py
+++ b/zipline/history/history_container.py
@@ -217,7 +217,7 @@ class HistoryContainer(object):
           history_specs (dict[Frequency:HistorySpec]): The starting history
             specs that this container should be able to service.
 
-          initial_sids (set[Security or Int]): The starting sids to watch.
+          initial_sids (set[Asset or Int]): The starting sids to watch.
 
           initial_dt (datetime): The datetime to start collecting history from.
 

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -58,7 +58,12 @@ DIVIDEND_FIELDS = [
     'sid',
 ]
 # Expected fields/index values for a dividend payment Series.
-DIVIDEND_PAYMENT_FIELDS = ['id', 'payment_sid', 'cash_amount', 'share_count']
+DIVIDEND_PAYMENT_FIELDS = [
+    'id',
+    'payment_sid',
+    'cash_amount',
+    'share_count',
+]
 
 
 def dividend_payment(data=None):
@@ -73,7 +78,7 @@ def dividend_payment(data=None):
     payment.
 
     Additionally, if @data is non-empty, either data['cash_amount'] should be
-    nonzero or data['payment_sid'] should be a security identifier and
+    nonzero or data['payment_sid'] should be an asset identifier and
     data['share_count'] should be nonzero.
 
     The returned Series is given its id value as a name so that concatenating
@@ -289,7 +294,6 @@ class SIDData(object):
 
     def __init__(self, sid, initial_values=None):
         self._sid = sid
-
         self._freqstr = None
 
         # To check if we have data, we use the __len__ which depends on the

--- a/zipline/sources/simulated.py
+++ b/zipline/sources/simulated.py
@@ -23,6 +23,7 @@ import pandas as pd
 from zipline.sources.data_source import DataSource
 from zipline.utils import tradingcalendar as calendar_nyse
 from zipline.gens.utils import hash_args
+from zipline.finance import trading
 
 
 class RandomWalkSource(DataSource):
@@ -92,6 +93,7 @@ class RandomWalkSource(DataSource):
         self.sd = sd
 
         self.sids = self.start_prices.keys()
+        trading.environment.update_asset_finder(identifiers=self.sids)
 
         self.open_and_closes = \
             calendar.open_and_closes[self.start:self.end]

--- a/zipline/sources/simulated.py
+++ b/zipline/sources/simulated.py
@@ -23,7 +23,7 @@ import pandas as pd
 from zipline.sources.data_source import DataSource
 from zipline.utils import tradingcalendar as calendar_nyse
 from zipline.gens.utils import hash_args
-from zipline.finance import trading
+from zipline.finance.trading import TradingEnvironment
 
 
 class RandomWalkSource(DataSource):
@@ -93,7 +93,9 @@ class RandomWalkSource(DataSource):
         self.sd = sd
 
         self.sids = self.start_prices.keys()
-        trading.environment.update_asset_finder(identifiers=self.sids)
+        TradingEnvironment.instance().update_asset_finder(
+            identifiers=self.sids
+        )
 
         self.open_and_closes = \
             calendar.open_and_closes[self.start:self.end]

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -85,14 +85,17 @@ from zipline.api import (
     order,
     set_slippage,
     record,
+    sid,
 )
 from zipline.errors import UnsupportedOrderParameters
+from zipline.assets import Future, Equity
 from zipline.finance.execution import (
     LimitOrder,
     MarketOrder,
     StopLimitOrder,
     StopOrder,
 )
+from zipline.finance.controls import AssetDateBounds
 from zipline.transforms import BatchTransform, batch_transform
 
 
@@ -111,14 +114,14 @@ class TestAlgorithm(TradingAlgorithm):
                    slippage=None,
                    commission=None):
         self.count = order_count
-        self.sid = sid
+        self.asset = self.sid(sid)
         self.amount = amount
         self.incr = 0
 
         if sid_filter:
             self.sid_filter = sid_filter
         else:
-            self.sid_filter = [self.sid]
+            self.sid_filter = [self.asset.sid]
 
         if slippage is not None:
             self.set_slippage(slippage)
@@ -129,7 +132,7 @@ class TestAlgorithm(TradingAlgorithm):
     def handle_data(self, data):
         # place an order for amount shares of sid
         if self.incr < self.count:
-            self.order(self.sid, self.amount)
+            self.order(self.asset, self.amount)
             self.incr += 1
 
 
@@ -141,13 +144,13 @@ class HeavyBuyAlgorithm(TradingAlgorithm):
     """
 
     def initialize(self, sid, amount):
-        self.sid = sid
+        self.asset = self.sid(sid)
         self.amount = amount
         self.incr = 0
 
     def handle_data(self, data):
         # place an order for 100 shares of sid
-        self.order(self.sid, self.amount)
+        self.order(self.asset, self.amount)
         self.incr += 1
 
 
@@ -177,7 +180,7 @@ class ExceptionAlgorithm(TradingAlgorithm):
     def initialize(self, throw_from, sid):
 
         self.throw_from = throw_from
-        self.sid = sid
+        self.asset = self.sid(sid)
 
         if self.throw_from == "initialize":
             raise Exception("Algo exception in initialize")
@@ -200,7 +203,7 @@ class ExceptionAlgorithm(TradingAlgorithm):
         if self.throw_from == "get_sid_filter":
             raise Exception("Algo exception in get_sid_filter")
         else:
-            return [self.sid]
+            return [self.asset]
 
     def set_transact_setter(self, txn_sim_callable):
         pass
@@ -209,7 +212,7 @@ class ExceptionAlgorithm(TradingAlgorithm):
 class DivByZeroAlgorithm(TradingAlgorithm):
 
     def initialize(self, sid):
-        self.sid = sid
+        self.asset = self.sid(sid)
         self.incr = 0
 
     def handle_data(self, data):
@@ -222,7 +225,7 @@ class DivByZeroAlgorithm(TradingAlgorithm):
 class TooMuchProcessingAlgorithm(TradingAlgorithm):
 
     def initialize(self, sid):
-        self.sid = sid
+        self.asset = self.sid(sid)
 
     def handle_data(self, data):
         # Unless we're running on some sort of
@@ -234,7 +237,7 @@ class TooMuchProcessingAlgorithm(TradingAlgorithm):
 class TimeoutAlgorithm(TradingAlgorithm):
 
     def initialize(self, sid):
-        self.sid = sid
+        self.asset = self.sid(sid)
         self.incr = 0
 
     def handle_data(self, data):
@@ -269,7 +272,7 @@ class TestOrderAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
         self.incr += 1
-        self.order(0, 1)
+        self.order(self.sid(0), 1)
 
 
 class TestOrderInstantAlgorithm(TradingAlgorithm):
@@ -286,7 +289,7 @@ class TestOrderInstantAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 self.last_price, "Orders was not filled at last price."
         self.incr += 2
-        self.order_value(0, data[0].price * 2.)
+        self.order_value(self.sid(0), data[0].price * 2.)
         self.last_price = data[0].price
 
 
@@ -311,7 +314,9 @@ class TestOrderStyleForwardingAlgorithm(TradingAlgorithm):
             assert len(self.portfolio.positions.keys()) == 0
 
             method_to_check = getattr(self, self.method_name)
-            method_to_check(0, data[0].price, style=StopLimitOrder(10, 10))
+            method_to_check(self.sid(0),
+                            data[0].price,
+                            style=StopLimitOrder(10, 10))
 
             assert len(self.blotter.open_orders[0]) == 1
             result = self.blotter.open_orders[0][0]
@@ -335,7 +340,12 @@ class TestOrderValueAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
         self.incr += 2
-        self.order_value(0, data[0].price * 2.)
+
+        multiplier = 2.
+        if isinstance(self.sid(0), Future):
+            multiplier *= self.sid(0).contract_multiplier
+
+        self.order_value(self.sid(0), data[0].price * multiplier)
 
 
 class TestTargetAlgorithm(TradingAlgorithm):
@@ -352,7 +362,7 @@ class TestTargetAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
         self.target_shares = np.random.randint(1, 30)
-        self.order_target(0, self.target_shares)
+        self.order_target(self.sid(0), self.target_shares)
 
 
 class TestOrderPercentAlgorithm(TradingAlgorithm):
@@ -363,7 +373,7 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
     def handle_data(self, data):
         if self.target_shares == 0:
             assert 0 not in self.portfolio.positions
-            self.order(0, 10)
+            self.order(self.sid(0), 10)
             self.target_shares = 10
             return
         else:
@@ -372,10 +382,17 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
 
-        self.order_percent(0, .001)
-        self.target_shares += np.floor((.001 *
-                                        self.portfolio.portfolio_value) /
-                                       data[0].price)
+        self.order_percent(self.sid(0), .001)
+
+        if isinstance(self.sid(0), Equity):
+            self.target_shares += np.floor(
+                (.001 * self.portfolio.portfolio_value) / data[0].price
+            )
+        if isinstance(self.sid(0), Future):
+            self.target_shares += np.floor(
+                (.001 * self.portfolio.portfolio_value) /
+                (data[0].price * self.sid(0).contract_multiplier)
+            )
 
 
 class TestTargetPercentAlgorithm(TradingAlgorithm):
@@ -394,7 +411,7 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
         self.sale_price = data[0].price
-        self.order_target_percent(0, .002)
+        self.order_target_percent(self.sid(0), .002)
 
 
 class TestTargetValueAlgorithm(TradingAlgorithm):
@@ -405,7 +422,7 @@ class TestTargetValueAlgorithm(TradingAlgorithm):
     def handle_data(self, data):
         if self.target_shares == 0:
             assert 0 not in self.portfolio.positions
-            self.order(0, 10)
+            self.order(self.sid(0), 10)
             self.target_shares = 10
             return
         else:
@@ -415,8 +432,14 @@ class TestTargetValueAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
 
-        self.order_target_value(0, 20)
+        self.order_target_value(self.sid(0), 20)
         self.target_shares = np.round(20 / data[0].price)
+
+        if isinstance(self.sid(0), Equity):
+            self.target_shares = np.round(20 / data[0].price)
+        if isinstance(self.sid(0), Future):
+            self.target_shares = np.round(
+                20 / (data[0].price * self.sid(0).contract_multiplier))
 
 
 ############################
@@ -468,6 +491,18 @@ class SetLongOnlyAlgorithm(TradingAlgorithm):
         self.set_long_only()
 
 
+class SetAssetDateBoundsAlgorithm(TradingAlgorithm):
+    """
+    Algorithm that tries to order 1 share of sid 0 on every bar and has an
+    AssetDateBounds() trading control in place.
+    """
+    def initialize(self):
+        self.register_trading_control(AssetDateBounds())
+
+    def handle_data(algo, data):
+        algo.order(algo.sid(0), 1)
+
+
 class TestRegisterTransformAlgorithm(TradingAlgorithm):
     def initialize(self, *args, **kwargs):
         self.set_slippage(FixedSlippage())
@@ -484,7 +519,7 @@ class AmbitiousStopLimitAlgorithm(TradingAlgorithm):
     """
 
     def initialize(self, *args, **kwargs):
-        self.sid = kwargs.pop('sid')
+        self.asset = self.sid(kwargs.pop('sid'))
 
     def handle_data(self, data):
 
@@ -493,42 +528,42 @@ class AmbitiousStopLimitAlgorithm(TradingAlgorithm):
         ########
 
         # Buy with low limit, shouldn't trigger.
-        self.order(self.sid, 100, limit_price=1)
+        self.order(self.asset, 100, limit_price=1)
 
         # But with high stop, shouldn't trigger
-        self.order(self.sid, 100, stop_price=10000000)
+        self.order(self.asset, 100, stop_price=10000000)
 
         # Buy with high limit (should trigger) but also high stop (should
         # prevent trigger).
-        self.order(self.sid, 100, limit_price=10000000, stop_price=10000000)
+        self.order(self.asset, 100, limit_price=10000000, stop_price=10000000)
 
         # Buy with low stop (should trigger), but also low limit (should
         # prevent trigger).
-        self.order(self.sid, 100, limit_price=1, stop_price=1)
+        self.order(self.asset, 100, limit_price=1, stop_price=1)
 
         #########
         # Sells #
         #########
 
         # Sell with high limit, shouldn't trigger.
-        self.order(self.sid, -100, limit_price=1000000)
+        self.order(self.asset, -100, limit_price=1000000)
 
         # Sell with low stop, shouldn't trigger.
-        self.order(self.sid, -100, stop_price=1)
+        self.order(self.asset, -100, stop_price=1)
 
         # Sell with low limit (should trigger), but also high stop (should
         # prevent trigger).
-        self.order(self.sid, -100, limit_price=1000000, stop_price=1000000)
+        self.order(self.asset, -100, limit_price=1000000, stop_price=1000000)
 
         # Sell with low limit (should trigger), but also low stop (should
         # prevent trigger).
-        self.order(self.sid, -100, limit_price=1, stop_price=1)
+        self.order(self.asset, -100, limit_price=1, stop_price=1)
 
         ###################
         # Rounding Checks #
         ###################
-        self.order(self.sid, 100, limit_price=.00000001)
-        self.order(self.sid, -100, stop_price=.00000001)
+        self.order(self.asset, 100, limit_price=.00000001)
+        self.order(self.asset, -100, stop_price=.00000001)
 
 
 ##########################################
@@ -695,8 +730,8 @@ class BatchTransformAlgorithm(TradingAlgorithm):
                 "batch transform is not updating for new kwargs"
 
         new_data = deepcopy(data)
-        for sid in new_data:
-            new_data[sid]['arbitrary'] = 123
+        for sidint in new_data:
+            new_data[sidint]['arbitrary'] = 123
 
         self.history_return_arbitrary_fields.append(
             self.return_arbitrary_fields.handle_data(new_data))
@@ -707,8 +742,7 @@ class BatchTransformAlgorithm(TradingAlgorithm):
                 self.return_nan.handle_data(data))
         else:
             nan_data = deepcopy(data)
-            for sid in nan_data.iterkeys():
-                nan_data[sid].price = np.nan
+            nan_data.price = np.nan
             self.history_return_nan.append(
                 self.return_nan.handle_data(nan_data))
 
@@ -810,7 +844,7 @@ class EmptyPositionsAlgorithm(TradingAlgorithm):
     def handle_data(self, data):
         if not self.ordered:
             for s in data:
-                self.order(s, 100)
+                self.order(self.sid(s), 100)
             self.ordered = True
 
         if not self.exited:
@@ -821,7 +855,7 @@ class EmptyPositionsAlgorithm(TradingAlgorithm):
                 (len(amounts) == len(data.keys()))
             ):
                 for stock in self.portfolio.positions:
-                    self.order(stock, -100)
+                    self.order(self.sid(stock), -100)
                 self.exited = True
 
         # Should be 0 when all positions are exited.
@@ -834,7 +868,7 @@ class InvalidOrderAlgorithm(TradingAlgorithm):
     appropriate exceptions are raised.
     """
     def initialize(self, *args, **kwargs):
-        self.sid = kwargs.pop('sids')[0]
+        self.asset = self.sid(kwargs.pop('sids')[0])
 
     def handle_data(self, data):
         from zipline.api import (
@@ -849,40 +883,48 @@ class InvalidOrderAlgorithm(TradingAlgorithm):
                       StopOrder(10), StopLimitOrder(10, 10)]:
 
             with assert_raises(UnsupportedOrderParameters):
-                order(self.sid, 10, limit_price=10, style=style)
+                order(self.asset, 10, limit_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order(self.sid, 10, stop_price=10, style=style)
+                order(self.asset, 10, stop_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_value(self.sid, 300, limit_price=10, style=style)
+                order_value(self.asset, 300, limit_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_value(self.sid, 300, stop_price=10, style=style)
+                order_value(self.asset, 300, stop_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_percent(self.sid, .1, limit_price=10, style=style)
+                order_percent(self.asset, .1, limit_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_percent(self.sid, .1, stop_price=10, style=style)
+                order_percent(self.asset, .1, stop_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_target(self.sid, 100, limit_price=10, style=style)
+                order_target(self.asset, 100, limit_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_target(self.sid, 100, stop_price=10, style=style)
+                order_target(self.asset, 100, stop_price=10, style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_target_value(self.sid, 100, limit_price=10, style=style)
+                order_target_value(self.asset, 100,
+                                   limit_price=10,
+                                   style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_target_value(self.sid, 100, stop_price=10, style=style)
+                order_target_value(self.asset, 100,
+                                   stop_price=10,
+                                   style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_target_percent(self.sid, .2, limit_price=10, style=style)
+                order_target_percent(self.asset, .2,
+                                     limit_price=10,
+                                     style=style)
 
             with assert_raises(UnsupportedOrderParameters):
-                order_target_percent(self.sid, .2, stop_price=10, style=style)
+                order_target_percent(self.asset, .2,
+                                     stop_price=10,
+                                     style=style)
 
 
 ##############################
@@ -913,7 +955,7 @@ def handle_data_api(context, data):
         assert context.portfolio.positions[0]['last_sale_price'] == \
             data[0].price, "Orders not filled at current price."
     context.incr += 1
-    order(0, 1)
+    order(sid(0), 1)
 
     record(incr=context.incr)
 
@@ -932,7 +974,8 @@ api_algo = """
 from zipline.api import (order,
                          set_slippage,
                          FixedSlippage,
-                         record)
+                         record,
+                         sid)
 
 def initialize(context):
     context.incr = 0
@@ -948,7 +991,7 @@ def handle_data(context, data):
         assert context.portfolio.positions[0]['last_sale_price'] == \
                 data[0].price, "Orders not filled at current price."
     context.incr += 1
-    order(0, 1)
+    order(sid(0), 1)
 
     record(incr=context.incr)
 """
@@ -1009,18 +1052,19 @@ from zipline.api import (order,
                          order_percent,
                          order_target,
                          order_target_value,
-                         order_target_percent)
+                         order_target_percent,
+                         sid)
 
 def initialize(context):
     pass
 
 def handle_data(context, data):
-    order(0, 10)
-    order_value(0, 300)
-    order_percent(0, .1)
-    order_target(0, 100)
-    order_target_value(0, 100)
-    order_target_percent(0, .2)
+    order(sid(0), 10)
+    order_value(sid(0), 300)
+    order_percent(sid(0), .1)
+    order_target(sid(0), 100)
+    order_target_value(sid(0), 100)
+    order_target_percent(sid(0), .2)
 """
 
 record_variables = """

--- a/zipline/utils/cli.py
+++ b/zipline/utils/cli.py
@@ -31,14 +31,15 @@ except:
     PYGMENTS = False
 
 import zipline
+from zipline.errors import NoSourceError, PipelineDateError
 
 DEFAULTS = {
-    'start': '2012-01-01',
-    'end': '2012-12-31',
     'data_frequency': 'daily',
     'capital_base': '10e6',
     'source': 'yahoo',
-    'symbols': 'AAPL'
+    'symbols': 'AAPL',
+    'metadata_index': 'symbol',
+    'source_time_column': 'Date',
 }
 
 
@@ -99,9 +100,12 @@ def parse_args(argv, ipython_mode=False):
     parser.add_argument('--start', '-s')
     parser.add_argument('--end', '-e')
     parser.add_argument('--capital_base')
-    parser.add_argument('--source', choices=('yahoo',))
+    parser.add_argument('--source', '-d')
+    parser.add_argument('--source_time_column', '-t')
     parser.add_argument('--symbols')
     parser.add_argument('--output', '-o')
+    parser.add_argument('--metadata_path', '-m')
+    parser.add_argument('--metadata_index', '-x')
     if ipython_mode:
         parser.add_argument('--local_namespace', action='store_true')
 
@@ -153,14 +157,59 @@ def run_pipeline(print_algo=True, **kwargs):
            pygments syntax coloring if pygments is found.
 
     """
-    start = pd.Timestamp(kwargs['start'], tz='UTC')
-    end = pd.Timestamp(kwargs['end'], tz='UTC')
+    start = kwargs['start']
+    end = kwargs['end']
+    # Compare against None because strings/timestamps may have been given
+    if start is not None:
+        start = pd.Timestamp(start, tz='UTC')
+    if end is not None:
+        end = pd.Timestamp(end, tz='UTC')
+
+    # Fail out if only one bound is provided
+    if ((start is None) or (end is None)) and (start != end):
+        raise PipelineDateError(start=start, end=end)
+
+    # Check if start and end are provided, and if the sim_params need to read
+    # a start and end from the DataSource
+    if start is None:
+        overwrite_sim_params = True
+    else:
+        overwrite_sim_params = False
 
     symbols = kwargs['symbols'].split(',')
+    asset_identifier = kwargs['metadata_index']
 
-    if kwargs['source'] == 'yahoo':
+    # Pull asset metadata
+    asset_metadata = kwargs.get('asset_metadata', None)
+    asset_metadata_path = kwargs['metadata_path']
+    # Read in a CSV file, if applicable
+    if asset_metadata_path is not None:
+        if os.path.isfile(asset_metadata_path):
+            asset_metadata = pd.read_csv(asset_metadata_path,
+                                         index_col=asset_identifier)
+
+    source_arg = kwargs['source']
+    source_time_column = kwargs['source_time_column']
+
+    if source_arg is None:
+        raise NoSourceError()
+
+    elif source_arg == 'yahoo':
         source = zipline.data.load_bars_from_yahoo(
             stocks=symbols, start=start, end=end)
+
+    elif os.path.isfile(source_arg):
+        source = zipline.data.load_prices_from_csv(
+            filepath=source_arg,
+            identifier_col=source_time_column
+        )
+
+    elif os.path.isdir(source_arg):
+        source = zipline.data.load_prices_from_csv_folder(
+            folderpath=source_arg,
+            identifier_col=source_time_column
+        )
+
     else:
         raise NotImplementedError(
             'Source %s not implemented.' % kwargs['source'])
@@ -188,9 +237,13 @@ def run_pipeline(print_algo=True, **kwargs):
     algo = zipline.TradingAlgorithm(script=algo_text,
                                     namespace=kwargs.get('namespace', {}),
                                     capital_base=float(kwargs['capital_base']),
-                                    algo_filename=kwargs.get('algofile'))
+                                    algo_filename=kwargs.get('algofile'),
+                                    asset_metadata=asset_metadata,
+                                    identifiers=symbols,
+                                    start=start,
+                                    end=end)
 
-    perf = algo.run(source)
+    perf = algo.run(source, overwrite_sim_params=overwrite_sim_params)
 
     output_fname = kwargs.get('output', None)
     if output_fname is not None:

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -120,6 +120,7 @@ def create_trade_history(sid, prices, amounts, interval, sim_params,
                          source_id="test_factory"):
     trades = []
     current = sim_params.first_open
+    trading.environment.update_asset_finder(identifiers=[sid])
 
     oneday = timedelta(days=1)
     use_midnight = interval >= oneday
@@ -149,7 +150,6 @@ def create_dividend(sid, payment, declared_date, ex_date, pay_date):
         'type': DATASOURCE_TYPE.DIVIDEND,
         'source_id': 'MockDividendSource'
     })
-
     return div
 
 
@@ -311,6 +311,8 @@ def create_test_df_source(sim_params=None, bars='daily'):
     x = np.arange(1, len(index) + 1)
 
     df = pd.DataFrame(x, index=index, columns=[0])
+
+    trading.environment.update_asset_finder(identifiers=[0])
 
     return DataFrameSource(df), df
 

--- a/zipline/utils/security_list.py
+++ b/zipline/utils/security_list.py
@@ -5,6 +5,7 @@ import os.path
 import pandas as pd
 import pytz
 import zipline
+from zipline.finance.trading import with_environment
 
 
 DATE_FORMAT = "%Y%m%d"
@@ -12,23 +13,16 @@ zipline_dir = os.path.dirname(zipline.__file__)
 SECURITY_LISTS_DIR = os.path.join(zipline_dir, 'resources', 'security_lists')
 
 
-def loopback(symbol, *args, **kwargs):
-    return symbol
-
-
 class SecurityList(object):
 
-    def __init__(self, lookup_func, data, current_date_func):
+    def __init__(self, data, current_date_func):
         """
-        lookup_func: function that takes a string symbol and a date and
-        returns a Security object.
         data: a nested dictionary:
             knowledge_date -> lookup_date ->
               {add: [symbol list], 'delete': []}, delete: [symbol list]}
         current_date_func: function taking no parameters, returning
             current datetime
         """
-        self.lookup_func = lookup_func
         self.data = data
         self._cache = {}
         self._knowledge_dates = self.make_knowledge_dates(self.data)
@@ -74,13 +68,17 @@ class SecurityList(object):
             self._cache[kd] = self._current_set
         return self._current_set
 
-    def update_current(self, effective_date, symbols, change_func):
+    @with_environment()
+    def update_current(self, effective_date, symbols, change_func, env=None):
         for symbol in symbols:
-            sid = self.lookup_func(
+            asset = env.asset_finder.lookup_symbol(
                 symbol,
                 as_of_date=effective_date
             )
-            change_func(sid)
+            # Pass if no Asset exists for the symbol
+            if asset is None:
+                continue
+            change_func(asset.sid)
 
 
 class SecurityListSet(object):
@@ -88,11 +86,7 @@ class SecurityListSet(object):
     # list implementations.
     security_list_type = SecurityList
 
-    def __init__(self, current_date_func, lookup_func=None):
-        if lookup_func is None:
-            self.lookup_func = loopback
-        else:
-            self.lookup_func = lookup_func
+    def __init__(self, current_date_func):
         self.current_date_func = current_date_func
         self._leveraged_etf = None
 
@@ -100,7 +94,6 @@ class SecurityListSet(object):
     def leveraged_etf_list(self):
         if self._leveraged_etf is None:
             self._leveraged_etf = self.security_list_type(
-                self.lookup_func,
                 load_from_directory('leveraged_etf_list'),
                 self.current_date_func
             )

--- a/zipline/utils/simfactory.py
+++ b/zipline/utils/simfactory.py
@@ -7,7 +7,7 @@ def create_test_zipline(**config):
     """
        :param config: A configuration object that is a dict with:
 
-           - sid - an integer, which will be used as the security ID.
+           - sid - an integer, which will be used as the asset ID.
            - order_count - the number of orders the test algo will place,
              defaults to 100
            - order_amount - the number of shares per order, defaults to 100
@@ -25,10 +25,15 @@ def create_test_zipline(**config):
              :py:mod:`zipline.finance.trading`
        """
     assert isinstance(config, dict)
-    sid_list = config.get('sid_list')
-    if not sid_list:
-        sid = config.get('sid')
-        sid_list = [sid]
+
+    try:
+        sid_list = config['sid_list']
+    except KeyError:
+        try:
+            sid_list = [config['sid']]
+        except KeyError:
+            raise Exception("simfactory create_test_zipline() requires "
+                            "argument 'sid_list' or 'sid'")
 
     concurrent_trades = config.get('concurrent_trades', False)
 
@@ -49,12 +54,13 @@ def create_test_zipline(**config):
         test_algo = config['algorithm']
     else:
         test_algo = TestAlgorithm(
-            sid,
+            sid_list[0],
             order_amount,
             order_count,
             sim_params=config.get('sim_params',
                                   factory.create_simulation_parameters()),
             slippage=config.get('slippage'),
+            identifiers=sid_list
         )
 
     # -------------------


### PR DESCRIPTION
This branch adds Asset management to Zipline and adds the necessary accounting to allow for trading of Futures.

Primary impacts:
1. There is now a distinction between an Asset's 'identifier', 'sid', and 'symbol'.
    * 'identifier': the user-provided unique int or str that allows us to marry-up AssetMetaData and DataSource data
    * 'sid': a unique integer that can be used to identify a specific Asset within a given TradingEnvironment
    * 'symbol': non-unique string name for user look-up and ease-of-use, but is not used internally
    * This distinction has not been completely refactored in to the API – many methods still call for an argument 'sid' where they would actually want an Asset object
2. Zipline user may provide 'identifiers' or 'asset_metadata' arguments to TradingAlgorithm.init so the asset_finder can be built. Alternatively, the sids given to DataFrameSource or PanelSource are used to build Assets (defaulting to Equities).
3. Zipline algorithms must use Asset objects as arguments to all order*() methods.
    * The sid(int) and symbol(str) methods can be used to look up an Asset
4. There is now a distinction between 'value' and 'exposure' in the perf tracker and positions tracker.

Note: There are a number of API methods that take an arg named 'sid,' but what we really expect is an asset object. This should be reconciled.