### PR TITLE
ENH: Moves calling of TradingAlgorithm.initialize to _create_generator

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -733,6 +733,7 @@ def handle_data(context, data):
                 sim_params=self.sim_params,
             )
             set_algo_instance(test_algo)
+            test_algo.run(self.source)
 
     def test_portfolio_in_init(self):
         """

--- a/tests/test_batchtransform.py
+++ b/tests/test_batchtransform.py
@@ -244,10 +244,10 @@ class TestBatchTransform(TestCase):
     def test_passing_of_args(self):
         algo = BatchTransformAlgorithm(1, kwarg='str',
                                        sim_params=self.sim_params)
+        algo.run(self.source)
         self.assertEqual(algo.args, (1,))
         self.assertEqual(algo.kwargs, {'kwarg': 'str'})
 
-        algo.run(self.source)
         expected_item = ((1, ), {'kwarg': 'str'})
         self.assertEqual(
             algo.history_return_args,

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -472,11 +472,13 @@ def handle_data(context, data):
             start=start, end=end)
 
         with self.assertRaises(IncompatibleHistoryFrequency):
-            TradingAlgorithm(
+            algo = TradingAlgorithm(
                 script=algo_text,
                 data_frequency='daily',
                 sim_params=sim_params
             )
+            source = RandomWalkSource(start=start, end=end)
+            algo.run(source)
 
     def test_basic_history(self):
         algo_text = """


### PR DESCRIPTION
This commit moves the call to the algo code's initialize method out of TradingAlgorithm.__init__. The algo code's initialize method will be called in _create_generator using args and kwargs that are stored from __init__.