### PR TITLE
CDay vs BDay from pandas.tseries.offsets

### DIFF
--- a/zipline/utils/tradingcalendar.py
+++ b/zipline/utils/tradingcalendar.py
@@ -248,7 +248,7 @@ def get_non_trading_days(start, end):
     return pd.DatetimeIndex(non_trading_days)
 
 non_trading_days = get_non_trading_days(start, end)
-trading_day = pd.tseries.offsets.CDay(holidays=non_trading_days)
+trading_day = pd.tseries.offsets.BDay(holidays=non_trading_days)
 
 
 def get_trading_days(start, end, trading_day=trading_day):


### PR DESCRIPTION
I get the following error trying to run on linux vm vs windows using zipline 0.7.0:

File "/usr/local/lib/python2.7/dist-packages/zipline/utils/tradingcalendar.py", line 251, in <module>
    trading_day = pd.tseries.offsets.CDay(holidays=non_trading_days)
AttributeError: 'module' object has no attribute 'CDay'


Should CDay instead be BDay to resemble the pandas.tseries.offsets.BusienssDay class?