### PR TITLE
TEST: Clean AssetFinder initialization and tests.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -33,7 +33,6 @@ from zipline.errors import (
     SidNotFound,
     SymbolNotFound,
 )
-from zipline.utils import tradingcalendar
 from zipline.assets._assets import (
     Asset, Equity, Future
 )
@@ -63,10 +62,7 @@ ASSET_FIELDS = [
 
 class AssetFinder(object):
 
-    def __init__(self,
-                 metadata=None,
-                 trading_calendar=tradingcalendar,
-                 allow_sid_assignment=True):
+    def __init__(self, metadata=None, allow_sid_assignment=True):
 
         # Any particular instance of AssetFinder should be
         # consistent throughout its lifetime, so we grab a reference
@@ -85,10 +81,9 @@ class AssetFinder(object):
         # The AssetFinder also holds a nested-dict of all metadata for
         # reference when building Assets
         self.metadata_cache = {}
-        if metadata:
+        if metadata is not None:
             self.consume_metadata(metadata)
 
-        self.trading_calendar = trading_calendar
         self.populate_cache()
 
     def _next_free_sid(self):

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -136,7 +136,7 @@ class TradingEnvironment(object):
 
         self.exchange_tz = exchange_tz
 
-        self.asset_finder = AssetFinder(trading_calendar=env_trading_calendar)
+        self.asset_finder = AssetFinder()
 
     def __enter__(self, *args, **kwargs):
         global environment


### PR DESCRIPTION
- AssetFinder no longer accepts an unused trading_calendar.
- AssetFinder correctly accepts a DataFrame as input.
- Tests for AssetFinder no longer rely on a global trading environment.