### PR TITLE
DEP: Removes unnecessary identifier_cache from asset_finder

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -138,7 +138,6 @@ class TestMiscellaneousAPI(TestCase):
         sids = [1, 2]
         self.sim_params = factory.create_simulation_parameters(
             num_days=2,
-            sids=sids,
             data_frequency='minute',
             emission_rate='minute',
         )

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 
 from datetime import (
     timedelta,
+    datetime
 )
 import pickle
 import pprint
@@ -542,9 +543,12 @@ class AssetFinderTestCase(TestCase):
         # Build a finder that is allowed to assign sids
         finder = AssetFinder(metadata=metadata, allow_sid_assignment=True)
 
-        # Verify that Assets were built
-        play = finder.retrieve_asset_by_identifier('PLAY')
+        # Verify that Assets were built and different sids were assigned
+        play = finder.lookup_symbol('PLAY', datetime.now())
+        msft = finder.lookup_symbol('MSFT', datetime.now())
         self.assertEqual('PLAY', play.symbol)
+        self.assertIsNotNone(play.sid)
+        self.assertNotEqual(play.sid, msft.sid)
 
     def test_sid_assignment_failure(self):
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -719,7 +719,7 @@ class AssetFinderTestCase(TestCase):
         # No contracts exist after 12/14/2015, so we should get none
         self.assertIsNone(finder.lookup_future_by_expiration('AD', dt, jan_16))
 
-    def test_map_identifier_list_to_sids(self):
+    def test_map_identifier_index_to_sids(self):
 
         # Build an empty finder and some Assets
         dt = pd.Timestamp('2014-01-01', tz='UTC')
@@ -731,12 +731,12 @@ class AssetFinderTestCase(TestCase):
 
         # Check for correct mapping and types
         pre_map = [asset1, asset2, asset200, asset201]
-        post_map = finder.map_identifier_list_to_sids(pre_map, dt)
+        post_map = finder.map_identifier_index_to_sids(pre_map, dt)
         self.assertListEqual([1, 2, 200, 201], post_map)
         for sid in post_map:
             self.assertIsInstance(sid, int)
 
         # Change order and check mapping again
         pre_map = [asset201, asset2, asset200, asset1]
-        post_map = finder.map_identifier_list_to_sids(pre_map, dt)
+        post_map = finder.map_identifier_index_to_sids(pre_map, dt)
         self.assertListEqual([201, 2, 200, 1], post_map)

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -718,3 +718,25 @@ class AssetFinderTestCase(TestCase):
 
         # No contracts exist after 12/14/2015, so we should get none
         self.assertIsNone(finder.lookup_future_by_expiration('AD', dt, jan_16))
+
+    def test_map_identifier_list_to_sids(self):
+
+        # Build an empty finder and some Assets
+        dt = pd.Timestamp('2014-01-01', tz='UTC')
+        finder = AssetFinder()
+        asset1 = Equity(1, symbol="AAPL")
+        asset2 = Equity(2, symbol="GOOG")
+        asset200 = Future(200, symbol="CLK15")
+        asset201 = Future(201, symbol="CLM15")
+
+        # Check for correct mapping and types
+        pre_map = [asset1, asset2, asset200, asset201]
+        post_map = finder.map_identifier_list_to_sids(pre_map, dt)
+        self.assertListEqual([1, 2, 200, 201], post_map)
+        for sid in post_map:
+            self.assertIsInstance(sid, int)
+
+        # Change order and check mapping again
+        pre_map = [asset201, asset2, asset200, asset1]
+        post_map = finder.map_identifier_list_to_sids(pre_map, dt)
+        self.assertListEqual([201, 2, 200, 1], post_map)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -437,7 +437,7 @@ def handle_data(context, data):
 
         _, df = factory.create_test_df_source(sim_params)
         df = df.astype(np.float64)
-        source = DataFrameSource(df, sids=[0])
+        source = DataFrameSource(df)
 
         test_algo = TradingAlgorithm(
             script=algo_text,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -76,7 +76,7 @@ class TestDataFrameSource(TestCase):
                         'volume', 'price']
 
         copy_panel = data.copy()
-        sids = finder.map_identifier_list_to_sids(
+        sids = finder.map_identifier_index_to_sids(
             data.items, data.major_axis[0]
         )
         copy_panel.items = sids

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -120,13 +120,11 @@ class TransformTestCase(TestCase):
 
         minute_sim_ps = factory.create_simulation_parameters(
             num_days=3,
-            sids=cls.sids,
             data_frequency='minute',
             emission_rate='minute',
         )
         daily_sim_ps = factory.create_simulation_parameters(
             num_days=30,
-            sids=cls.sids,
             data_frequency='daily',
             emission_rate='daily',
         )

--- a/tests/test_transforms_talib.py
+++ b/tests/test_transforms_talib.py
@@ -98,7 +98,7 @@ class TestTALIB(TestCase):
         zipline_transforms = [ta.MA(timeperiod=10),
                               ta.MA(timeperiod=25)]
         talib_fn = talib.abstract.MA
-        algo = TALIBAlgorithm(talib=zipline_transforms)
+        algo = TALIBAlgorithm(talib=zipline_transforms, identifiers=[0])
         algo.run(self.source)
         # Test if computed values match those computed by pandas rolling mean.
         sid = 0

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -39,7 +39,6 @@ from zipline.errors import (
     UnsupportedCommissionModel,
     UnsupportedOrderParameters,
     UnsupportedSlippageModel,
-    SidNotFound,
 )
 
 from zipline.finance.trading import TradingEnvironment
@@ -461,10 +460,22 @@ class TradingAlgorithm(object):
  __init__().""", UserWarning)
                 overwrite_sim_params = False
         elif isinstance(source, pd.DataFrame):
-            # if DataFrame provided, wrap in DataFrameSource
-            source = DataFrameSource(source)
+            # if DataFrame provided, map columns to sids and wrap
+            # in DataFrameSource
+            copy_frame = source.copy()
+            copy_frame.columns = self.asset_finder.map_identifier_list_to_sids(
+                source.columns, source.index[0]
+            )
+            source = DataFrameSource(copy_frame)
+
         elif isinstance(source, pd.Panel):
-            source = DataPanelSource(source)
+            # If Panel provided, map items to sids and wrap
+            # in DataPanelSource
+            copy_panel = source.copy()
+            copy_panel.items = self.asset_finder.map_identifier_list_to_sids(
+                source.items, source.major_axis[0]
+            )
+            source = DataPanelSource(copy_panel)
 
         if isinstance(source, list):
             self.set_sources(source)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -463,16 +463,17 @@ class TradingAlgorithm(object):
             # if DataFrame provided, map columns to sids and wrap
             # in DataFrameSource
             copy_frame = source.copy()
-            copy_frame.columns = self.asset_finder.map_identifier_list_to_sids(
-                source.columns, source.index[0]
-            )
+            copy_frame.columns = \
+                self.asset_finder.map_identifier_index_to_sids(
+                    source.columns, source.index[0]
+                )
             source = DataFrameSource(copy_frame)
 
         elif isinstance(source, pd.Panel):
             # If Panel provided, map items to sids and wrap
             # in DataPanelSource
             copy_panel = source.copy()
-            copy_panel.items = self.asset_finder.map_identifier_list_to_sids(
+            copy_panel.items = self.asset_finder.map_identifier_index_to_sids(
                 source.items, source.major_axis[0]
             )
             source = DataPanelSource(copy_panel)

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -26,7 +26,6 @@ from six import with_metaclass, string_types
 
 from zipline.errors import (
     ConsumeAssetMetaDataError,
-    IdentifierNotFound,
     InvalidAssetType,
     MultipleSymbolsFound,
     SidAssignmentError,
@@ -68,7 +67,6 @@ class AssetFinder(object):
         self.cache = {}
         self.sym_cache = {}
         self.future_chains_cache = {}
-        self.identifier_cache = {}
         self.fuzzy_match = {}
 
         # This flag controls if the AssetFinder is allowed to generate its own
@@ -107,15 +105,6 @@ class AssetFinder(object):
             return None
         else:
             raise SidNotFound(sid=sid)
-
-    def retrieve_asset_by_identifier(self, identifier):
-        if isinstance(identifier, Asset):
-            return identifier
-        asset = self.identifier_cache.get(identifier)
-        if asset is not None:
-            return asset
-        else:
-            raise IdentifierNotFound(identifier=identifier)
 
     @staticmethod
     def _lookup_symbol_in_infos(infos, as_of_date):
@@ -342,7 +331,6 @@ class AssetFinder(object):
         self.cache = {}
         self.sym_cache = {}
         self.future_chains_cache = {}
-        self.identifier_cache = {}
         self.fuzzy_match = {}
 
         for identifier, row in self.metadata_cache.items():
@@ -350,7 +338,6 @@ class AssetFinder(object):
 
             # Insert asset into the various caches
             self.cache[asset.sid] = asset
-            self.identifier_cache[identifier] = asset
 
             if asset.symbol is not '':
                 self.sym_cache.setdefault(asset.symbol, []).append(asset)

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -224,16 +224,6 @@ Asset with sid '{sid}' was not found.
 """.strip()
 
 
-class IdentifierNotFound(ZiplineError):
-    """
-    Raised when a retrieve_asset_by_identifier() call contains a non-existent
-    identifier.
-    """
-    msg = """
-Asset with identifier '{identifier}' was not found.
-""".strip()
-
-
 class InvalidAssetType(ZiplineError):
     """
     Raised when an AssetFinder tries to build an Asset with an invalid

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -246,12 +246,23 @@ TradingEnvironment can not set asset_finder to object of class {cls}.
 
 class ConsumeAssetMetaDataError(ZiplineError):
     """
-    Raised when AssetMetaData.consume() is called on an invalid object.
+    Raised when AssetFinder.consume() is called on an invalid object.
     """
     msg = """
 AssetFinder can not consume metadata of type {obj}. Metadata must be a dict, a
 DataFrame, or a tables.Table. If the provided metadata is a Table, the rows
 must contain both or one of 'sid' or 'symbol'.
+""".strip()
+
+
+class MapAssetIdentifierIndexError(ZiplineError):
+    """
+    Raised when AssetMetaData.map_identifier_index_to_sids() is called on an
+    index of invalid objects.
+    """
+    msg = """
+AssetFinder can not map an index with values of type {obj}. Asset indices of
+DataFrames or Panels must be integer sids, string symbols, or Asset objects.
 """.strip()
 
 

--- a/zipline/examples/pairtrade.py
+++ b/zipline/examples/pairtrade.py
@@ -23,7 +23,6 @@ import pytz
 from zipline.algorithm import TradingAlgorithm
 from zipline.transforms import batch_transform
 from zipline.utils.factory import load_from_yahoo
-from zipline.sources.data_frame_source import DataFrameSource
 
 
 @batch_transform
@@ -121,10 +120,9 @@ if __name__ == '__main__':
     end = datetime(2002, 1, 1, 0, 0, 0, 0, pytz.utc)
     data = load_from_yahoo(stocks=['PEP', 'KO'], indexes={},
                            start=start, end=end)
-    source = DataFrameSource(data)
 
     pairtrade = Pairtrade()
-    results = pairtrade.run(source)
+    results = pairtrade.run(data)
     data['spreads'] = np.nan
 
     ax1 = plt.subplot(211)

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -440,8 +440,7 @@ class SimulationParameters(object):
     def __init__(self, period_start, period_end,
                  capital_base=10e3,
                  emission_rate='daily',
-                 data_frequency='daily',
-                 sids=None):
+                 data_frequency='daily'):
 
         self.period_start = period_start
         self.period_end = period_end
@@ -449,7 +448,6 @@ class SimulationParameters(object):
 
         self.emission_rate = emission_rate
         self.data_frequency = data_frequency
-        self.sids = sids
 
         # copied to algorithm's environment for runtime access
         self.arena = 'backtest'

--- a/zipline/sources/data_frame_source.py
+++ b/zipline/sources/data_frame_source.py
@@ -18,6 +18,7 @@ Tools to generate data sources.
 """
 import numpy as np
 import pandas as pd
+import datetime
 
 from zipline.gens.utils import hash_args
 
@@ -49,10 +50,9 @@ class DataFrameSource(DataSource):
         # Remap sids based on the trading environment
         self.identifiers = kwargs.get('sids', self.data.columns)
         env.update_asset_finder(identifiers=self.identifiers)
-        self.data.columns = [
-            env.asset_finder.retrieve_asset_by_identifier(identifier).sid
-            for identifier in self.data.columns
-        ]
+        self.data.columns, _ = env.asset_finder.lookup_generic(
+            self.data.columns, datetime.datetime.now()
+        )
         self.sids = self.data.columns
 
         # Hash_value for downstream sorting.
@@ -128,10 +128,9 @@ class DataPanelSource(DataSource):
         # Remap sids based on the trading environment
         self.identifiers = kwargs.get('sids', self.data.items)
         env.update_asset_finder(identifiers=self.identifiers)
-        self.data.items = [
-            env.asset_finder.retrieve_asset_by_identifier(identifier).sid
-            for identifier in self.data.items
-        ]
+        self.data.items, _ = env.asset_finder.lookup_generic(
+            self.data.items, datetime.datetime.now()
+        )
         self.sids = self.data.items
 
         # Hash_value for downstream sorting.

--- a/zipline/sources/data_frame_source.py
+++ b/zipline/sources/data_frame_source.py
@@ -48,8 +48,9 @@ class DataFrameSource(DataSource):
         self.end = kwargs.get('end', self.data.index[-1])
 
         # Remap sids based on the trading environment
-        self.identifiers = kwargs.get('sids', self.data.columns)
-        env.update_asset_finder(identifiers=self.identifiers)
+        env.update_asset_finder(
+            identifiers=kwargs.get('sids', self.data.columns)
+        )
         self.data.columns, _ = env.asset_finder.lookup_generic(
             self.data.columns, datetime.datetime.now()
         )
@@ -78,22 +79,21 @@ class DataFrameSource(DataSource):
     def raw_data_gen(self):
         for dt, series in self.data.iterrows():
             for sid, price in series.iteritems():
-                if sid in self.sids:
-                    # Skip SIDs that can not be forward filled
-                    if np.isnan(price) and \
-                       sid not in self.started_sids:
-                        continue
-                    self.started_sids.add(sid)
+                # Skip SIDs that can not be forward filled
+                if np.isnan(price) and \
+                   sid not in self.started_sids:
+                    continue
+                self.started_sids.add(sid)
 
-                    event = {
-                        'dt': dt,
-                        'sid': sid,
-                        'price': price,
-                        # Just chose something large
-                        # if no volume available.
-                        'volume': 1e9,
-                    }
-                    yield event
+                event = {
+                    'dt': dt,
+                    'sid': sid,
+                    'price': price,
+                    # Just chose something large
+                    # if no volume available.
+                    'volume': 1e9,
+                }
+                yield event
 
     @property
     def raw_data(self):
@@ -126,8 +126,9 @@ class DataPanelSource(DataSource):
         self.end = kwargs.get('end', self.data.major_axis[-1])
 
         # Remap sids based on the trading environment
-        self.identifiers = kwargs.get('sids', self.data.items)
-        env.update_asset_finder(identifiers=self.identifiers)
+        env.update_asset_finder(
+            identifiers=kwargs.get('sids', self.data.items)
+        )
         self.data.items, _ = env.asset_finder.lookup_generic(
             self.data.items, datetime.datetime.now()
         )
@@ -165,21 +166,20 @@ class DataPanelSource(DataSource):
         for dt in self.data.major_axis:
             df = self.data.major_xs(dt)
             for sid, series in df.iteritems():
-                if sid in self.sids:
-                    # Skip SIDs that can not be forward filled
-                    if np.isnan(series['price']) and \
-                       sid not in self.started_sids:
-                        continue
-                    self.started_sids.add(sid)
+                # Skip SIDs that can not be forward filled
+                if np.isnan(series['price']) and \
+                   sid not in self.started_sids:
+                    continue
+                self.started_sids.add(sid)
 
-                    event = {
-                        'dt': dt,
-                        'sid': sid,
-                    }
-                    for field_name, value in series.iteritems():
-                        event[field_name] = value
+                event = {
+                    'dt': dt,
+                    'sid': sid,
+                }
+                for field_name, value in series.iteritems():
+                    event[field_name] = value
 
-                    yield event
+                yield event
 
     @property
     def raw_data(self):

--- a/zipline/sources/data_frame_source.py
+++ b/zipline/sources/data_frame_source.py
@@ -22,7 +22,6 @@ import pandas as pd
 from zipline.gens.utils import hash_args
 
 from zipline.sources.data_source import DataSource
-from zipline.finance.trading import with_environment
 
 
 class DataFrameSource(DataSource):
@@ -37,9 +36,9 @@ class DataFrameSource(DataSource):
         Bars where the price is nan are filtered out.
     """
 
-    @with_environment()
-    def __init__(self, data, env=None, **kwargs):
+    def __init__(self, data, **kwargs):
         assert isinstance(data.index, pd.tseries.index.DatetimeIndex)
+        # Only accept integer SIDs as the items of the DataFrame
         assert isinstance(data.columns, pd.Int64Index)
         # TODO is ffilling correct/necessary?
         # Forward fill prices
@@ -108,8 +107,7 @@ class DataPanelSource(DataSource):
         Bars where the price is nan are filtered out.
     """
 
-    @with_environment()
-    def __init__(self, data, env=None, **kwargs):
+    def __init__(self, data, **kwargs):
         assert isinstance(data.major_axis, pd.tseries.index.DatetimeIndex)
         # Only accept integer SIDs as the items of the Panel
         assert isinstance(data.items, pd.Int64Index)

--- a/zipline/sources/test_source.py
+++ b/zipline/sources/test_source.py
@@ -137,13 +137,13 @@ class SpecificEquityTrades(object):
                 set(event.sid for event in self.event_list)
             )
             env.update_asset_finder(identifiers=self.identifiers)
-            self.sids = [
-                env.asset_finder.retrieve_asset_by_identifier(identifier).sid
-                for identifier in self.identifiers
-            ]
+            assets_by_identifier = {}
+            for identifier in self.identifiers:
+                assets_by_identifier[identifier] = env.asset_finder.\
+                    lookup_generic(identifier, datetime.now())[0]
+            self.sids = [asset.sid for asset in assets_by_identifier.values()]
             for event in self.event_list:
-                event.sid = env.asset_finder.\
-                    retrieve_asset_by_identifier(event.sid).sid
+                event.sid = assets_by_identifier[event.sid].sid
 
         else:
             # Unpack config dictionary with default values.
@@ -161,10 +161,11 @@ class SpecificEquityTrades(object):
 
             self.identifiers = kwargs.get('sids', [1, 2])
             env.update_asset_finder(identifiers=self.identifiers)
-            self.sids = [
-                env.asset_finder.retrieve_asset_by_identifier(identifier).sid
-                for identifier in self.identifiers
-            ]
+            assets_by_identifier = {}
+            for identifier in self.identifiers:
+                assets_by_identifier[identifier] = env.asset_finder.\
+                    lookup_generic(identifier, datetime.now())[0]
+            self.sids = [asset.sid for asset in assets_by_identifier.values()]
 
         # Hash_value for downstream sorting.
         self.arg_string = hash_args(*args, **kwargs)

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -43,7 +43,7 @@ __all__ = ['load_from_yahoo', 'load_bars_from_yahoo']
 def create_simulation_parameters(year=2006, start=None, end=None,
                                  capital_base=float("1.0e5"),
                                  num_days=None, load=None,
-                                 sids=None, data_frequency='daily',
+                                 data_frequency='daily',
                                  emission_rate='daily'):
     """Construct a complete environment with reasonable defaults"""
     if start is None:
@@ -60,7 +60,6 @@ def create_simulation_parameters(year=2006, start=None, end=None,
         period_start=start,
         period_end=end,
         capital_base=capital_base,
-        sids=sids,
         data_frequency=data_frequency,
         emission_rate=emission_rate,
     )


### PR DESCRIPTION
The identifier cache's usage was nearly identical to using lookup_generic, so this commit removes identifier-keyed caching and modifies anything that uses it.