### PR TITLE
Futures additions for Asset and AssetFinder

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -230,6 +230,7 @@ class TestFuture(TestCase):
     future = Future(
         2468,
         symbol='OMH15',
+        root_symbol='OM',
         notice_date=pd.Timestamp('2014-01-20', tz='UTC'),
         expiration_date=pd.Timestamp('2014-02-20', tz='UTC'),
         contract_multiplier=500
@@ -244,6 +245,7 @@ class TestFuture(TestCase):
         self.assertTrue("Future" in reprd)
         self.assertTrue("2468" in reprd)
         self.assertTrue("OMH15" in reprd)
+        self.assertTrue("root_symbol='OM'" in reprd)
         self.assertTrue(("notice_date=Timestamp('2014-01-20 00:00:00+0000', "
                         "tz='UTC')") in reprd)
         self.assertTrue("expiration_date=Timestamp('2014-02-20 00:00:00+0000'"
@@ -256,6 +258,7 @@ class TestFuture(TestCase):
 
     def test_to_and_from_dict(self):
         dictd = self.future.to_dict()
+        self.assertTrue('root_symbol' in dictd)
         self.assertTrue('notice_date' in dictd)
         self.assertTrue('expiration_date' in dictd)
         self.assertTrue('contract_multiplier' in dictd)
@@ -263,6 +266,9 @@ class TestFuture(TestCase):
         from_dict = Future.from_dict(dictd)
         self.assertTrue(isinstance(from_dict, Future))
         self.assertEqual(self.future, from_dict)
+
+    def test_root_symbol(self):
+        self.assertEqual('OM', self.future.root_symbol)
 
 
 class AssetFinderTestCase(TestCase):

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -227,24 +227,27 @@ class AssetTestCase(TestCase):
 
 
 class TestFuture(TestCase):
-
-    future = Future(2468,
-                    symbol='OMK15',
-                    notice_date='2014-01-20',
-                    expiration_date='2014-02-20',
-                    contract_multiplier=500)
+    future = Future(
+        2468,
+        symbol='OMH15',
+        notice_date=pd.Timestamp('2014-01-20', tz='UTC'),
+        expiration_date=pd.Timestamp('2014-02-20', tz='UTC'),
+        contract_multiplier=500
+    )
 
     def test_str(self):
         strd = self.future.__str__()
-        self.assertEqual("Future(2468 [OMK15])", strd)
+        self.assertEqual("Future(2468 [OMH15])", strd)
 
     def test_repr(self):
         reprd = self.future.__repr__()
         self.assertTrue("Future" in reprd)
         self.assertTrue("2468" in reprd)
-        self.assertTrue("OMK15" in reprd)
-        self.assertTrue("notice_date='2014-01-20'" in reprd)
-        self.assertTrue("expiration_date='2014-02-20'" in reprd)
+        self.assertTrue("OMH15" in reprd)
+        self.assertTrue(("notice_date=Timestamp('2014-01-20 00:00:00+0000', "
+                        "tz='UTC')") in reprd)
+        self.assertTrue("expiration_date=Timestamp('2014-02-20 00:00:00+0000'"
+                        in reprd)
         self.assertTrue("contract_multiplier=500" in reprd)
 
     def test_reduce(self):

--- a/zipline/assets/_assets.pyx
+++ b/zipline/assets/_assets.pyx
@@ -224,6 +224,7 @@ cdef class Equity(Asset):
 
 cdef class Future(Asset):
 
+    cdef readonly object root_symbol
     cdef readonly object notice_date
     cdef readonly object expiration_date
     cdef readonly int contract_multiplier
@@ -231,6 +232,7 @@ cdef class Future(Asset):
     def __cinit__(self,
                   int sid, # sid is required
                   object symbol="",
+                  object root_symbol="",
                   object asset_name="",
                   object start_date=None,
                   object end_date=None,
@@ -240,6 +242,7 @@ cdef class Future(Asset):
                   object exchange="",
                   int contract_multiplier=1):
 
+        self.root_symbol         = root_symbol
         self.notice_date         = notice_date
         self.expiration_date     = expiration_date
         self.contract_multiplier = contract_multiplier
@@ -255,7 +258,7 @@ cdef class Future(Asset):
             return 'Future(%d)' % self.sid
 
     def __repr__(self):
-        attrs = ('symbol', 'asset_name', 'exchange',
+        attrs = ('symbol', 'root_symbol', 'asset_name', 'exchange',
                  'start_date', 'end_date', 'first_traded', 'notice_date',
                  'expiration_date', 'contract_multiplier')
         tuples = ((attr, repr(getattr(self, attr, None)))
@@ -273,6 +276,7 @@ cdef class Future(Asset):
         """
         return (self.__class__, (self.sid,
                                  self.symbol,
+                                 self.root_symbol,
                                  self.asset_name,
                                  self.start_date,
                                  self.end_date,
@@ -287,6 +291,7 @@ cdef class Future(Asset):
         Convert to a python dict.
         """
         super_dict = super(Future, self).to_dict()
+        super_dict['root_symbol'] = self.root_symbol
         super_dict['notice_date'] = self.notice_date
         super_dict['expiration_date'] = self.expiration_date
         super_dict['contract_multiplier'] = self.contract_multiplier

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -242,12 +242,17 @@ class AssetFinder(object):
         self.identifier_cache = {}
         self.fuzzy_match = {}
 
-        counter = 0
         for identifier, row in self.metadata_cache.items():
-            self.spawn_asset(identifier=identifier, **row)
-            counter += 1
+            asset = self._spawn_asset(identifier=identifier, **row)
 
-    def spawn_asset(self, identifier, **kwargs):
+            # Insert asset into the various caches
+            self.cache[asset.sid] = asset
+            self.identifier_cache[identifier] = asset
+
+            if asset.symbol is not '':
+                self.sym_cache.setdefault(asset.symbol, []).append(asset)
+
+    def _spawn_asset(self, identifier, **kwargs):
 
         # Check if the sid is declared
         try:
@@ -330,11 +335,6 @@ class AssetFinder(object):
             asset = Future(**kwargs)
         else:
             raise InvalidAssetType(asset_type=asset_type)
-
-        self.cache[asset.sid] = asset
-        self.identifier_cache[identifier] = asset
-        if asset.symbol is not '':
-            self.sym_cache.setdefault(asset.symbol, []).append(asset)
 
         return asset
 

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -44,6 +44,7 @@ ASSET_FIELDS = [
     'sid',
     'asset_type',
     'symbol',
+    'root_symbol',
     'asset_name',
     'start_date',
     'end_date',


### PR DESCRIPTION
This branch adds further functionality for futures in zipline.

Asset objects now have a `root_symbol` attribute, and AssetFinder holds an additional cache, `future_cache`, keyed on root_symbol. Also adds the AssetFinder methods `lookup_future_chain` (returns the list of valid contracts for a given root symbol), `lookup_future_in_chain` (finds the ith contract in the chain), and `lookup_future_by_expiration` (finds a contract by its expiration date).

