### PR TITLE
PERF: Reduce time spent indexing in risk cumulative update.

### DIFF
--- a/tests/risk/test_risk_cumulative.py
+++ b/tests/risk/test_risk_cumulative.py
@@ -112,7 +112,8 @@ class TestRisk(unittest.TestCase):
 
     def test_max_drawdown_06(self):
         for dt, value in answer_key.RISK_CUMULATIVE.max_drawdown.iteritems():
+            dt_loc = self.cumulative_metrics_06.cont_index.get_loc(dt)
             np.testing.assert_almost_equal(
-                self.cumulative_metrics_06.max_drawdowns[dt],
+                self.cumulative_metrics_06.max_drawdowns[dt_loc],
                 value,
                 err_msg="Mismatch at %s" % (dt,))

--- a/tests/risk/test_risk_period.py
+++ b/tests/risk/test_risk_period.py
@@ -61,7 +61,7 @@ class TestRisk(unittest.TestCase):
         self.metrics_06 = risk.RiskReport(
             self.algo_returns_06,
             self.sim_params,
-            benchmark_returns=self.benchmark_returns_06,
+            benchmark_returns=self.benchmark_returns_06
         )
 
         start_08 = datetime.datetime(

--- a/tests/test_events_through_risk.py
+++ b/tests/test_events_through_risk.py
@@ -153,9 +153,10 @@ class TestEventsThroughRisk(unittest.TestCase):
         for bar in gen:
             current_dt = algo.datetime
             crm = algo.perf_tracker.cumulative_risk_metrics
+            dt_loc = crm.cont_index.get_loc(current_dt)
 
             np.testing.assert_almost_equal(
-                crm.algorithm_returns[current_dt],
+                crm.algorithm_returns[dt_loc],
                 expected_algorithm_returns[current_dt],
                 decimal=6)
 

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -481,8 +481,12 @@ class PerformanceTracker(object):
         log.info("last close: {d}".format(
             d=self.sim_params.last_close))
 
-        bms = self.cumulative_risk_metrics.benchmark_returns
-        ars = self.cumulative_risk_metrics.algorithm_returns
+        bms = pd.Series(
+            index=self.cumulative_risk_metrics.cont_index,
+            data=self.cumulative_risk_metrics.benchmark_returns_cont)
+        ars = pd.Series(
+            index=self.cumulative_risk_metrics.cont_index,
+            data=self.cumulative_risk_metrics.algorithm_returns_cont)
         acl = self.cumulative_risk_metrics.algorithm_cumulative_leverages
         self.risk_report = risk.RiskReport(
             ars,

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -290,9 +290,10 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             raise Exception(message)
 
         self.update_current_max()
-        self.metrics.benchmark_volatility.iloc[dt_loc] = \
+        metrics = self.metrics
+        metrics.benchmark_volatility.iloc[dt_loc] = \
             self.calculate_volatility(self.benchmark_returns)
-        self.metrics.algorithm_volatility.iloc[dt_loc] = \
+        metrics.algorithm_volatility.iloc[dt_loc] = \
             self.calculate_volatility(self.algorithm_returns)
 
         # caching the treasury rates for the minutely case is a
@@ -311,13 +312,13 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         self.excess_returns[dt_loc] = (
             self.algorithm_cumulative_returns[dt_loc] -
             self.treasury_period_return)
-        self.metrics.beta.iloc[dt_loc] = self.calculate_beta()
-        self.metrics.alpha.iloc[dt_loc] = self.calculate_alpha()
-        self.metrics.sharpe.iloc[dt_loc] = self.calculate_sharpe()
-        self.metrics.downside_risk.iloc[dt_loc] = \
+        metrics.beta.iloc[dt_loc] = self.calculate_beta()
+        metrics.alpha.iloc[dt_loc] = self.calculate_alpha()
+        metrics.sharpe.iloc[dt_loc] = self.calculate_sharpe()
+        metrics.downside_risk.iloc[dt_loc] = \
             self.calculate_downside_risk()
-        self.metrics.sortino.iloc[dt_loc] = self.calculate_sortino()
-        self.metrics.information.iloc[dt_loc] = self.calculate_information()
+        metrics.sortino.iloc[dt_loc] = self.calculate_sortino()
+        metrics.information.iloc[dt_loc] = self.calculate_information()
         self.max_drawdown = self.calculate_max_drawdown()
         self.max_drawdowns[dt_loc] = self.max_drawdown
         self.max_leverage = self.calculate_max_leverage()
@@ -331,12 +332,13 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         dt = self.latest_dt
         dt_loc = self.latest_dt_loc
         period_label = dt.strftime("%Y-%m")
+        metrics = self.metrics
         rval = {
             'trading_days': self.num_trading_days,
             'benchmark_volatility':
-            self.metrics.benchmark_volatility.iloc[dt_loc],
+            metrics.benchmark_volatility.iloc[dt_loc],
             'algo_volatility':
-            self.metrics.algorithm_volatility.iloc[dt_loc],
+            metrics.algorithm_volatility.iloc[dt_loc],
             'treasury_period_return': self.treasury_period_return,
             # Though the two following keys say period return,
             # they would be more accurately called the cumulative return.
@@ -346,11 +348,11 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             self.algorithm_cumulative_returns[dt_loc],
             'benchmark_period_return':
             self.benchmark_cumulative_returns[dt_loc],
-            'beta': self.metrics.beta.iloc[dt_loc],
-            'alpha': self.metrics.alpha.iloc[dt_loc],
-            'sharpe': self.metrics.sharpe.iloc[dt_loc],
-            'sortino': self.metrics.sortino.iloc[dt_loc],
-            'information': self.metrics.information.iloc[dt_loc],
+            'beta': metrics.beta.iloc[dt_loc],
+            'alpha': metrics.alpha.iloc[dt_loc],
+            'sharpe': metrics.sharpe.iloc[dt_loc],
+            'sortino': metrics.sortino.iloc[dt_loc],
+            'information': metrics.information.iloc[dt_loc],
             'excess_return': self.excess_returns[dt_loc],
             'max_drawdown': self.max_drawdown,
             'max_leverage': self.max_leverage,

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -318,7 +318,7 @@ class RiskMetricsPeriod(object):
         if self.algorithm_leverages is None:
             return 0.0
         else:
-            return max(self.algorithm_leverages.values)
+            return max(self.algorithm_leverages)
 
     def __getstate__(self):
         state_dict = \


### PR DESCRIPTION
Instead of using the pandas.Series datetime index for every single
vector, get the index at the beginning of the update loop based on the
dt and then use that index to set the values.

Also, since the dt lookup is no longer needed, store the values as numpy
arrays, which are more lightweight.

Locally, this patch cuts out about 60% of the time spent in the update
method.