### PR TITLE
ENH: Adds the full Asset objects to the kwargs of MultipleSymbolsFound

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -173,7 +173,7 @@ class AssetFinder(object):
                 return infos[0]
             else:
                 raise MultipleSymbolsFound(symbol=symbol,
-                                           options=str(infos))
+                                           options=infos)
 
         # Try to find symbol matching as_of_date
         asset, _ = self._lookup_symbol_in_infos(infos, as_of_date)


### PR DESCRIPTION
It is not necessary to pass the possible matches as a str, so this change passes the list as-is.