### PR TITLE
Remove uses of lookup_generic

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -597,13 +597,19 @@ class TestAlgoScript(TestCase):
 
     def test_api_get_environment(self):
         platform = 'zipline'
+        metadata = {0: {'symbol': 'TEST',
+                        'asset_type': 'equity'}}
         algo = TradingAlgorithm(script=api_get_environment_algo,
+                                asset_metadata=metadata,
                                 platform=platform)
         algo.run(self.df)
         self.assertEqual(algo.environment, platform)
 
     def test_api_symbol(self):
-        algo = TradingAlgorithm(script=api_symbol_algo)
+        metadata = {0: {'symbol': 'TEST',
+                        'asset_type': 'equity'}}
+        algo = TradingAlgorithm(script=api_symbol_algo,
+                                asset_metadata=metadata)
         algo.run(self.df)
 
     def test_fixed_slippage(self):

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -662,11 +662,9 @@ class TradingAlgorithm(object):
         Default symbol lookup for any source that directly maps the
         symbol to the Asset (e.g. yahoo finance).
         """
-        asset, _ = self.asset_finder.lookup_generic(
-            asset_convertible_or_iterable=symbol_str,
-            as_of_date=self.datetime,
-            )
-        return asset
+        return self.asset_finder.lookup_symbol_resolve_multiple(
+            symbol_str,
+            as_of_date=self.datetime)
 
     @api_method
     def symbols(self, *args):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -1003,7 +1003,7 @@ from zipline.api import get_environment, order, symbol
 def initialize(context):
     context.environment = get_environment()
 
-handle_data = lambda context, data: order(symbol(0), 1)
+handle_data = lambda context, data: order(symbol('TEST'), 1)
 """
 
 api_symbol_algo = """
@@ -1014,7 +1014,7 @@ def initialize(context):
     pass
 
 def handle_data(context, data):
-    order(symbol(0), 1)
+    order(symbol('TEST'), 1)
 """
 
 call_order_in_init = """


### PR DESCRIPTION
Changes two uses of lookup_generic to use the exact lookup in the context of each call.

1) TradingAlgorithm.symbol e.g. `order(symbol('FOO`), 100)`

2) SpecificEquitySource's use of the asset_finder to ensure that sids have been inserted into the asset finder.

The main goal here is to reduce some complexity before a larger wholesale change to the class, and bring usage of lookup_generic back down to just the consumers that require the multiple lookup.