### PR TITLE
Reduce surface area of AssetFinder behavior

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -957,7 +957,6 @@ class TestGetDatetime(TestCase):
         algo = TradingAlgorithm(
             script=algo,
             sim_params=sim_params,
-            identifiers=[1]
         )
         algo.run(source)
         self.assertFalse(algo.first_bar)

--- a/tests/test_algorithm_gen.py
+++ b/tests/test_algorithm_gen.py
@@ -105,7 +105,7 @@ class AlgorithmGeneratorTestCase(TestCase):
                 start=datetime(2012, 5, 1, tzinfo=pytz.utc),
                 end=datetime(2012, 6, 30, tzinfo=pytz.utc)
             )
-            algo = TestAlgo(self, identifiers=[8229], sim_params=sim_params)
+            algo = TestAlgo(self, sim_params=sim_params)
             trade_source = factory.create_daily_trade_source(
                 [8229],
                 200,
@@ -131,7 +131,7 @@ class AlgorithmGeneratorTestCase(TestCase):
             start=datetime(2011, 7, 30, tzinfo=pytz.utc),
             end=datetime(2012, 7, 30, tzinfo=pytz.utc)
         )
-        algo = TestAlgo(self, identifiers=[8229], sim_params=sim_params)
+        algo = TestAlgo(self, sim_params=sim_params)
         trade_source = factory.create_daily_trade_source(
             [8229],
             sim_params
@@ -158,7 +158,7 @@ class AlgorithmGeneratorTestCase(TestCase):
             period_end=datetime(2012, 7, 30, tzinfo=pytz.utc),
             data_frequency='minute'
         )
-        algo = TestAlgo(self, identifiers=[8229], sim_params=sim_params)
+        algo = TestAlgo(self, sim_params=sim_params)
 
         midnight_custom_source = [Event({
             'custom_field': 42.0,
@@ -222,6 +222,9 @@ class AlgorithmGeneratorTestCase(TestCase):
         """
         sim_params = create_simulation_parameters(num_days=1,
                                                   data_frequency='minute')
-        algo = TestAlgo(self, sim_params=sim_params, identifiers=[8229])
-        algo.run(source=[], overwrite_sim_params=False)
+        algo = TestAlgo(self, sim_params=sim_params)
+        source = pd.DataFrame(
+            columns=[8229],
+            index=pd.DatetimeIndex([sim_params.period_start]))
+        algo.run(source=source, overwrite_sim_params=False)
         self.assertEqual(algo.datetime, sim_params.last_close)

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -486,7 +486,8 @@ class AssetFinderTestCase(TestCase):
 
         # Consume the Assets
         finder = AssetFinder()
-        finder.consume_identifiers([equity_asset, future_asset])
+        finder.insert_metadata(equity_asset, **equity_asset.to_dict())
+        finder.insert_metadata(future_asset, **future_asset.to_dict())
         finder.populate_cache()
 
         # Test equality with newly built Assets

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -31,7 +31,13 @@ import pandas as pd
 
 from nose_parameterized import parameterized
 
-from zipline.assets import Asset, Equity, Future, AssetFinder
+from zipline.assets import (
+    Asset,
+    Equity,
+    Future,
+    AssetFinder,
+    populate_finder_from_identifier_index
+)
 from zipline.errors import (
     SymbolNotFound,
     MultipleSymbolsFound,
@@ -599,7 +605,7 @@ class AssetFinderTestCase(TestCase):
         ad_contracts = finder.lookup_future_chain('AD', dt, first_day)
         self.assertEqual(len(ad_contracts), 2)
 
-    def test_map_identifier_index_to_sids(self):
+    def test_populate_finder_from_identifier_index(self):
         # Build an empty finder and some Assets
         dt = pd.Timestamp('2014-01-01', tz='UTC')
         finder = AssetFinder()
@@ -609,13 +615,15 @@ class AssetFinderTestCase(TestCase):
         asset201 = Future(201, symbol="CLM15")
 
         # Check for correct mapping and types
-        pre_map = [asset1, asset2, asset200, asset201]
-        post_map = finder.map_identifier_index_to_sids(pre_map, dt)
-        self.assertListEqual([1, 2, 200, 201], post_map)
-        for sid in post_map:
+        pre_pop = [asset1, asset2, asset200, asset201]
+        post_pop = populate_finder_from_identifier_index(finder, pre_pop, dt)
+        self.assertListEqual([1, 2, 200, 201], post_pop)
+        for sid in post_pop:
             self.assertIsInstance(sid, int)
 
         # Change order and check mapping again
-        pre_map = [asset201, asset2, asset200, asset1]
-        post_map = finder.map_identifier_index_to_sids(pre_map, dt)
-        self.assertListEqual([201, 2, 200, 1], post_map)
+        pre_pop = [asset201, asset2, asset200, asset1]
+        post_pop = populate_finder_from_identifier_index(
+            finder, pre_pop, dt)
+        post_pop = populate_finder_from_identifier_index(finder, pre_pop, dt)
+        self.assertListEqual([201, 2, 200, 1], post_pop)

--- a/tests/test_batchtransform.py
+++ b/tests/test_batchtransform.py
@@ -114,8 +114,11 @@ class TestChangeOfSids(TestCase):
     def test_all_sids_passed(self):
         algo = BatchTransformAlgorithmSetSid(
             sim_params=self.sim_params,
-            identifiers=[i for i in range(0, 90)]
         )
+        for sid in [i for i in range(0, 90)]:
+            algo.asset_finder.insert_metadata(sid)
+        algo.asset_finder.populate_cache()
+
         source = DifferentSidSource()
         algo.run(source)
         for i, (df, date) in enumerate(zip(algo.history, source.trading_days)):

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -38,7 +38,8 @@ class BlotterTestCase(TestCase):
     @with_environment()
     def setUp(self, env=None):
         setup_logger(self)
-        env.update_asset_finder(identifiers=[24])
+        env.asset_finder.insert_metadata(24)
+        env.asset_finder.populate_cache()
 
     def tearDown(self):
         teardown_logger(self)

--- a/tests/test_events_through_risk.py
+++ b/tests/test_events_through_risk.py
@@ -68,8 +68,9 @@ class TestEventsThroughRisk(unittest.TestCase):
         )
 
         algo = BuyAndHoldAlgorithm(
-            identifiers=[1],
             sim_params=sim_params)
+        algo.asset_finder.insert_metadata(1)
+        algo.asset_finder.populate_cache()
 
         first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
         second_date = datetime.datetime(2006, 1, 4, tzinfo=pytz.utc)
@@ -130,6 +131,8 @@ class TestEventsThroughRisk(unittest.TestCase):
 
         algo.benchmark_return_source = benchmark_data
         algo.set_sources(list([trade_bar_data]))
+        algo.asset_finder.insert_metadata(1)
+        algo.asset_finder.populate_cache()
         gen = algo._create_generator(sim_params)
 
         # TODO: Hand derive these results.
@@ -189,9 +192,9 @@ class TestEventsThroughRisk(unittest.TestCase):
                 emission_rate='daily',
                 data_frequency='minute')
 
-            algo = BuyAndHoldAlgorithm(
-                identifiers=[1],
-                sim_params=sim_params)
+            algo = BuyAndHoldAlgorithm(sim_params=sim_params)
+            algo.asset_finder.insert_metadata(1)
+            algo.asset_finder.populate_cache()
 
             first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
             first_open, first_close = \
@@ -291,6 +294,8 @@ class TestEventsThroughRisk(unittest.TestCase):
 
             algo.benchmark_return_source = benchmark_data
             algo.set_sources(list([trade_bar_data]))
+            algo.asset_finder.insert_metadata(1)
+            algo.asset_finder.populate_cache()
             gen = algo._create_generator(sim_params)
 
             crm = algo.perf_tracker.cumulative_risk_metrics

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -510,7 +510,6 @@ def handle_data(context, data):
             script=algo_text,
             data_frequency='minute',
             sim_params=sim_params,
-            identifiers=[0]
         )
 
         source = RandomWalkSource(start=start,

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -1893,7 +1893,9 @@ class TestPerformanceTracker(unittest.TestCase):
         foosid = 1
         barsid = 2
 
-        env.update_asset_finder(identifiers=[foosid, barsid])
+        for sid in [foosid, barsid]:
+            env.asset_finder.insert_metadata(sid)
+        env.asset_finder.populate_cache()
 
         foo_event_1 = factory.create_trade(foosid, 10.0, 20, start_dt)
         order_event_1 = Order(sid=foo_event_1.sid,
@@ -1989,7 +1991,9 @@ class TestPerformanceTracker(unittest.TestCase):
 
     @with_environment()
     def test_close_position_event(self, env=None):
-        env.update_asset_finder(identifiers=[1, 2])
+        for sid in [1, 2]:
+            env.asset_finder.insert_metadata(sid)
+        env.asset_finder.populate_cache()
         pt = perf.PositionTracker()
         dt = pd.Timestamp("1984/03/06 3:00PM")
         pos1 = perf.Position(1, amount=np.float64(120.0),

--- a/tests/test_security_list.py
+++ b/tests/test_security_list.py
@@ -68,8 +68,10 @@ class SecurityListTestCase(TestCase):
 
         env.update_asset_finder(
             clear_metadata=True,
-            identifiers=["BZQ", "URTY", "JFT", "AAPL", "GOOG"]
         )
+        for sid in ["BZQ", "URTY", "JFT", "AAPL", "GOOG"]:
+            env.asset_finder.insert_metadata(sid)
+        env.asset_finder.populate_cache()
 
         setup_logger(self)
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -25,7 +25,7 @@ from zipline.sources import (DataFrameSource,
                              DataPanelSource,
                              RandomWalkSource)
 from zipline.utils import tradingcalendar as calendar_nyse
-from zipline.assets import AssetFinder
+from zipline.assets import AssetFinder, populate_finder_from_identifier_index
 
 
 class TestDataFrameSource(TestCase):
@@ -76,9 +76,8 @@ class TestDataFrameSource(TestCase):
                         'volume', 'price']
 
         copy_panel = data.copy()
-        sids = finder.map_identifier_index_to_sids(
-            data.items, data.major_axis[0]
-        )
+        sids = populate_finder_from_identifier_index(
+            finder, data.items, data.major_axis[0])
         copy_panel.items = sids
         source = DataPanelSource(copy_panel)
         for event in source:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -102,7 +102,6 @@ def with_algo(f):
             initialize=initialize_with(self, tfm_name, days),
             handle_data=handle_data_wrapper(f),
             sim_params=sim_params,
-            identifiers=[1, 2, 3]
         )
         algo.run(source)
 

--- a/tests/test_transforms_talib.py
+++ b/tests/test_transforms_talib.py
@@ -98,7 +98,7 @@ class TestTALIB(TestCase):
         zipline_transforms = [ta.MA(timeperiod=10),
                               ta.MA(timeperiod=25)]
         talib_fn = talib.abstract.MA
-        algo = TALIBAlgorithm(talib=zipline_transforms, identifiers=[0])
+        algo = TALIBAlgorithm(talib=zipline_transforms)
         algo.run(self.source)
         # Test if computed values match those computed by pandas rolling mean.
         sid = 0

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -64,7 +64,11 @@ from zipline.finance.slippage import (
     SlippageModel,
     transact_partial
 )
-from zipline.assets import Asset, Future
+from zipline.assets import (
+    Asset,
+    Future,
+    populate_finder_from_identifier_index
+)
 from zipline.gens.composites import date_sorted_sources
 from zipline.gens.tradesimulation import AlgorithmSimulator
 from zipline.sources import DataFrameSource, DataPanelSource
@@ -460,10 +464,9 @@ class TradingAlgorithm(object):
             # if DataFrame provided, map columns to sids and wrap
             # in DataFrameSource
             copy_frame = source.copy()
-            copy_frame.columns = \
-                self.asset_finder.map_identifier_index_to_sids(
-                    source.columns, source.index[0]
-                )
+            asset_sids = populate_finder_from_identifier_index(
+                self.asset_finder, source.columns, source.index[0])
+            copy_frame.columns = asset_sids
             for sid in copy_frame.columns:
                 self.asset_finder.insert_metadata(sid)
             self.asset_finder.populate_cache()
@@ -473,9 +476,9 @@ class TradingAlgorithm(object):
             # If Panel provided, map items to sids and wrap
             # in DataPanelSource
             copy_panel = source.copy()
-            copy_panel.items = self.asset_finder.map_identifier_index_to_sids(
-                source.items, source.major_axis[0]
-            )
+            asset_sids = populate_finder_from_identifier_index(
+                self.asset_finder, source.items, source.major_axis[0])
+            copy_panel.items = asset_sids
             for sid in copy_panel.items:
                 self.asset_finder.insert_metadata(sid)
             self.asset_finder.populate_cache()

--- a/zipline/assets/__init__.py
+++ b/zipline/assets/__init__.py
@@ -22,7 +22,8 @@ from ._assets import (
 )
 from .assets import (
     AssetFinder,
-    AssetConvertible
+    AssetConvertible,
+    populate_finder_from_identifier_index
 )
 
 __all__ = [
@@ -32,5 +33,6 @@ __all__ = [
     'AssetFinder',
     'AssetConvertible',
     'make_asset_array',
-    'CACHE_FILE_TEMPLATE'
+    'CACHE_FILE_TEMPLATE',
+    'populate_finder_from_identifier_index',
 ]

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -481,7 +481,18 @@ class AssetFinder(object):
 
         # If symbols or Assets are provided, construction and mapping is
         # necessary
-        self.consume_identifiers(index)
+        for identifier in index:
+            # Handle case where full Assets are passed in
+            # For example, in the creation of a DataFrameSource, the source's
+            # 'sid' args may be full Assets
+            if isinstance(identifier, Asset):
+                sid = identifier.sid
+                metadata = identifier.to_dict()
+                metadata['asset_type'] = identifier.__class__.__name__
+                self.insert_metadata(identifier=sid, **metadata)
+            else:
+                self.insert_metadata(identifier)
+
         self.populate_cache()
 
         # Look up all Assets for mapping
@@ -538,23 +549,6 @@ class AssetFinder(object):
                     raise SidAssignmentError(identifier=identifier)
 
         self.metadata_cache[identifier] = entry
-
-    def consume_identifiers(self, identifiers):
-        """
-        Consumes the given identifiers in to the metadata cache of this
-        AssetFinder.
-        """
-        for identifier in identifiers:
-            # Handle case where full Assets are passed in
-            # For example, in the creation of a DataFrameSource, the source's
-            # 'sid' args may be full Assets
-            if isinstance(identifier, Asset):
-                sid = identifier.sid
-                metadata = identifier.to_dict()
-                metadata['asset_type'] = identifier.__class__.__name__
-                self.insert_metadata(identifier=sid, **metadata)
-            else:
-                self.insert_metadata(identifier)
 
     def consume_metadata(self, metadata):
         """

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -266,7 +266,7 @@ must contain both or one of 'sid' or 'symbol'.
 
 class MapAssetIdentifierIndexError(ZiplineError):
     """
-    Raised when AssetMetaData.map_identifier_index_to_sids() is called on an
+    Raised when populate_finder_from_identifier_index() is called on an
     index of invalid objects.
     """
     msg = """

--- a/zipline/examples/dual_ema_talib.py
+++ b/zipline/examples/dual_ema_talib.py
@@ -77,8 +77,9 @@ if __name__ == '__main__':
     data = load_from_yahoo(stocks=['AAPL'], indexes={}, start=start,
                            end=end)
 
-    algo = TradingAlgorithm(initialize=initialize, handle_data=handle_data,
-                            identifiers=['AAPL'])
+    algo = TradingAlgorithm(initialize=initialize, handle_data=handle_data)
+    algo.asset_finder.insert_metadata('AAPL')
+    algo.asset_finder.populate_cache()
     results = algo.run(data).dropna()
 
     fig = plt.figure()

--- a/zipline/examples/olmar.py
+++ b/zipline/examples/olmar.py
@@ -156,8 +156,7 @@ if __name__ == '__main__':
     data = load_from_yahoo(stocks=STOCKS, indexes={}, start=start, end=end)
     data = data.dropna()
     olmar = TradingAlgorithm(handle_data=handle_data,
-                             initialize=initialize,
-                             identifiers=STOCKS)
+                             initialize=initialize)
     results = olmar.run(data)
     results.portfolio_value.plot()
     pl.show()

--- a/zipline/examples/quantopian_buy_apple.py
+++ b/zipline/examples/quantopian_buy_apple.py
@@ -40,8 +40,8 @@ if __name__ == '__main__':
                            end=end)
     data = data.dropna()
     algo = TradingAlgorithm(initialize=initialize,
-                            handle_data=handle_date,
-                            identifiers=['AAPL'])
+                            handle_data=handle_date)
+    algo.asset_finder.insert_metadata('AAPL')
     results = algo.run(data)
     results.portfolio_value.plot()
     pl.show()

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -156,8 +156,7 @@ class TradingEnvironment(object):
     def update_asset_finder(self,
                             clear_metadata=False,
                             asset_finder=None,
-                            asset_metadata=None,
-                            identifiers=None):
+                            asset_metadata=None):
         """
         Updates the AssetFinder using the provided asset metadata and
         identifiers.
@@ -167,14 +166,11 @@ class TradingEnvironment(object):
         outright with the new asset_finder.
         If asset_metadata is provided, the existing metadata will be cleared
         and replaced with the provided metadata.
-        All identifiers will be inserted in the asset metadata if they are not
-        already present.
 
         :param clear_metadata: A boolean
         :param asset_finder: An AssetFinder object to replace the environment's
         existing asset_finder
         :param asset_metadata: A dict, DataFrame, or readable object
-        :param identifiers: A list of identifiers to be inserted
         :return:
         """
         populate = False
@@ -190,10 +186,6 @@ class TradingEnvironment(object):
         if asset_metadata is not None:
             self.asset_finder.clear_metadata()
             self.asset_finder.consume_metadata(asset_metadata)
-            populate = True
-
-        if identifiers is not None:
-            self.asset_finder.consume_identifiers(identifiers)
             populate = True
 
         if populate:

--- a/zipline/sources/simulated.py
+++ b/zipline/sources/simulated.py
@@ -93,9 +93,6 @@ class RandomWalkSource(DataSource):
         self.sd = sd
 
         self.sids = self.start_prices.keys()
-        TradingEnvironment.instance().update_asset_finder(
-            identifiers=self.sids
-        )
 
         self.open_and_closes = \
             calendar.open_and_closes[self.start:self.end]

--- a/zipline/sources/test_source.py
+++ b/zipline/sources/test_source.py
@@ -136,8 +136,10 @@ class SpecificEquityTrades(object):
                 'sids',
                 set(event.sid for event in self.event_list)
             )
-            env.update_asset_finder(identifiers=self.identifiers)
             assets_by_identifier = {}
+            for identifier in self.identifiers:
+                env.asset_finder.insert_metadata(identifier)
+            env.asset_finder.populate_cache()
             for identifier in self.identifiers:
                 assets_by_identifier[identifier] = env.asset_finder.\
                     lookup_generic(identifier, datetime.now())[0]
@@ -160,8 +162,10 @@ class SpecificEquityTrades(object):
             self.concurrent = kwargs.get('concurrent', False)
 
             self.identifiers = kwargs.get('sids', [1, 2])
-            env.update_asset_finder(identifiers=self.identifiers)
             assets_by_identifier = {}
+            for identifier in self.identifiers:
+                env.asset_finder.insert_metadata(identifier)
+            env.asset_finder.populate_cache()
             for identifier in self.identifiers:
                 assets_by_identifier[identifier] = env.asset_finder.\
                     lookup_generic(identifier, datetime.now())[0]

--- a/zipline/utils/cli.py
+++ b/zipline/utils/cli.py
@@ -239,7 +239,6 @@ def run_pipeline(print_algo=True, **kwargs):
                                     capital_base=float(kwargs['capital_base']),
                                     algo_filename=kwargs.get('algofile'),
                                     asset_metadata=asset_metadata,
-                                    identifiers=symbols,
                                     start=start,
                                     end=end)
 

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -119,7 +119,8 @@ def create_trade_history(sid, prices, amounts, interval, sim_params,
                          source_id="test_factory"):
     trades = []
     current = sim_params.first_open
-    trading.environment.update_asset_finder(identifiers=[sid])
+    trading.environment.asset_finder.insert_metadata(sid)
+    trading.environment.asset_finder.populate_cache()
 
     oneday = timedelta(days=1)
     use_midnight = interval >= oneday
@@ -310,8 +311,6 @@ def create_test_df_source(sim_params=None, bars='daily'):
     x = np.arange(1, len(index) + 1)
 
     df = pd.DataFrame(x, index=index, columns=[0])
-
-    trading.environment.update_asset_finder(identifiers=[0])
 
     return DataFrameSource(df), df
 

--- a/zipline/utils/simfactory.py
+++ b/zipline/utils/simfactory.py
@@ -60,8 +60,10 @@ def create_test_zipline(**config):
             sim_params=config.get('sim_params',
                                   factory.create_simulation_parameters()),
             slippage=config.get('slippage'),
-            identifiers=sid_list
         )
+        for sid in sid_list:
+            test_algo.asset_finder.insert_metadata(sid)
+            test_algo.asset_finder.populate_cache()
 
     # -------------------
     # Trade Source


### PR DESCRIPTION
In preparation of the port of the AssetFinder over to being backed by a sqlite file, remove some methods of AssetFinder, so that they do not need to be ported.

These are not absolute requirements to that port, but should help future changes be simpler, especially in the case of making the 'add assets from the DataFrame index' separate from the rest of the class.

Methods removed:
- consume_identifiers, insert_metadata and consume_metadata encompasses this behavior.
- map_identifier_index_to_sids, changed to a function outside of the AssetFinder which takes an asset finder as a parameter. It is a convenience function, but not core functionality, so moving it away from the core pieces before those pieces are broken up into a AssetSQLiteWriter and AssetFinder.