### PR TITLE
TST: Remove test for lookup of future contract by symbol.

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -304,49 +304,38 @@ class TestMiscellaneousAPI(TestCase):
                     1: {'symbol': 'PLAY',
                         'asset_type': 'equity',
                         'start_date': '2005-01-01',
-                        'end_date': '2006-01-01'},
-                    2: {'symbol': 'OMG15',
-                        'asset_type': 'future'}}
+                        'end_date': '2006-01-01'}}
         algo = TradingAlgorithm(asset_metadata=metadata)
 
         # Test before either PLAY existed
         algo.datetime = pd.Timestamp('2001-12-01', tz='UTC')
-        self.assertEqual(2, algo.symbol('OMG15'))
         with self.assertRaises(SymbolNotFound):
             algo.symbol('PLAY')
         with self.assertRaises(SymbolNotFound):
-            algo.symbols('PLAY', 'OMG15')
+            algo.symbols('PLAY')
 
         # Test when first PLAY exists
         algo.datetime = pd.Timestamp('2002-12-01', tz='UTC')
-        self.assertEqual(2, algo.symbol('OMG15'))
-        self.assertEqual(0, algo.symbol('PLAY'))
-        list_result = algo.symbols('PLAY', 'OMG15')
+        list_result = algo.symbols('PLAY')
         self.assertEqual(0, list_result[0])
-        self.assertEqual(2, list_result[1])
 
         # Test after first PLAY ends
         algo.datetime = pd.Timestamp('2004-12-01', tz='UTC')
-        self.assertEqual(2, algo.symbol('OMG15'))
         self.assertEqual(0, algo.symbol('PLAY'))
 
         # Test after second PLAY begins
         algo.datetime = pd.Timestamp('2005-12-01', tz='UTC')
-        self.assertEqual(2, algo.symbol('OMG15'))
         self.assertEqual(1, algo.symbol('PLAY'))
 
         # Test after second PLAY ends
         algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
-        self.assertEqual(2, algo.symbol('OMG15'))
         self.assertEqual(1, algo.symbol('PLAY'))
-        list_result = algo.symbols('PLAY', 'OMG15')
+        list_result = algo.symbols('PLAY')
         self.assertEqual(1, list_result[0])
-        self.assertEqual(2, list_result[1])
 
         # Test lookup SID
         self.assertIsInstance(algo.sid(0), Equity)
         self.assertIsInstance(algo.sid(1), Equity)
-        self.assertIsInstance(algo.sid(2), Future)
 
 
 class TestTransformAlgorithm(TestCase):


### PR DESCRIPTION
The lookup of future contract by individual symbol is a constraint on
incoming changes of changing how the asset finder stores data.

(i.e. the asset finder is changing so that there are separate tables for
both futures and equities.)

Since this lookup is not yet fully supported, we can add it back in on
top of the new asset finder.

## Other Notes

@jfkirk this is the small reduction in features of the asset finder that we discussed in person. It should be possible to add the lookup back in, but since `symbol('AFUTURE')` is not yet used, it was easier to do the port of the underlying engine without supporting the feature, but shouldn't be too much work to add back in once that port is finished.