### PR TITLE
BUG: Aligns performance packet generation between minute and daily modes

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -1949,8 +1949,7 @@ class TestPerformanceTracker(unittest.TestCase):
                     tracker.process_order(event)
                 elif event.type == zp.DATASOURCE_TYPE.TRANSACTION:
                     tracker.process_transaction(event)
-            tracker.handle_minute_close(date)
-            msg = tracker.to_dict()
+            msg, _ = tracker.handle_minute_close(date)
             messages[date] = msg
 
         self.assertEquals(2, len(messages))


### PR DESCRIPTION
This PR re-aligns the end-of-day logic between 'minute' and 'daily' emission modes in the PerformanceTracker. As part of this, the trade simulation is retooled to handle the perf packets.