### PR TITLE
DEV: Uses ValueError when PerformanceTracker.to_dict receives invalid…

### DIFF
--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -298,7 +298,7 @@ class PerformanceTracker(object):
             _dict['minute_perf'] = self.todays_performance.to_dict(
                 self.saved_dt)
         else:
-            raise BaseException("Invalid emission type: %s" % emission_type)
+            raise ValueError("Invalid emission type: %s" % emission_type)
 
         return _dict
 

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -121,9 +121,8 @@ class AlgorithmSimulator(object):
                     )
                     # Perf messages are only emitted if the snapshot contained
                     # a benchmark event.
-                    if messages is not None:
-                        for message in messages:
-                            yield message
+                    for message in messages:
+                        yield message
 
                     # When emitting minutely, we need to call
                     # before_trading_start before the next trading day begins
@@ -315,7 +314,7 @@ class AlgorithmSimulator(object):
         if benchmark_event_occurred:
             return self.generate_messages(dt)
         else:
-            return None
+            return ()
 
     def _call_handle_data(self):
         """


### PR DESCRIPTION
… emission type

@ssanderson Is this alright?

@richafrank Also takes the opportunity to remove in 'is not None' check in the trade simulation.