### PR TITLE
MAINT: Remove unused `assets` property.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -491,10 +491,6 @@ class AssetFinder(object):
         c.execute(query)
         return [r[0] for r in c.fetchall()]
 
-    @property
-    def assets(self):
-        return self.cache.values()
-
     def _lookup_generic_scalar(self,
                                asset_convertible,
                                as_of_date,


### PR DESCRIPTION
It references a self.cache attribute that no longer exists.

ping @jfkirk