### PR TITLE
ENH: adds auto_close as a simulation parameter

### DIFF
--- a/tests/serialization_cases.py
+++ b/tests/serialization_cases.py
@@ -67,7 +67,7 @@ def object_serialization_cases(skip_daily=False):
         (PerformancePeriod,
             (10000,), {'position_tracker': PositionTracker()}, 'to_dict'),
         (Position, (8554,), {}, 'dict'),
-        (PositionTracker, (), {}, 'dict'),
+        (PositionTracker, (), {'auto_close': True}, 'dict'),
         (PerformanceTracker, (sim_params_minute,), {}, 'to_dict'),
         (RiskMetricsCumulative, (sim_params_minute,), {}, 'to_dict'),
         (RiskMetricsPeriod,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -31,6 +31,7 @@ from zipline.utils.test_utils import (
     teardown_logger
 )
 import zipline.utils.factory as factory
+from zipline.utils.factory import create_simulation_parameters
 import zipline.utils.simfactory as simfactory
 
 from zipline.errors import (
@@ -1449,6 +1450,27 @@ class TestClosePosAlgo(TestCase):
         self.check_algo_pnl(results, expected_pnl)
 
         expected_positions = [1, 1, 0]
+        self.check_algo_positions(results, expected_positions)
+
+    def test_no_auto_close_future(self):
+        metadata = {1: {'symbol': 'TEST',
+                        'asset_type': 'future',
+                        'notice_date': self.days[3],
+                        'expiration_date': self.days[4]}}
+        sim_params = create_simulation_parameters(auto_close=False)
+        self.algo = TestAlgorithm(sid=1, amount=1, order_count=1,
+                                  instant_fill=True, commission=PerShare(0),
+                                  asset_metadata=metadata,
+                                  sim_params=sim_params)
+        self.data = DataPanelSource(self.no_close_panel)
+
+        # Check results
+        results = self.run_algo()
+
+        expected_pnl = [0, 1, 2]
+        self.check_algo_pnl(results, expected_pnl)
+
+        expected_positions = [1, 1, 1]
         self.check_algo_positions(results, expected_positions)
 
     def run_algo(self):

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -29,7 +29,8 @@ log = logbook.Logger('Performance')
 
 class PositionTracker(object):
 
-    def __init__(self):
+    def __init__(self, auto_close=True):
+        self.auto_close = auto_close
         # sid => position object
         self.positions = positiondict()
         # Arrays for quick calculations of positions value
@@ -69,6 +70,9 @@ class PositionTracker(object):
                     asset.contract_multiplier
                 self._position_payout_multipliers[sid] = \
                     asset.contract_multiplier
+
+                if not self.auto_close:
+                    return
                 # Futures are closed on their notice_date
                 if asset.notice_date:
                     self._insert_auto_close_position_date(

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -108,7 +108,9 @@ class PerformanceTracker(object):
         self.dividend_frame = pd.DataFrame()
         self._dividend_count = 0
 
-        self.position_tracker = PositionTracker()
+        self.auto_close = sim_params.auto_close
+
+        self.position_tracker = PositionTracker(auto_close=self.auto_close)
 
         self.perf_periods = []
 
@@ -495,7 +497,7 @@ class PerformanceTracker(object):
 
         # Check if any assets need to be auto-closed before generating today's
         # perf period
-        if next_trading_day:
+        if next_trading_day and self.auto_close:
             self.check_asset_auto_closes(next_trading_day=next_trading_day)
 
         # Take a snapshot of our current performance to return to the

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -433,7 +433,8 @@ class SimulationParameters(object):
     def __init__(self, period_start, period_end,
                  capital_base=10e3,
                  emission_rate='daily',
-                 data_frequency='daily'):
+                 data_frequency='daily',
+                 auto_close=True):
 
         self.period_start = period_start
         self.period_end = period_end
@@ -441,6 +442,7 @@ class SimulationParameters(object):
 
         self.emission_rate = emission_rate
         self.data_frequency = data_frequency
+        self.auto_close = auto_close
 
         # copied to algorithm's environment for runtime access
         self.arena = 'backtest'

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -44,7 +44,8 @@ def create_simulation_parameters(year=2006, start=None, end=None,
                                  capital_base=float("1.0e5"),
                                  num_days=None, load=None,
                                  data_frequency='daily',
-                                 emission_rate='daily'):
+                                 emission_rate='daily',
+                                 auto_close=True):
     """Construct a complete environment with reasonable defaults"""
     if start is None:
         start = datetime(year, 1, 1, tzinfo=pytz.utc)
@@ -62,6 +63,7 @@ def create_simulation_parameters(year=2006, start=None, end=None,
         capital_base=capital_base,
         data_frequency=data_frequency,
         emission_rate=emission_rate,
+        auto_close=auto_close,
     )
 
     return sim_params


### PR DESCRIPTION
Allows users to turn off automatic closing of futures by setting an ```auto_close``` flag to ```False``` in the simulation parameters.
cc @jfkirk @StewartDouglas @yankees714 