### PR TITLE
WIP, ENH: allows cascading of assets into children products

### DIFF
--- a/zipline/assets/_assets.pyx
+++ b/zipline/assets/_assets.pyx
@@ -41,6 +41,7 @@ cdef class Asset:
     cdef public object first_traded
 
     cdef readonly object exchange
+    cdef readonly object children
 
     def __cinit__(self,
                   int sid, # sid is required
@@ -50,6 +51,7 @@ cdef class Asset:
                   object end_date=None,
                   object first_traded=None,
                   object exchange="",
+                  object children=None,
                   *args,
                   **kwargs):
 
@@ -61,6 +63,7 @@ cdef class Asset:
         self.start_date    = start_date
         self.end_date      = end_date
         self.first_traded  = first_traded
+        self.children = children
 
     def __int__(self):
         return self.sid
@@ -127,7 +130,7 @@ cdef class Asset:
 
     def __repr__(self):
         attrs = ('symbol', 'asset_name', 'exchange',
-                 'start_date', 'end_date', 'first_traded')
+                 'start_date', 'end_date', 'first_traded', 'children')
         tuples = ((attr, repr(getattr(self, attr, None)))
                   for attr in attrs)
         strings = ('%s=%s' % (t[0], t[1]) for t in tuples)
@@ -147,7 +150,8 @@ cdef class Asset:
                                  self.start_date,
                                  self.end_date,
                                  self.first_traded,
-                                 self.exchange,))
+                                 self.exchange,
+                                 self.children))
 
     cpdef to_dict(self):
         """
@@ -161,6 +165,7 @@ cdef class Asset:
             'end_date': self.end_date,
             'first_traded': self.first_traded,
             'exchange': self.exchange,
+            'children': self.children,
         }
 
     @classmethod
@@ -240,7 +245,8 @@ cdef class Future(Asset):
                   object expiration_date=None,
                   object first_traded=None,
                   object exchange="",
-                  int contract_multiplier=1):
+                  int contract_multiplier=1,
+                  object children=None):
 
         self.root_symbol         = root_symbol
         self.notice_date         = notice_date
@@ -260,7 +266,7 @@ cdef class Future(Asset):
     def __repr__(self):
         attrs = ('symbol', 'root_symbol', 'asset_name', 'exchange',
                  'start_date', 'end_date', 'first_traded', 'notice_date',
-                 'expiration_date', 'contract_multiplier')
+                 'expiration_date', 'contract_multiplier', 'children')
         tuples = ((attr, repr(getattr(self, attr, None)))
                   for attr in attrs)
         strings = ('%s=%s' % (t[0], t[1]) for t in tuples)
@@ -284,7 +290,8 @@ cdef class Future(Asset):
                                  self.expiration_date,
                                  self.first_traded,
                                  self.exchange,
-                                 self.contract_multiplier,))
+                                 self.contract_multiplier,
+                                 self.children,))
 
     cpdef to_dict(self):
         """

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -368,6 +368,19 @@ class PerformanceTracker(object):
         if txn:
             self.process_transaction(txn)
 
+    def process_cascade_position(self, event):
+
+        # CLOSE_POSITION events that contain prices that must be handled as
+        # a final trade event
+        if 'price' in event:
+            self.process_trade(event)
+
+        txns = self.position_tracker.\
+            maybe_create_cascade_transaction(event)
+        if txns:
+            for txn in txns:
+                self.process_transaction(txn)
+
     def check_upcoming_dividends(self, next_trading_day):
         """
         Check if we currently own any stocks with dividends whose ex_date is

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -198,6 +198,8 @@ class AlgorithmSimulator(object):
         perf_process_commission = self.algo.perf_tracker.process_commission
         perf_process_close_position = \
             self.algo.perf_tracker.process_close_position
+        perf_process_cascade_position = \
+            self.algo.perf_tracker.process_cascade_position
         blotter_process_trade = self.algo.blotter.process_trade
         blotter_process_benchmark = self.algo.blotter.process_benchmark
 
@@ -214,6 +216,7 @@ class AlgorithmSimulator(object):
         trades = []
         customs = []
         closes = []
+        cascades = []
 
         # splits and dividends are processed once a day.
         #
@@ -244,6 +247,8 @@ class AlgorithmSimulator(object):
                 dividends.append(event)
             elif event.type == DATASOURCE_TYPE.CLOSE_POSITION:
                 closes.append(event)
+            elif event.type == DATASOURCE_TYPE.CASCADE_POSITION:
+                cascades.append(event)
             else:
                 raise log.warn("Unrecognized event=%s".format(event))
 
@@ -282,6 +287,10 @@ class AlgorithmSimulator(object):
         for close in closes:
             self.update_universe(close)
             perf_process_close_position(close)
+
+        for cascade in cascades:
+            self.update_universe(cascade)
+            perf_process_cascade_position(cascade)
 
         if splits is not None:
             for split in splits:

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -44,7 +44,8 @@ DATASOURCE_TYPE = Enum(
     'CUSTOM',
     'BENCHMARK',
     'COMMISSION',
-    'CLOSE_POSITION'
+    'CLOSE_POSITION',
+    'CASCADE_POSITION',
 )
 
 # Expected fields/index values for a dividend Series.


### PR DESCRIPTION
In European gas and energy futures larger products (years, quarters) can be cascade into smaller "children" products (months, days). 
![67304_ill_cascading](https://cloud.githubusercontent.com/assets/10514666/9167513/14d20d54-3f55-11e5-9297-1328ede0e4c8.png)
Examples can be found [here](http://kwa-analytics.com/access-level/public-access/european-gas-futures-cascade-rules-overview-1/) and [here](http://www.nasdaqomx.com/transactions/markets/commodities/markets/power/power-ds-futures)
This is very important functionality for us but I was unable to find any U.S. examples. Is cascading possible in North American markets? If not another usage of this functionality would be the opening of arbitrage possibility between the larger and smaller products.

To-dos:
- add algo unittest
- combine with auto-close (i.e. the first quarter of a year product is closed and the remaining 3 quarters are opened)

cc @jfkirk @StewartDouglas @yankees714 @dhexus
