### PR TITLE
BUG: Use NAN from numpy.

### DIFF
--- a/zipline/lib/adjusted_array.pyx
+++ b/zipline/lib/adjusted_array.pyx
@@ -23,8 +23,8 @@ from zipline.errors import (
     WindowLengthTooLong,
 )
 
-cdef extern from "math.h" nogil:
-    float NAN
+
+cdef double NAN = float64('nan')
 
 
 NOMASK = None


### PR DESCRIPTION
MSVC doesn't define NAN in math.h because they only implement C89.

See http://tdistler.com/2011/03/24/how-to-define-nan-not-a-number-on-windows.