### PR TITLE
MAINT: Removes the ability to reference a global TradingEnvironment

### DIFF
--- a/tests/history_cases.py
+++ b/tests/history_cases.py
@@ -10,18 +10,19 @@ from zipline.history.history import HistorySpec
 from zipline.protocol import BarData
 from zipline.utils.test_utils import to_utc
 
+_cases_env = TradingEnvironment()
+
 
 def mixed_frequency_expected_index(count, frequency):
     """
     Helper for enumerating expected indices for test_mixed_frequency.
     """
-    env = TradingEnvironment.instance()
     minute = MIXED_FREQUENCY_MINUTES[count]
 
     if frequency == '1d':
-        return [env.previous_open_and_close(minute)[1], minute]
+        return [_cases_env.previous_open_and_close(minute)[1], minute]
     elif frequency == '1m':
-        return [env.previous_market_minute(minute), minute]
+        return [_cases_env.previous_market_minute(minute), minute]
 
 
 def mixed_frequency_expected_data(count, frequency):
@@ -41,32 +42,36 @@ def mixed_frequency_expected_data(count, frequency):
             return [count - 1, count]
 
 
-MIXED_FREQUENCY_MINUTES = TradingEnvironment.instance().market_minute_window(
+MIXED_FREQUENCY_MINUTES = _cases_env.market_minute_window(
     to_utc('2013-07-03 9:31AM'), 600,
 )
 ONE_MINUTE_PRICE_ONLY_SPECS = [
-    HistorySpec(1, '1m', 'price', True, data_frequency='minute'),
+    HistorySpec(1, '1m', 'price', True, _cases_env, data_frequency='minute'),
 ]
 DAILY_OPEN_CLOSE_SPECS = [
-    HistorySpec(3, '1d', 'open_price', False, data_frequency='minute'),
-    HistorySpec(3, '1d', 'close_price', False, data_frequency='minute'),
+    HistorySpec(3, '1d', 'open_price', False, _cases_env,
+                data_frequency='minute'),
+    HistorySpec(3, '1d', 'close_price', False, _cases_env,
+                data_frequency='minute'),
 ]
 ILLIQUID_PRICES_SPECS = [
-    HistorySpec(3, '1m', 'price', False, data_frequency='minute'),
-    HistorySpec(5, '1m', 'price', True, data_frequency='minute'),
+    HistorySpec(3, '1m', 'price', False, _cases_env, data_frequency='minute'),
+    HistorySpec(5, '1m', 'price', True, _cases_env, data_frequency='minute'),
 ]
 MIXED_FREQUENCY_SPECS = [
-    HistorySpec(1, '1m', 'price', False, data_frequency='minute'),
-    HistorySpec(2, '1m', 'price', False, data_frequency='minute'),
-    HistorySpec(2, '1d', 'price', False, data_frequency='minute'),
+    HistorySpec(1, '1m', 'price', False, _cases_env, data_frequency='minute'),
+    HistorySpec(2, '1m', 'price', False, _cases_env, data_frequency='minute'),
+    HistorySpec(2, '1d', 'price', False, _cases_env, data_frequency='minute'),
 ]
 MIXED_FIELDS_SPECS = [
-    HistorySpec(3, '1m', 'price', True, data_frequency='minute'),
-    HistorySpec(3, '1m', 'open_price', True, data_frequency='minute'),
-    HistorySpec(3, '1m', 'close_price', True, data_frequency='minute'),
-    HistorySpec(3, '1m', 'high', True, data_frequency='minute'),
-    HistorySpec(3, '1m', 'low', True, data_frequency='minute'),
-    HistorySpec(3, '1m', 'volume', True, data_frequency='minute'),
+    HistorySpec(3, '1m', 'price', True, _cases_env, data_frequency='minute'),
+    HistorySpec(3, '1m', 'open_price', True, _cases_env,
+                data_frequency='minute'),
+    HistorySpec(3, '1m', 'close_price', True, _cases_env,
+                data_frequency='minute'),
+    HistorySpec(3, '1m', 'high', True, _cases_env, data_frequency='minute'),
+    HistorySpec(3, '1m', 'low', True, _cases_env, data_frequency='minute'),
+    HistorySpec(3, '1m', 'volume', True, _cases_env, data_frequency='minute'),
 ]
 
 

--- a/tests/modelling/test_us_equity_pricing_loader.py
+++ b/tests/modelling/test_us_equity_pricing_loader.py
@@ -96,12 +96,15 @@ TEST_QUERY_ASSETS = EQUITY_INFO.index
 
 class BcolzDailyBarTestCase(TestCase):
 
-    def setUp(self):
-        all_trading_days = TradingEnvironment.instance().trading_days
-        self.trading_days = all_trading_days[
+    @classmethod
+    def setUpClass(cls):
+        all_trading_days = TradingEnvironment().trading_days
+        cls.trading_days = all_trading_days[
             all_trading_days.get_loc(TEST_CALENDAR_START):
             all_trading_days.get_loc(TEST_CALENDAR_STOP) + 1
         ]
+
+    def setUp(self):
 
         self.asset_info = EQUITY_INFO
         self.writer = SyntheticDailyBarWriter(
@@ -401,7 +404,7 @@ class USEquityPricingLoaderTestCase(TestCase):
         writer.write(SPLITS, MERGERS, DIVIDENDS)
 
         cls.assets = TEST_QUERY_ASSETS
-        all_days = TradingEnvironment.instance().trading_days
+        all_days = TradingEnvironment().trading_days
         cls.calendar_days = all_days[
             all_days.slice_indexer(TEST_CALENDAR_START, TEST_CALENDAR_STOP)
         ]

--- a/tests/risk/test_risk_cumulative.py
+++ b/tests/risk/test_risk_cumulative.py
@@ -21,13 +21,17 @@ import pytz
 import zipline.finance.risk as risk
 from zipline.utils import factory
 
-from zipline.finance.trading import SimulationParameters
+from zipline.finance.trading import SimulationParameters, TradingEnvironment
 
 from . import answer_key
 ANSWER_KEY = answer_key.ANSWER_KEY
 
 
 class TestRisk(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
 
     def setUp(self):
         start_date = datetime.datetime(
@@ -42,7 +46,8 @@ class TestRisk(unittest.TestCase):
 
         self.sim_params = SimulationParameters(
             period_start=start_date,
-            period_end=end_date
+            period_end=end_date,
+            env=self.env,
         )
 
         self.algo_returns_06 = factory.create_returns_from_list(
@@ -51,7 +56,8 @@ class TestRisk(unittest.TestCase):
         )
 
         self.cumulative_metrics_06 = risk.RiskMetricsCumulative(
-            self.sim_params)
+            self.sim_params, env=self.env
+        )
 
         for dt, returns in answer_key.RETURNS_DATA.iterrows():
             self.cumulative_metrics_06.update(dt,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -92,7 +92,6 @@ from zipline.sources import (SpecificEquityTrades,
 from zipline.assets import Equity
 
 from zipline.finance.execution import LimitOrder
-from zipline.finance import trading
 from zipline.finance.trading import SimulationParameters
 from zipline.utils.api_support import set_algo_instance
 from zipline.utils.events import DateRuleFactory, TimeRuleFactory
@@ -103,24 +102,31 @@ from zipline.finance.commission import PerShare
 
 
 class TestRecordAlgorithm(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[133])
+
     def setUp(self):
-        self.sim_params = factory.create_simulation_parameters(num_days=4)
-        trading.environment.write_data(equities_identifiers=[133])
+        self.sim_params = factory.create_simulation_parameters(num_days=4,
+                                                               env=self.env)
         trade_history = factory.create_trade_history(
             133,
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(days=1),
-            self.sim_params
+            self.sim_params,
+            self.env
         )
 
-        self.source = SpecificEquityTrades(event_list=trade_history)
+        self.source = SpecificEquityTrades(event_list=trade_history,
+                                           env=self.env)
         self.df_source, self.df = \
-            factory.create_test_df_source(self.sim_params)
+            factory.create_test_df_source(self.sim_params, self.env)
 
     def test_record_incr(self):
-        algo = RecordAlgorithm(
-            sim_params=self.sim_params)
+        algo = RecordAlgorithm(sim_params=self.sim_params, env=self.env)
         output = algo.run(self.source)
 
         np.testing.assert_array_equal(output['incr'].values,
@@ -134,19 +140,68 @@ class TestRecordAlgorithm(TestCase):
 
 
 class TestMiscellaneousAPI(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sids = [1, 2]
+        cls.env = TradingEnvironment()
+
+        metadata = {3: {'symbol': 'PLAY',
+                        'asset_type': 'equity',
+                        'start_date': '2002-01-01',
+                        'end_date': '2004-01-01'},
+                    4: {'symbol': 'PLAY',
+                        'asset_type': 'equity',
+                        'start_date': '2005-01-01',
+                        'end_date': '2006-01-01'}}
+
+        futures_metadata = {
+            5: {
+                'symbol': 'CLG06',
+                'root_symbol': 'CL',
+                'asset_type': 'future',
+                'start_date': pd.Timestamp('2005-12-01', tz='UTC'),
+                'notice_date': pd.Timestamp('2005-12-20', tz='UTC'),
+                'expiration_date': pd.Timestamp('2006-01-20', tz='UTC')},
+            6: {
+                'root_symbol': 'CL',
+                'symbol': 'CLK06',
+                'asset_type': 'future',
+                'start_date': pd.Timestamp('2005-12-01', tz='UTC'),
+                'notice_date': pd.Timestamp('2006-03-20', tz='UTC'),
+                'expiration_date': pd.Timestamp('2006-04-20', tz='UTC')},
+            7: {
+                'symbol': 'CLQ06',
+                'root_symbol': 'CL',
+                'asset_type': 'future',
+                'start_date': pd.Timestamp('2005-12-01', tz='UTC'),
+                'notice_date': pd.Timestamp('2006-06-20', tz='UTC'),
+                'expiration_date': pd.Timestamp('2006-07-20', tz='UTC')},
+            8: {
+                'symbol': 'CLX06',
+                'root_symbol': 'CL',
+                'asset_type': 'future',
+                'start_date': pd.Timestamp('2006-02-01', tz='UTC'),
+                'notice_date': pd.Timestamp('2006-09-20', tz='UTC'),
+                'expiration_date': pd.Timestamp('2006-10-20', tz='UTC')}
+        }
+        cls.env.write_data(equities_identifiers=cls.sids,
+                           equities_data=metadata,
+                           futures_data=futures_metadata)
+
     def setUp(self):
         setup_logger(self)
-        sids = [1, 2]
         self.sim_params = factory.create_simulation_parameters(
             num_days=2,
             data_frequency='minute',
             emission_rate='minute',
+            env=self.env,
         )
-        trading.environment.write_data(equities_identifiers=sids)
         self.source = factory.create_minutely_trade_source(
-            sids,
+            self.sids,
             sim_params=self.sim_params,
             concurrent=True,
+            env=self.env,
         )
 
     def tearDown(self):
@@ -191,7 +246,8 @@ class TestMiscellaneousAPI(TestCase):
 
         algo = TradingAlgorithm(initialize=initialize,
                                 handle_data=handle_data,
-                                sim_params=self.sim_params)
+                                sim_params=self.sim_params,
+                                env=self.env)
         algo.run(self.source)
 
     def test_get_open_orders(self):
@@ -241,7 +297,8 @@ class TestMiscellaneousAPI(TestCase):
 
         algo = TradingAlgorithm(initialize=initialize,
                                 handle_data=handle_data,
-                                sim_params=self.sim_params)
+                                sim_params=self.sim_params,
+                                env=self.env)
         algo.run(self.source)
 
     def test_schedule_function(self):
@@ -277,6 +334,7 @@ class TestMiscellaneousAPI(TestCase):
             initialize=initialize,
             handle_data=handle_data,
             sim_params=self.sim_params,
+            env=self.env,
         )
         algo.run(self.source)
 
@@ -292,7 +350,10 @@ class TestMiscellaneousAPI(TestCase):
 
         self.sim_params.data_frequency = mode
         algo = TradingAlgorithm(
-            initialize=nop, handle_data=nop, sim_params=self.sim_params,
+            initialize=nop,
+            handle_data=nop,
+            sim_params=self.sim_params,
+            env=self.env,
         )
 
         # Schedule something for NOT Always.
@@ -320,16 +381,7 @@ class TestMiscellaneousAPI(TestCase):
 
     def test_asset_lookup(self):
 
-        trading.environment = trading.TradingEnvironment()
-        metadata = {0: {'symbol': 'PLAY',
-                        'asset_type': 'equity',
-                        'start_date': '2002-01-01',
-                        'end_date': '2004-01-01'},
-                    1: {'symbol': 'PLAY',
-                        'asset_type': 'equity',
-                        'start_date': '2005-01-01',
-                        'end_date': '2006-01-01'}}
-        algo = TradingAlgorithm(asset_metadata=metadata)
+        algo = TradingAlgorithm(env=self.env)
 
         # Test before either PLAY existed
         algo.datetime = pd.Timestamp('2001-12-01', tz='UTC')
@@ -341,63 +393,30 @@ class TestMiscellaneousAPI(TestCase):
         # Test when first PLAY exists
         algo.datetime = pd.Timestamp('2002-12-01', tz='UTC')
         list_result = algo.symbols('PLAY')
-        self.assertEqual(0, list_result[0])
+        self.assertEqual(3, list_result[0])
 
         # Test after first PLAY ends
         algo.datetime = pd.Timestamp('2004-12-01', tz='UTC')
-        self.assertEqual(0, algo.symbol('PLAY'))
+        self.assertEqual(3, algo.symbol('PLAY'))
 
         # Test after second PLAY begins
         algo.datetime = pd.Timestamp('2005-12-01', tz='UTC')
-        self.assertEqual(1, algo.symbol('PLAY'))
+        self.assertEqual(4, algo.symbol('PLAY'))
 
         # Test after second PLAY ends
         algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
-        self.assertEqual(1, algo.symbol('PLAY'))
+        self.assertEqual(4, algo.symbol('PLAY'))
         list_result = algo.symbols('PLAY')
-        self.assertEqual(1, list_result[0])
+        self.assertEqual(4, list_result[0])
 
         # Test lookup SID
-        self.assertIsInstance(algo.sid(0), Equity)
-        self.assertIsInstance(algo.sid(1), Equity)
+        self.assertIsInstance(algo.sid(3), Equity)
+        self.assertIsInstance(algo.sid(4), Equity)
 
     def test_future_chain(self):
         """ Tests the future_chain API function.
         """
-        trading.environment = trading.TradingEnvironment()
-        metadata = {
-            0: {
-                'symbol': 'CLG06',
-                'root_symbol': 'CL',
-                'asset_type': 'future',
-                'start_date': pd.Timestamp('2005-12-01', tz='UTC'),
-                'notice_date': pd.Timestamp('2005-12-20', tz='UTC'),
-                'expiration_date': pd.Timestamp('2006-01-20', tz='UTC')},
-            1: {
-                'root_symbol': 'CL',
-                'symbol': 'CLK06',
-                'asset_type': 'future',
-                'start_date': pd.Timestamp('2005-12-01', tz='UTC'),
-                'notice_date': pd.Timestamp('2006-03-20', tz='UTC'),
-                'expiration_date': pd.Timestamp('2006-04-20', tz='UTC')},
-            2: {
-                'symbol': 'CLQ06',
-                'root_symbol': 'CL',
-                'asset_type': 'future',
-                'start_date': pd.Timestamp('2005-12-01', tz='UTC'),
-                'notice_date': pd.Timestamp('2006-06-20', tz='UTC'),
-                'expiration_date': pd.Timestamp('2006-07-20', tz='UTC')},
-            3: {
-                'symbol': 'CLX06',
-                'root_symbol': 'CL',
-                'asset_type': 'future',
-                'start_date': pd.Timestamp('2006-02-01', tz='UTC'),
-                'notice_date': pd.Timestamp('2006-09-20', tz='UTC'),
-                'expiration_date': pd.Timestamp('2006-10-20', tz='UTC')}
-        }
-
-        trading.environment.write_data(futures_data=metadata)
-        algo = TradingAlgorithm()
+        algo = TradingAlgorithm(env=self.env)
         algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
 
         # Check that the fields of the FutureChain object are set correctly
@@ -432,25 +451,37 @@ class TestMiscellaneousAPI(TestCase):
 
 
 class TestTransformAlgorithm(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        futures_metadata = {3: {'asset_type': 'future',
+                                'contract_multiplier': 10}}
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[0, 1, 133],
+                           futures_data=futures_metadata)
+
     def setUp(self):
         setup_logger(self)
-        self.sim_params = factory.create_simulation_parameters(num_days=4)
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=[133])
+        self.sim_params = factory.create_simulation_parameters(num_days=4,
+                                                               env=self.env)
 
         trade_history = factory.create_trade_history(
             133,
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(days=1),
-            self.sim_params
+            self.sim_params,
+            self.env
         )
-        self.source = SpecificEquityTrades(event_list=trade_history)
+        self.source = SpecificEquityTrades(
+            event_list=trade_history,
+            env=self.env,
+        )
         self.df_source, self.df = \
-            factory.create_test_df_source(self.sim_params)
+            factory.create_test_df_source(self.sim_params, self.env)
 
         self.panel_source, self.panel = \
-            factory.create_test_panel_source(self.sim_params)
+            factory.create_test_panel_source(self.sim_params, self.env)
 
     def tearDown(self):
         teardown_logger(self)
@@ -458,6 +489,7 @@ class TestTransformAlgorithm(TestCase):
     def test_source_as_input(self):
         algo = TestRegisterTransformAlgorithm(
             sim_params=self.sim_params,
+            env=self.env,
             sids=[133]
         )
         algo.run(self.source)
@@ -467,19 +499,21 @@ class TestTransformAlgorithm(TestCase):
     def test_invalid_order_parameters(self):
         algo = InvalidOrderAlgorithm(
             sids=[133],
-            sim_params=self.sim_params
+            sim_params=self.sim_params,
+            env=self.env,
         )
         algo.run(self.source)
 
     def test_multi_source_as_input(self):
-        trading.environment.write_data(equities_identifiers=[0, 1])
         sim_params = SimulationParameters(
             self.df.index[0],
-            self.df.index[-1]
+            self.df.index[-1],
+            env=self.env,
         )
         algo = TestRegisterTransformAlgorithm(
             sim_params=sim_params,
-            sids=[0, 1]
+            sids=[0, 1],
+            env=self.env,
         )
         algo.run([self.source, self.df_source], overwrite_sim_params=False)
         self.assertEqual(len(algo.sources), 2)
@@ -487,6 +521,7 @@ class TestTransformAlgorithm(TestCase):
     def test_df_as_input(self):
         algo = TestRegisterTransformAlgorithm(
             sim_params=self.sim_params,
+            env=self.env,
         )
         algo.run(self.df)
         assert isinstance(algo.sources[0], DataFrameSource)
@@ -494,6 +529,7 @@ class TestTransformAlgorithm(TestCase):
     def test_panel_as_input(self):
         algo = TestRegisterTransformAlgorithm(
             sim_params=self.sim_params,
+            env=self.env,
             sids=[0, 1])
         algo.run(self.panel)
         assert isinstance(algo.sources[0], DataPanelSource)
@@ -506,8 +542,6 @@ class TestTransformAlgorithm(TestCase):
 
         res1 = algo1.run(self.df)
 
-        # Create a new trading environment
-        trading.environment = trading.TradingEnvironment()
         # Create a new trading algorithm, which will
         # use the newly instantiated environment.
         algo2 = TestRegisterTransformAlgorithm(
@@ -523,12 +557,14 @@ class TestTransformAlgorithm(TestCase):
         self.sim_params.data_frequency = 'daily'
         algo = TestRegisterTransformAlgorithm(
             sim_params=self.sim_params,
+            env=self.env,
         )
         self.assertEqual(algo.sim_params.data_frequency, 'daily')
 
         self.sim_params.data_frequency = 'minute'
         algo = TestRegisterTransformAlgorithm(
             sim_params=self.sim_params,
+            env=self.env,
         )
         self.assertEqual(algo.sim_params.data_frequency, 'minute')
 
@@ -543,6 +579,7 @@ class TestTransformAlgorithm(TestCase):
     def test_order_methods(self, algo_class):
         algo = algo_class(
             sim_params=self.sim_params,
+            env=self.env,
         )
         algo.run(self.df)
 
@@ -554,12 +591,9 @@ class TestTransformAlgorithm(TestCase):
         (TestTargetValueAlgorithm,),
     ])
     def test_order_methods_for_future(self, algo_class):
-        # Use sid not already in test database.
-        metadata = {3: {'asset_type': 'future',
-                        'contract_multiplier': 10}}
         algo = algo_class(
             sim_params=self.sim_params,
-            asset_metadata=metadata
+            env=self.env,
         )
         algo.run(self.df)
 
@@ -573,7 +607,8 @@ class TestTransformAlgorithm(TestCase):
                                 'order_target_value']
 
         for name in method_names_to_test:
-            trading.environment = trading.TradingEnvironment()
+            # Don't supply an env so the TradingAlgorithm builds a new one for
+            # each method
             algo = TestOrderStyleForwardingAlgorithm(
                 sim_params=self.sim_params,
                 instant_fill=False,
@@ -583,11 +618,11 @@ class TestTransformAlgorithm(TestCase):
 
     def test_order_instant(self):
         algo = TestOrderInstantAlgorithm(sim_params=self.sim_params,
+                                         env=self.env,
                                          instant_fill=True)
         algo.run(self.df)
 
     def test_minute_data(self):
-        trading.environment.write_data(equities_identifiers=[0, 1])
         source = RandomWalkSource(freq='minute',
                                   start=pd.Timestamp('2000-1-3',
                                                      tz='UTC'),
@@ -595,6 +630,7 @@ class TestTransformAlgorithm(TestCase):
                                                    tz='UTC'))
         self.sim_params.data_frequency = 'minute'
         algo = TestOrderInstantAlgorithm(sim_params=self.sim_params,
+                                         env=self.env,
                                          instant_fill=True)
         algo.run(source)
 
@@ -603,26 +639,33 @@ class TestPositions(TestCase):
 
     def setUp(self):
         setup_logger(self)
-        self.sim_params = factory.create_simulation_parameters(num_days=4)
-        trading.environment.write_data(equities_identifiers=[1, 133])
+        self.env = TradingEnvironment()
+        self.sim_params = factory.create_simulation_parameters(num_days=4,
+                                                               env=self.env)
+        self.env.write_data(equities_identifiers=[1, 133])
 
         trade_history = factory.create_trade_history(
             1,
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(days=1),
-            self.sim_params
+            self.sim_params,
+            self.env
         )
-        self.source = SpecificEquityTrades(event_list=trade_history)
+        self.source = SpecificEquityTrades(
+            event_list=trade_history,
+            env=self.env,
+        )
 
         self.df_source, self.df = \
-            factory.create_test_df_source(self.sim_params)
+            factory.create_test_df_source(self.sim_params, self.env)
 
     def tearDown(self):
         teardown_logger(self)
 
     def test_empty_portfolio(self):
-        algo = EmptyPositionsAlgorithm(sim_params=self.sim_params)
+        algo = EmptyPositionsAlgorithm(sim_params=self.sim_params,
+                                       env=self.env)
         daily_stats = algo.run(self.df)
 
         expected_position_count = [
@@ -638,7 +681,9 @@ class TestPositions(TestCase):
 
     def test_noop_orders(self):
 
-        algo = AmbitiousStopLimitAlgorithm(sid=1)
+        algo = AmbitiousStopLimitAlgorithm(sid=1,
+                                           sim_params=self.sim_params,
+                                           env=self.env)
         daily_stats = algo.run(self.source)
 
         # Verify that possitions are empty for all dates.
@@ -647,25 +692,39 @@ class TestPositions(TestCase):
 
 
 class TestAlgoScript(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(
+            equities_identifiers=[0, 1, 133]
+        )
+
     def setUp(self):
         days = 251
         # Note that create_simulation_parameters creates
         # a new TradingEnvironment
-        self.sim_params = factory.create_simulation_parameters(num_days=days)
+        self.sim_params = factory.create_simulation_parameters(num_days=days,
+                                                               env=self.env)
+
         setup_logger(self)
-        trading.environment.write_data(equities_identifiers=[1, 133])
         trade_history = factory.create_trade_history(
             133,
             [10.0] * days,
             [100] * days,
             timedelta(days=1),
-            self.sim_params
+            self.sim_params,
+            self.env
         )
 
-        self.source = SpecificEquityTrades(sids=[133],
-                                           event_list=trade_history)
+        self.source = SpecificEquityTrades(
+            sids=[133],
+            event_list=trade_history,
+            env=self.env,
+        )
+
         self.df_source, self.df = \
-            factory.create_test_df_source(self.sim_params)
+            factory.create_test_df_source(self.sim_params, self.env)
 
         self.zipline_test_config = {
             'sid': 0,
@@ -714,7 +773,6 @@ class TestAlgoScript(TestCase):
     def test_fixed_slippage(self):
         # verify order -> transaction -> portfolio position.
         # --------------
-        trading.environment.write_data(equities_identifiers=[0])
         test_algo = TradingAlgorithm(
             script="""
 from zipline.api import (slippage,
@@ -739,6 +797,7 @@ def handle_data(context, data):
 
     context.incr += 1""",
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
@@ -769,7 +828,6 @@ def handle_data(context, data):
     def test_volshare_slippage(self):
         # verify order -> transaction -> portfolio position.
         # --------------
-        trading.environment.write_data(equities_identifiers=[0])
         test_algo = TradingAlgorithm(
             script="""
 from zipline.api import *
@@ -795,6 +853,7 @@ def handle_data(context, data):
     context.incr += 1
     """,
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
@@ -831,13 +890,13 @@ def handle_data(context, data):
         test_algo = TradingAlgorithm(
             script=record_variables,
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
         self.zipline_test_config['algorithm'] = test_algo
         self.zipline_test_config['trade_count'] = 200
 
-        trading.environment.write_data(equities_identifiers=[0])
         zipline = simfactory.create_test_zipline(
             **self.zipline_test_config)
         output, _ = drain_zipline(self, zipline)
@@ -864,10 +923,10 @@ def handle_data(context, data):
         test_algo.record(foo=MagicMock())
 
     def _algo_record_float_magic_should_pass(self, var_type):
-        trading.environment.write_data(equities_identifiers=[0])
         test_algo = TradingAlgorithm(
             script=record_float_magic % var_type,
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
@@ -891,10 +950,10 @@ def handle_data(context, data):
         Only test that order methods can be called without error.
         Correct filling of orders is tested in zipline.
         """
-        trading.environment.write_data(equities_identifiers=[0])
         test_algo = TradingAlgorithm(
             script=call_all_order_methods,
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
@@ -915,6 +974,7 @@ def handle_data(context, data):
             test_algo = TradingAlgorithm(
                 script=call_order_in_init,
                 sim_params=self.sim_params,
+                env=self.env,
             )
             set_algo_instance(test_algo)
             test_algo.run(self.source)
@@ -923,10 +983,10 @@ def handle_data(context, data):
         """
         Test that accessing portfolio in init doesn't break.
         """
-        trading.environment.write_data(equities_identifiers=[0])
         test_algo = TradingAlgorithm(
             script=access_portfolio_in_init,
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
@@ -942,10 +1002,10 @@ def handle_data(context, data):
         """
         Test that accessing account in init doesn't break.
         """
-        trading.environment.write_data(equities_identifiers=[0])
         test_algo = TradingAlgorithm(
             script=access_account_in_init,
             sim_params=self.sim_params,
+            env=self.env,
         )
         set_algo_instance(test_algo)
 
@@ -962,8 +1022,6 @@ class TestHistory(TestCase):
 
     def setUp(self):
         setup_logger(self)
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=[0, 1])
 
     def tearDown(self):
         teardown_logger(self)
@@ -972,9 +1030,12 @@ class TestHistory(TestCase):
     def setUpClass(cls):
         cls._start = pd.Timestamp('1991-01-01', tz='UTC')
         cls._end = pd.Timestamp('1991-01-15', tz='UTC')
+        cls.env = TradingEnvironment()
         cls.sim_params = factory.create_simulation_parameters(
             data_frequency='minute',
+            env=cls.env
         )
+        cls.env.write_data(equities_identifiers=[0, 1])
 
     @property
     def source(self):
@@ -994,6 +1055,7 @@ def handle_data(context, data):
         algo = TradingAlgorithm(
             script=history_algo,
             sim_params=self.sim_params,
+            env=self.env,
         )
         output = algo.run(self.source)
         self.assertIsNot(output, None)
@@ -1006,6 +1068,7 @@ def handle_data(context, data):
             initialize=lambda _: None,
             handle_data=handle_data,
             sim_params=self.sim_params,
+            env=self.env,
         )
         algo.run(self.source)
 
@@ -1020,6 +1083,7 @@ def handle_data(context, data):
             initialize=lambda _: None,
             handle_data=handle_data,
             sim_params=self.sim_params,
+            env=self.env,
         )
         algo.run(self.source)
 
@@ -1029,10 +1093,13 @@ def handle_data(context, data):
 
 class TestGetDatetime(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[0, 1])
+
     def setUp(self):
         setup_logger(self)
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=[0, 1])
 
     def tearDown(self):
         teardown_logger(self)
@@ -1075,11 +1142,13 @@ class TestGetDatetime(TestCase):
             end=end,
         )
         sim_params = factory.create_simulation_parameters(
-            data_frequency='minute'
+            data_frequency='minute',
+            env=self.env,
         )
         algo = TradingAlgorithm(
             script=algo,
             sim_params=sim_params,
+            env=self.env,
         )
         algo.run(source)
         self.assertFalse(algo.first_bar)
@@ -1087,19 +1156,28 @@ class TestGetDatetime(TestCase):
 
 class TestTradingControls(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.sid = 133
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[cls.sid])
+
     def setUp(self):
-        self.sim_params = factory.create_simulation_parameters(num_days=4)
-        self.sid = 133
-        trading.environment.write_data(equities_identifiers=[self.sid])
+        self.sim_params = factory.create_simulation_parameters(num_days=4,
+                                                               env=self.env)
         self.trade_history = factory.create_trade_history(
             self.sid,
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(days=1),
-            self.sim_params
+            self.sim_params,
+            self.env
         )
 
-        self.source = SpecificEquityTrades(event_list=self.trade_history)
+        self.source = SpecificEquityTrades(
+            event_list=self.trade_history,
+            env=self.env,
+        )
 
     def _check_algo(self,
                     algo,
@@ -1131,7 +1209,9 @@ class TestTradingControls(TestCase):
             algo.order_count += 1
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid,
                                            max_shares=10,
-                                           max_notional=500.0)
+                                           max_notional=500.0,
+                                           sim_params=self.sim_params,
+                                           env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
         # Buy three shares four times.  Should bail on the fourth before it's
@@ -1142,7 +1222,9 @@ class TestTradingControls(TestCase):
 
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid,
                                            max_shares=10,
-                                           max_notional=500.0)
+                                           max_notional=500.0,
+                                           sim_params=self.sim_params,
+                                           env=self.env)
         self.check_algo_fails(algo, handle_data, 3)
 
         # Buy two shares four times. Should bail due to max_notional on the
@@ -1153,7 +1235,9 @@ class TestTradingControls(TestCase):
 
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid,
                                            max_shares=10,
-                                           max_notional=61.0)
+                                           max_notional=61.0,
+                                           sim_params=self.sim_params,
+                                           env=self.env)
         self.check_algo_fails(algo, handle_data, 2)
 
         # Set the trading control to a different sid, then BUY ALL THE THINGS!.
@@ -1163,7 +1247,9 @@ class TestTradingControls(TestCase):
             algo.order_count += 1
         algo = SetMaxPositionSizeAlgorithm(sid=self.sid + 1,
                                            max_shares=10,
-                                           max_notional=61.0)
+                                           max_notional=61.0,
+                                           sim_params=self.sim_params,
+                                           env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
         # Set the trading control sid to None, then BUY ALL THE THINGS!. Should
@@ -1171,14 +1257,19 @@ class TestTradingControls(TestCase):
         def handle_data(algo, data):
             algo.order(algo.sid(self.sid), 10000)
             algo.order_count += 1
-        algo = SetMaxPositionSizeAlgorithm(max_shares=10, max_notional=61.0)
+        algo = SetMaxPositionSizeAlgorithm(max_shares=10, max_notional=61.0,
+                                           sim_params=self.sim_params,
+                                           env=self.env)
         self.check_algo_fails(algo, handle_data, 0)
 
     def test_set_do_not_order_list(self):
         # set the restricted list to be the sid, and fail.
         algo = SetDoNotOrderListAlgorithm(
             sid=self.sid,
-            restricted_list=[self.sid])
+            restricted_list=[self.sid],
+            sim_params=self.sim_params,
+            env=self.env,
+        )
 
         def handle_data(algo, data):
             algo.order(algo.sid(self.sid), 100)
@@ -1189,7 +1280,10 @@ class TestTradingControls(TestCase):
         # set the restricted list to exclude the sid, and succeed
         algo = SetDoNotOrderListAlgorithm(
             sid=self.sid,
-            restricted_list=[134, 135, 136])
+            restricted_list=[134, 135, 136],
+            sim_params=self.sim_params,
+            env=self.env,
+        )
 
         def handle_data(algo, data):
             algo.order(algo.sid(self.sid), 100)
@@ -1205,7 +1299,9 @@ class TestTradingControls(TestCase):
             algo.order_count += 1
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid,
                                         max_shares=10,
-                                        max_notional=500.0)
+                                        max_notional=500.0,
+                                        sim_params=self.sim_params,
+                                        env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
         # Buy 1, then 2, then 3, then 4 shares.  Bail on the last attempt
@@ -1216,7 +1312,9 @@ class TestTradingControls(TestCase):
 
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid,
                                         max_shares=3,
-                                        max_notional=500.0)
+                                        max_notional=500.0,
+                                        sim_params=self.sim_params,
+                                        env=self.env)
         self.check_algo_fails(algo, handle_data, 3)
 
         # Buy 1, then 2, then 3, then 4 shares.  Bail on the last attempt
@@ -1227,7 +1325,9 @@ class TestTradingControls(TestCase):
 
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid,
                                         max_shares=10,
-                                        max_notional=40.0)
+                                        max_notional=40.0,
+                                        sim_params=self.sim_params,
+                                        env=self.env)
         self.check_algo_fails(algo, handle_data, 3)
 
         # Set the trading control to a different sid, then BUY ALL THE THINGS!.
@@ -1237,7 +1337,9 @@ class TestTradingControls(TestCase):
             algo.order_count += 1
         algo = SetMaxOrderSizeAlgorithm(sid=self.sid + 1,
                                         max_shares=1,
-                                        max_notional=1.0)
+                                        max_notional=1.0,
+                                        sim_params=self.sim_params,
+                                        env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
         # Set the trading control sid to None, then BUY ALL THE THINGS!.
@@ -1247,7 +1349,9 @@ class TestTradingControls(TestCase):
             algo.order(algo.sid(self.sid), 10000)
             algo.order_count += 1
         algo = SetMaxOrderSizeAlgorithm(max_shares=1,
-                                        max_notional=1.0)
+                                        max_notional=1.0,
+                                        sim_params=self.sim_params,
+                                        env=self.env)
         self.check_algo_fails(algo, handle_data, 0)
 
     def test_set_max_order_count(self):
@@ -1259,26 +1363,31 @@ class TestTradingControls(TestCase):
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(hours=6),
-            self.sim_params
+            self.sim_params,
+            self.env
         )
-        self.source = SpecificEquityTrades(event_list=trade_history)
+        self.source = SpecificEquityTrades(event_list=trade_history,
+                                           env=self.env)
 
         def handle_data(algo, data):
             for i in range(5):
                 algo.order(algo.sid(self.sid), 1)
                 algo.order_count += 1
 
-        algo = SetMaxOrderCountAlgorithm(3)
+        algo = SetMaxOrderCountAlgorithm(3, sim_params=self.sim_params,
+                                         env=self.env)
         self.check_algo_fails(algo, handle_data, 3)
 
         # Second call to handle_data is the same day as the first, so the last
         # order of the second call should fail.
-        algo = SetMaxOrderCountAlgorithm(9)
+        algo = SetMaxOrderCountAlgorithm(9, sim_params=self.sim_params,
+                                         env=self.env)
         self.check_algo_fails(algo, handle_data, 9)
 
         # Only ten orders are placed per day, so this should pass even though
         # in total more than 20 orders are placed.
-        algo = SetMaxOrderCountAlgorithm(10)
+        algo = SetMaxOrderCountAlgorithm(10, sim_params=self.sim_params,
+                                         env=self.env)
         self.check_algo_succeeds(algo, handle_data, order_count=20)
 
     def test_long_only(self):
@@ -1286,7 +1395,7 @@ class TestTradingControls(TestCase):
         def handle_data(algo, data):
             algo.order(algo.sid(self.sid), -1)
             algo.order_count += 1
-        algo = SetLongOnlyAlgorithm()
+        algo = SetLongOnlyAlgorithm(sim_params=self.sim_params, env=self.env)
         self.check_algo_fails(algo, handle_data, 0)
 
         # Buy on even days, sell on odd days.  Never takes a short position, so
@@ -1297,7 +1406,7 @@ class TestTradingControls(TestCase):
             else:
                 algo.order(algo.sid(self.sid), -1)
             algo.order_count += 1
-        algo = SetLongOnlyAlgorithm()
+        algo = SetLongOnlyAlgorithm(sim_params=self.sim_params, env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
         # Buy on first three days, then sell off holdings.  Should succeed.
@@ -1305,7 +1414,7 @@ class TestTradingControls(TestCase):
             amounts = [1, 1, 1, -3]
             algo.order(algo.sid(self.sid), amounts[algo.order_count])
             algo.order_count += 1
-        algo = SetLongOnlyAlgorithm()
+        algo = SetLongOnlyAlgorithm(sim_params=self.sim_params, env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
         # Buy on first three days, then sell off holdings plus an extra share.
@@ -1314,7 +1423,7 @@ class TestTradingControls(TestCase):
             amounts = [1, 1, 1, -4]
             algo.order(algo.sid(self.sid), amounts[algo.order_count])
             algo.order_count += 1
-        algo = SetLongOnlyAlgorithm()
+        algo = SetLongOnlyAlgorithm(sim_params=self.sim_params, env=self.env)
         self.check_algo_fails(algo, handle_data, 3)
 
     def test_register_post_init(self):
@@ -1334,59 +1443,80 @@ class TestTradingControls(TestCase):
                 algo.set_long_only()
 
         algo = TradingAlgorithm(initialize=initialize,
-                                handle_data=handle_data)
+                                handle_data=handle_data,
+                                sim_params=self.sim_params,
+                                env=self.env)
         algo.run(self.source)
         self.source.rewind()
 
     def test_asset_date_bounds(self):
 
         # Run the algorithm with a sid that ends far in the future
-        df_source, _ = factory.create_test_df_source(self.sim_params)
+        temp_env = TradingEnvironment()
+        df_source, _ = factory.create_test_df_source(self.sim_params, temp_env)
         metadata = {0: {'start_date': '1990-01-01',
                         'end_date': '2020-01-01'}}
         algo = SetAssetDateBoundsAlgorithm(
             asset_metadata=metadata,
-            sim_params=self.sim_params,)
+            sim_params=self.sim_params,
+            env=temp_env,
+        )
         algo.run(df_source)
 
         # Run the algorithm with a sid that has already ended
-        trading.environment = trading.TradingEnvironment()
-        df_source, _ = factory.create_test_df_source(self.sim_params)
+        temp_env = TradingEnvironment()
+        df_source, _ = factory.create_test_df_source(self.sim_params, temp_env)
         metadata = {0: {'start_date': '1989-01-01',
                         'end_date': '1990-01-01'}}
         algo = SetAssetDateBoundsAlgorithm(
             asset_metadata=metadata,
-            sim_params=self.sim_params,)
+            sim_params=self.sim_params,
+            env=temp_env,
+        )
         with self.assertRaises(TradingControlViolation):
             algo.run(df_source)
 
         # Run the algorithm with a sid that has not started
-        trading.environment = trading.TradingEnvironment()
-        df_source, _ = factory.create_test_df_source(self.sim_params)
+        temp_env = TradingEnvironment()
+        df_source, _ = factory.create_test_df_source(self.sim_params, temp_env)
         metadata = {0: {'start_date': '2020-01-01',
                         'end_date': '2021-01-01'}}
         algo = SetAssetDateBoundsAlgorithm(
             asset_metadata=metadata,
-            sim_params=self.sim_params,)
+            sim_params=self.sim_params,
+            env=temp_env,
+        )
         with self.assertRaises(TradingControlViolation):
             algo.run(df_source)
 
 
 class TestAccountControls(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.sidint = 133
+        cls.env = TradingEnvironment()
+        cls.env.write_data(
+            equities_identifiers=[cls.sidint]
+        )
+
     def setUp(self):
-        self.sim_params = factory.create_simulation_parameters(num_days=4)
-        self.sidint = 133
-        trading.environment.write_data(equities_identifiers=[self.sidint])
+        self.sim_params = factory.create_simulation_parameters(
+            num_days=4, env=self.env
+        )
         self.trade_history = factory.create_trade_history(
             self.sidint,
             [10.0, 10.0, 11.0, 11.0],
             [100, 100, 100, 300],
             timedelta(days=1),
-            self.sim_params
+            self.sim_params,
+            self.env,
         )
 
-        self.source = SpecificEquityTrades(event_list=self.trade_history)
+        self.source = SpecificEquityTrades(
+            event_list=self.trade_history,
+            env=self.env,
+        )
 
     def _check_algo(self,
                     algo,
@@ -1413,22 +1543,24 @@ class TestAccountControls(TestCase):
         def handle_data(algo, data):
             algo.order(algo.sid(self.sidint), 1)
 
-        algo = SetMaxLeverageAlgorithm(0)
+        algo = SetMaxLeverageAlgorithm(0, sim_params=self.sim_params,
+                                       env=self.env)
         self.check_algo_fails(algo, handle_data)
 
         # Set max leverage to 1 so buying one share passes
         def handle_data(algo, data):
             algo.order(algo.sid(self.sidint), 1)
 
-        algo = SetMaxLeverageAlgorithm(1)
+        algo = SetMaxLeverageAlgorithm(1,  sim_params=self.sim_params,
+                                       env=self.env)
         self.check_algo_succeeds(algo, handle_data)
 
 
 class TestClosePosAlgo(TestCase):
 
     def setUp(self):
-        trading.environment = trading.TradingEnvironment()
-        self.days = TradingEnvironment().trading_days
+        self.env = TradingEnvironment()
+        self.days = self.env.trading_days
         self.index = [self.days[0], self.days[1], self.days[2]]
         self.panel = pd.Panel({1: pd.DataFrame({
             'price': [1, 2, 4], 'volume': [1e9, 0, 0],
@@ -1449,9 +1581,10 @@ class TestClosePosAlgo(TestCase):
         metadata = {1: {'symbol': 'TEST',
                         'asset_type': 'equity',
                         'end_date': self.days[3]}}
+        self.env.write_data(equities_data=metadata)
         self.algo = TestAlgorithm(sid=1, amount=1, order_count=1,
                                   instant_fill=True, commission=PerShare(0),
-                                  asset_metadata=metadata)
+                                  env=self.env)
         self.data = DataPanelSource(self.panel)
 
         # Check results
@@ -1465,9 +1598,10 @@ class TestClosePosAlgo(TestCase):
         metadata = {1: {'symbol': 'TEST',
                         'asset_type': 'future',
                         }}
-        trading.environment.write_data(futures_data=metadata)
+        self.env.write_data(futures_data=metadata)
         self.algo = TestAlgorithm(sid=1, amount=1, order_count=1,
-                                  instant_fill=True, commission=PerShare(0),)
+                                  instant_fill=True, commission=PerShare(0),
+                                  env=self.env)
         self.data = DataPanelSource(self.panel)
 
         # Check results
@@ -1482,9 +1616,10 @@ class TestClosePosAlgo(TestCase):
                         'asset_type': 'future',
                         'notice_date': self.days[3],
                         'expiration_date': self.days[4]}}
-        trading.environment.write_data(futures_data=metadata)
+        self.env.write_data(futures_data=metadata)
         self.algo = TestAlgorithm(sid=1, amount=1, order_count=1,
-                                  instant_fill=True, commission=PerShare(0),)
+                                  instant_fill=True, commission=PerShare(0),
+                                  env=self.env)
         self.data = DataPanelSource(self.no_close_panel)
 
         # Check results

--- a/tests/test_algorithm_gen.py
+++ b/tests/test_algorithm_gen.py
@@ -135,18 +135,17 @@ class AlgorithmGeneratorTestCase(TestCase):
         Ensure the pipeline of generators are in sync, at least as far as
         their current dates.
         """
-        # Ensure we are pointing to the TradingEnvironment for this class
-        trading.environment = AlgorithmGeneratorTestCase.env
 
         sim_params = factory.create_simulation_parameters(
             start=datetime(2011, 7, 30, tzinfo=pytz.utc),
-            end=datetime(2012, 7, 30, tzinfo=pytz.utc)
+            end=datetime(2012, 7, 30, tzinfo=pytz.utc),
+            env=self.env,
         )
-        algo = TestAlgo(self, sim_params=sim_params,
-                        env=AlgorithmGeneratorTestCase.env)
+        algo = TestAlgo(self, sim_params=sim_params, env=self.env)
         trade_source = factory.create_daily_trade_source(
             [8229],
-            sim_params
+            sim_params,
+            env=self.env,
         )
         algo.set_sources([trade_source])
 
@@ -168,10 +167,10 @@ class AlgorithmGeneratorTestCase(TestCase):
         sim_params = SimulationParameters(
             period_start=datetime(2012, 7, 30, tzinfo=pytz.utc),
             period_end=datetime(2012, 7, 30, tzinfo=pytz.utc),
-            data_frequency='minute'
+            data_frequency='minute',
+            env=self.env,
         )
-        algo = TestAlgo(self, sim_params=sim_params,
-                        env=AlgorithmGeneratorTestCase.env)
+        algo = TestAlgo(self, sim_params=sim_params, env=self.env)
 
         midnight_custom_source = [Event({
             'custom_field': 42.0,
@@ -214,13 +213,14 @@ class AlgorithmGeneratorTestCase(TestCase):
 
         sim_params = factory.create_simulation_parameters(
             start=datetime(2008, 1, 1, tzinfo=pytz.utc),
-            end=datetime(2008, 1, 5, tzinfo=pytz.utc)
+            end=datetime(2008, 1, 5, tzinfo=pytz.utc),
+            env=self.env,
         )
-        algo = TestAlgo(self, sim_params=sim_params,
-                        env=AlgorithmGeneratorTestCase.env)
+        algo = TestAlgo(self, sim_params=sim_params, env=self.env)
         trade_source = factory.create_daily_trade_source(
             [8229],
-            sim_params
+            sim_params,
+            env=self.env,
         )
         algo.set_sources([trade_source])
 
@@ -238,8 +238,8 @@ class AlgorithmGeneratorTestCase(TestCase):
         See https://github.com/quantopian/zipline/issues/241
         """
         sim_params = create_simulation_parameters(num_days=1,
-                                                  data_frequency='minute')
-        algo = TestAlgo(self, sim_params=sim_params,
-                        env=AlgorithmGeneratorTestCase.env)
+                                                  data_frequency='minute',
+                                                  env=self.env)
+        algo = TestAlgo(self, sim_params=sim_params, env=self.env)
         algo.run(source=[], overwrite_sim_params=False)
         self.assertEqual(algo.datetime, sim_params.last_close)

--- a/tests/test_batchtransform.py
+++ b/tests/test_batchtransform.py
@@ -30,10 +30,9 @@ import zipline.utils.factory as factory
 from zipline.transforms import batch_transform
 
 from zipline.test_algorithms import (BatchTransformAlgorithm,
-                                     BatchTransformAlgorithmMinute,
-                                     ReturnPriceBatchTransform)
+                                     BatchTransformAlgorithmMinute)
 
-from zipline.finance import trading
+from zipline.finance.trading import TradingEnvironment
 from zipline.algorithm import TradingAlgorithm
 from zipline.utils.tradingcalendar import trading_days
 from copy import deepcopy
@@ -107,16 +106,19 @@ class DifferentSidSource(DataSource):
 class TestChangeOfSids(TestCase):
     def setUp(self):
         self.sids = range(90)
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=self.sids)
+        self.env = TradingEnvironment()
+        self.env.write_data(equities_identifiers=self.sids)
+
         self.sim_params = factory.create_simulation_parameters(
             start=datetime(1990, 1, 1, tzinfo=pytz.utc),
-            end=datetime(1990, 1, 8, tzinfo=pytz.utc)
+            end=datetime(1990, 1, 8, tzinfo=pytz.utc),
+            env=self.env,
         )
 
     def test_all_sids_passed(self):
         algo = BatchTransformAlgorithmSetSid(
             sim_params=self.sim_params,
+            env=self.env,
         )
         source = DifferentSidSource()
         algo.run(source)
@@ -131,26 +133,32 @@ class TestChangeOfSids(TestCase):
 
 
 class TestBatchTransformMinutely(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[0])
+
     def setUp(self):
         setup_logger(self)
         start = pd.datetime(1990, 1, 3, 0, 0, 0, 0, pytz.utc)
         end = pd.datetime(1990, 1, 8, 0, 0, 0, 0, pytz.utc)
         self.sim_params = factory.create_simulation_parameters(
-            start=start,
-            end=end,
+            start=start, end=end, env=self.env,
         )
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=[0])
         self.sim_params.emission_rate = 'daily'
         self.sim_params.data_frequency = 'minute'
         self.source, self.df = \
-            factory.create_test_df_source(bars='minute')
+            factory.create_test_df_source(sim_params=self.sim_params,
+                                          env=self.env,
+                                          bars='minute')
 
     def tearDown(self):
         teardown_logger(self)
 
     def test_core(self):
-        algo = BatchTransformAlgorithmMinute(sim_params=self.sim_params)
+        algo = BatchTransformAlgorithmMinute(sim_params=self.sim_params,
+                                             env=self.env)
         algo.run(self.source)
         wl = int(algo.window_length * 6.5 * 60)
         for bt in algo.history[wl:]:
@@ -158,7 +166,9 @@ class TestBatchTransformMinutely(TestCase):
 
     def test_window_length(self):
         algo = BatchTransformAlgorithmMinute(sim_params=self.sim_params,
-                                             window_length=1, refresh_period=0)
+                                             env=self.env,
+                                             window_length=1,
+                                             refresh_period=0)
         algo.run(self.source)
         wl = int(algo.window_length * 6.5 * 60)
         np.testing.assert_array_equal(algo.history[:(wl - 1)],
@@ -171,24 +181,25 @@ class TestBatchTransform(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.env = trading.TradingEnvironment()
+        cls.env = TradingEnvironment()
         cls.env.write_data(equities_identifiers=[0])
 
     def setUp(self):
         setup_logger(self)
         self.sim_params = factory.create_simulation_parameters(
             start=datetime(1990, 1, 1, tzinfo=pytz.utc),
-            end=datetime(1990, 1, 8, tzinfo=pytz.utc)
+            end=datetime(1990, 1, 8, tzinfo=pytz.utc),
+            env=self.env
         )
-        trading.environment = TestBatchTransform.env
         self.source, self.df = \
-            factory.create_test_df_source(self.sim_params)
+            factory.create_test_df_source(self.sim_params, self.env)
 
     def tearDown(self):
         teardown_logger(self)
 
     def test_core_functionality(self):
-        algo = BatchTransformAlgorithm(sim_params=self.sim_params)
+        algo = BatchTransformAlgorithm(sim_params=self.sim_params,
+                                       env=self.env)
         algo.run(self.source)
         wl = algo.window_length
         # The following assertion depend on window length of 3
@@ -257,7 +268,8 @@ class TestBatchTransform(TestCase):
 
     def test_passing_of_args(self):
         algo = BatchTransformAlgorithm(1, kwarg='str',
-                                       sim_params=self.sim_params)
+                                       sim_params=self.sim_params,
+                                       env=self.env)
         algo.run(self.source)
         self.assertEqual(algo.args, (1,))
         self.assertEqual(algo.kwargs, {'kwarg': 'str'})
@@ -278,22 +290,3 @@ class TestBatchTransform(TestCase):
                 # 1990-01-08 - window now full
                 expected_item
             ])
-
-
-def run_batchtransform(window_length=10):
-    sim_params = factory.create_simulation_parameters(
-        start=datetime(1990, 1, 1, tzinfo=pytz.utc),
-        end=datetime(1995, 1, 8, tzinfo=pytz.utc)
-    )
-    source, df = factory.create_test_df_source(sim_params)
-
-    return_price_class = ReturnPriceBatchTransform(
-        refresh_period=1,
-        window_length=window_length,
-        clean_nans=False
-    )
-
-    for raw_event in source:
-        raw_event['datetime'] = raw_event.dt
-        event = {0: raw_event}
-        return_price_class.handle_data(event)

--- a/tests/test_events_through_risk.py
+++ b/tests/test_events_through_risk.py
@@ -19,8 +19,7 @@ import pytz
 
 import numpy as np
 
-from zipline.finance.trading import SimulationParameters
-from zipline.finance import trading
+from zipline.finance.trading import SimulationParameters, TradingEnvironment
 from zipline.algorithm import TradingAlgorithm
 from zipline.protocol import (
     Event,
@@ -43,10 +42,12 @@ class BuyAndHoldAlgorithm(TradingAlgorithm):
 
 class TestEventsThroughRisk(unittest.TestCase):
 
-    def test_daily_buy_and_hold(self):
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[1])
 
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=[1])
+    def test_daily_buy_and_hold(self):
 
         start_date = datetime.datetime(
             year=2006,
@@ -70,8 +71,7 @@ class TestEventsThroughRisk(unittest.TestCase):
             emission_rate='daily'
         )
 
-        algo = BuyAndHoldAlgorithm(
-            sim_params=sim_params)
+        algo = BuyAndHoldAlgorithm(sim_params=sim_params, env=self.env)
 
         first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
         second_date = datetime.datetime(2006, 1, 4, tzinfo=pytz.utc)
@@ -169,178 +169,176 @@ class TestEventsThroughRisk(unittest.TestCase):
                 err_msg="Mismatch at %s" % (current_dt,))
 
     def test_minute_buy_and_hold(self):
-        with trading.TradingEnvironment():
-            start_date = datetime.datetime(
-                year=2006,
-                month=1,
-                day=3,
-                hour=0,
-                minute=0,
-                tzinfo=pytz.utc)
-            end_date = datetime.datetime(
-                year=2006,
-                month=1,
-                day=5,
-                hour=0,
-                minute=0,
-                tzinfo=pytz.utc)
 
-            sim_params = SimulationParameters(
-                period_start=start_date,
-                period_end=end_date,
-                emission_rate='daily',
-                data_frequency='minute')
+        start_date = datetime.datetime(
+            year=2006,
+            month=1,
+            day=3,
+            hour=0,
+            minute=0,
+            tzinfo=pytz.utc)
+        end_date = datetime.datetime(
+            year=2006,
+            month=1,
+            day=5,
+            hour=0,
+            minute=0,
+            tzinfo=pytz.utc)
 
-            algo = BuyAndHoldAlgorithm(
-                identifiers=[1],
-                sim_params=sim_params)
+        sim_params = SimulationParameters(
+            period_start=start_date,
+            period_end=end_date,
+            emission_rate='daily',
+            data_frequency='minute',
+            env=self.env)
 
-            first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
-            first_open, first_close = \
-                trading.environment.get_open_and_close(first_date)
+        algo = BuyAndHoldAlgorithm(
+            sim_params=sim_params,
+            env=self.env)
 
-            second_date = datetime.datetime(2006, 1, 4, tzinfo=pytz.utc)
-            second_open, second_close = \
-                trading.environment.get_open_and_close(second_date)
+        first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
+        first_open, first_close = self.env.get_open_and_close(first_date)
 
-            third_date = datetime.datetime(2006, 1, 5, tzinfo=pytz.utc)
-            third_open, third_close = \
-                trading.environment.get_open_and_close(third_date)
+        second_date = datetime.datetime(2006, 1, 4, tzinfo=pytz.utc)
+        second_open, second_close = self.env.get_open_and_close(second_date)
 
-            benchmark_data = [
-                Event({
-                    'returns': 0.1,
-                    'dt': first_close,
-                    'source_id': 'test-benchmark-source',
-                    'type': DATASOURCE_TYPE.BENCHMARK
-                }),
-                Event({
-                    'returns': 0.2,
-                    'dt': second_close,
-                    'source_id': 'test-benchmark-source',
-                    'type': DATASOURCE_TYPE.BENCHMARK
-                }),
-                Event({
-                    'returns': 0.4,
-                    'dt': third_close,
-                    'source_id': 'test-benchmark-source',
-                    'type': DATASOURCE_TYPE.BENCHMARK
-                }),
-            ]
+        third_date = datetime.datetime(2006, 1, 5, tzinfo=pytz.utc)
+        third_open, third_close = self.env.get_open_and_close(third_date)
 
-            trade_bar_data = [
-                Event({
-                    'open_price': 10,
-                    'close_price': 15,
-                    'price': 15,
-                    'volume': 1000,
-                    'sid': 1,
-                    'dt': first_open,
-                    'source_id': 'test-trade-source',
-                    'type': DATASOURCE_TYPE.TRADE
-                }),
-                Event({
-                    'open_price': 10,
-                    'close_price': 15,
-                    'price': 15,
-                    'volume': 1000,
-                    'sid': 1,
-                    'dt': first_open + datetime.timedelta(minutes=10),
-                    'source_id': 'test-trade-source',
-                    'type': DATASOURCE_TYPE.TRADE
-                }),
-                Event({
-                    'open_price': 15,
-                    'close_price': 20,
-                    'price': 20,
-                    'volume': 2000,
-                    'sid': 1,
-                    'dt': second_open,
-                    'source_id': 'test-trade-source',
-                    'type': DATASOURCE_TYPE.TRADE
-                }),
-                Event({
-                    'open_price': 15,
-                    'close_price': 20,
-                    'price': 20,
-                    'volume': 2000,
-                    'sid': 1,
-                    'dt': second_open + datetime.timedelta(minutes=10),
-                    'source_id': 'test-trade-source',
-                    'type': DATASOURCE_TYPE.TRADE
-                }),
-                Event({
-                    'open_price': 20,
-                    'close_price': 15,
-                    'price': 15,
-                    'volume': 1000,
-                    'sid': 1,
-                    'dt': third_open,
-                    'source_id': 'test-trade-source',
-                    'type': DATASOURCE_TYPE.TRADE
-                }),
-                Event({
-                    'open_price': 20,
-                    'close_price': 15,
-                    'price': 15,
-                    'volume': 1000,
-                    'sid': 1,
-                    'dt': third_open + datetime.timedelta(minutes=10),
-                    'source_id': 'test-trade-source',
-                    'type': DATASOURCE_TYPE.TRADE
-                }),
-            ]
+        benchmark_data = [
+            Event({
+                'returns': 0.1,
+                'dt': first_close,
+                'source_id': 'test-benchmark-source',
+                'type': DATASOURCE_TYPE.BENCHMARK
+            }),
+            Event({
+                'returns': 0.2,
+                'dt': second_close,
+                'source_id': 'test-benchmark-source',
+                'type': DATASOURCE_TYPE.BENCHMARK
+            }),
+            Event({
+                'returns': 0.4,
+                'dt': third_close,
+                'source_id': 'test-benchmark-source',
+                'type': DATASOURCE_TYPE.BENCHMARK
+            }),
+        ]
 
-            algo.benchmark_return_source = benchmark_data
-            algo.set_sources(list([trade_bar_data]))
-            gen = algo._create_generator(sim_params)
+        trade_bar_data = [
+            Event({
+                'open_price': 10,
+                'close_price': 15,
+                'price': 15,
+                'volume': 1000,
+                'sid': 1,
+                'dt': first_open,
+                'source_id': 'test-trade-source',
+                'type': DATASOURCE_TYPE.TRADE
+            }),
+            Event({
+                'open_price': 10,
+                'close_price': 15,
+                'price': 15,
+                'volume': 1000,
+                'sid': 1,
+                'dt': first_open + datetime.timedelta(minutes=10),
+                'source_id': 'test-trade-source',
+                'type': DATASOURCE_TYPE.TRADE
+            }),
+            Event({
+                'open_price': 15,
+                'close_price': 20,
+                'price': 20,
+                'volume': 2000,
+                'sid': 1,
+                'dt': second_open,
+                'source_id': 'test-trade-source',
+                'type': DATASOURCE_TYPE.TRADE
+            }),
+            Event({
+                'open_price': 15,
+                'close_price': 20,
+                'price': 20,
+                'volume': 2000,
+                'sid': 1,
+                'dt': second_open + datetime.timedelta(minutes=10),
+                'source_id': 'test-trade-source',
+                'type': DATASOURCE_TYPE.TRADE
+            }),
+            Event({
+                'open_price': 20,
+                'close_price': 15,
+                'price': 15,
+                'volume': 1000,
+                'sid': 1,
+                'dt': third_open,
+                'source_id': 'test-trade-source',
+                'type': DATASOURCE_TYPE.TRADE
+            }),
+            Event({
+                'open_price': 20,
+                'close_price': 15,
+                'price': 15,
+                'volume': 1000,
+                'sid': 1,
+                'dt': third_open + datetime.timedelta(minutes=10),
+                'source_id': 'test-trade-source',
+                'type': DATASOURCE_TYPE.TRADE
+            }),
+        ]
 
-            crm = algo.perf_tracker.cumulative_risk_metrics
-            dt_loc = crm.cont_index.get_loc(algo.datetime)
+        algo.benchmark_return_source = benchmark_data
+        algo.set_sources(list([trade_bar_data]))
+        gen = algo._create_generator(sim_params)
 
-            first_msg = next(gen)
+        crm = algo.perf_tracker.cumulative_risk_metrics
+        dt_loc = crm.cont_index.get_loc(algo.datetime)
 
-            self.assertIsNotNone(first_msg,
-                                 "There should be a message emitted.")
+        first_msg = next(gen)
 
-            # Protects against bug where the positions appeared to be
-            # a day late, because benchmarks were triggering
-            # calculations before the events for the day were
-            # processed.
-            self.assertEqual(1, len(algo.portfolio.positions), "There should "
-                             "be one position after the first day.")
+        self.assertIsNotNone(first_msg,
+                             "There should be a message emitted.")
 
-            self.assertEquals(
-                0,
-                crm.algorithm_volatility[dt_loc],
-                "On the first day algorithm volatility does not exist.")
+        # Protects against bug where the positions appeared to be
+        # a day late, because benchmarks were triggering
+        # calculations before the events for the day were
+        # processed.
+        self.assertEqual(1, len(algo.portfolio.positions), "There should "
+                         "be one position after the first day.")
 
-            second_msg = next(gen)
+        self.assertEquals(
+            0,
+            crm.algorithm_volatility[dt_loc],
+            "On the first day algorithm volatility does not exist.")
 
-            self.assertIsNotNone(second_msg, "There should be a message "
-                                 "emitted.")
+        second_msg = next(gen)
 
-            self.assertEqual(1, len(algo.portfolio.positions),
-                             "Number of positions should stay the same.")
+        self.assertIsNotNone(second_msg, "There should be a message "
+                             "emitted.")
 
-            # TODO: Hand derive. Current value is just a canary to
-            # detect changes.
-            np.testing.assert_almost_equal(
-                0.050022510129558301,
-                crm.algorithm_returns[-1],
-                decimal=6)
+        self.assertEqual(1, len(algo.portfolio.positions),
+                         "Number of positions should stay the same.")
 
-            third_msg = next(gen)
+        # TODO: Hand derive. Current value is just a canary to
+        # detect changes.
+        np.testing.assert_almost_equal(
+            0.050022510129558301,
+            crm.algorithm_returns[-1],
+            decimal=6)
 
-            self.assertEqual(1, len(algo.portfolio.positions),
-                             "Number of positions should stay the same.")
+        third_msg = next(gen)
 
-            self.assertIsNotNone(third_msg, "There should be a message "
-                                 "emitted.")
+        self.assertEqual(1, len(algo.portfolio.positions),
+                         "Number of positions should stay the same.")
 
-            # TODO: Hand derive. Current value is just a canary to
-            # detect changes.
-            np.testing.assert_almost_equal(
-                -0.047639464532418657,
-                crm.algorithm_returns[-1],
-                decimal=6)
+        self.assertIsNotNone(third_msg, "There should be a message "
+                             "emitted.")
+
+        # TODO: Hand derive. Current value is just a canary to
+        # detect changes.
+        np.testing.assert_almost_equal(
+            -0.047639464532418657,
+            crm.algorithm_returns[-1],
+            decimal=6)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -26,8 +26,6 @@ from nose_parameterized import parameterized
 import os
 from unittest import TestCase
 
-from zipline.finance import trading
-
 matplotlib.use('Agg')
 
 
@@ -41,6 +39,4 @@ class ExamplesTests(TestCase):
     @parameterized.expand(((os.path.basename(f).replace('.', '_'), f) for f in
                            glob.glob(os.path.join(example_dir(), '*.py'))))
     def test_example(self, name, example):
-        # Create a new trading environment for each test.
-        trading.environment = trading.TradingEnvironment()
         imp.load_source('__main__', os.path.basename(example), open(example))

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -24,6 +24,7 @@ from zipline.test_algorithms import (
     SetPortfolioAlgorithm,
 )
 from zipline.finance.slippage import FixedSlippage
+from zipline.finance.trading import TradingEnvironment
 
 
 from zipline.utils.test_utils import (
@@ -38,6 +39,11 @@ EXTENDED_TIMEOUT = 90
 
 
 class ExceptionTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[133])
 
     def setUp(self):
         self.zipline_test_config = {
@@ -65,7 +71,8 @@ class ExceptionTestCase(TestCase):
             ExceptionAlgorithm(
                 'handle_data',
                 self.zipline_test_config['sid'],
-                sim_params=factory.create_simulation_parameters()
+                sim_params=factory.create_simulation_parameters(),
+                env=self.env
         )
 
         zipline = simfactory.create_test_zipline(
@@ -75,8 +82,7 @@ class ExceptionTestCase(TestCase):
         with self.assertRaises(Exception) as ctx:
             output, _ = drain_zipline(self, zipline)
 
-        self.assertEqual(str(ctx.exception),
-                         'Algo exception in handle_data')
+        self.assertEqual(str(ctx.exception), 'Algo exception in handle_data')
 
     def test_zerodivision_exception_in_handle_data(self):
 
@@ -85,7 +91,8 @@ class ExceptionTestCase(TestCase):
         self.zipline_test_config['algorithm'] = \
             DivByZeroAlgorithm(
                 self.zipline_test_config['sid'],
-                sim_params=factory.create_simulation_parameters()
+                sim_params=factory.create_simulation_parameters(),
+                env=self.env
         )
 
         zipline = simfactory.create_test_zipline(
@@ -105,7 +112,8 @@ class ExceptionTestCase(TestCase):
         self.zipline_test_config['algorithm'] = \
             SetPortfolioAlgorithm(
                 self.zipline_test_config['sid'],
-                sim_params=factory.create_simulation_parameters()
+                sim_params=factory.create_simulation_parameters(),
+                env=self.env
         )
 
         zipline = simfactory.create_test_zipline(

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -39,7 +39,6 @@ import zipline.utils.simfactory as simfactory
 from zipline.finance.blotter import Blotter
 from zipline.gens.composites import date_sorted_sources
 
-from zipline.finance import trading
 from zipline.finance.trading import TradingEnvironment
 from zipline.finance.execution import MarketOrder, LimitOrder
 from zipline.finance.trading import SimulationParameters
@@ -57,9 +56,12 @@ EXTENDED_TIMEOUT = 90
 
 class FinanceTestCase(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.env.write_data(equities_identifiers=[1, 133])
+
     def setUp(self):
-        trading.environment = trading.TradingEnvironment()
-        trading.environment.write_data(equities_identifiers=[1, 133])
         self.zipline_test_config = {
             'sid': 133,
         }
@@ -74,7 +76,8 @@ class FinanceTestCase(TestCase):
         sim_params = factory.create_simulation_parameters()
         trade_source = factory.create_daily_trade_source(
             [133],
-            sim_params
+            sim_params,
+            env=self.env,
         )
         prev = None
         for trade in trade_source:
@@ -92,7 +95,6 @@ class FinanceTestCase(TestCase):
         # No transactions can be filled on the first trade, so
         # we have one extra trade to ensure all orders are filled.
         self.zipline_test_config['trade_count'] = 101
-        trading.environment = trading.TradingEnvironment()
         full_zipline = simfactory.create_test_zipline(
             **self.zipline_test_config)
         assert_single_position(self, full_zipline)
@@ -229,7 +231,8 @@ class FinanceTestCase(TestCase):
             price,
             volume,
             trade_interval,
-            sim_params
+            sim_params,
+            env=self.env,
         )
 
         if alternate:
@@ -263,7 +266,7 @@ class FinanceTestCase(TestCase):
             self.assertEqual(order.sid, sid)
             self.assertEqual(order.amount, order_amount * alternator ** i)
 
-        tracker = PerformanceTracker(sim_params)
+        tracker = PerformanceTracker(sim_params, env=self.env)
 
         benchmark_returns = [
             Event({'dt': dt,
@@ -271,7 +274,7 @@ class FinanceTestCase(TestCase):
                    'type':
                    zipline.protocol.DATASOURCE_TYPE.BENCHMARK,
                    'source_id': 'benchmarks'})
-            for dt, ret in trading.environment.benchmark_returns.iteritems()
+            for dt, ret in self.env.benchmark_returns.iteritems()
             if dt.date() >= sim_params.period_start.date() and
             dt.date() <= sim_params.period_end.date()
         ]
@@ -410,6 +413,7 @@ class TradingEnvironmentTestCase(TestCase):
             period_start=datetime(2008, 1, 1, tzinfo=pytz.utc),
             period_end=datetime(2008, 12, 31, tzinfo=pytz.utc),
             capital_base=100000,
+            env=self.env,
         )
 
         self.assertTrue(env.last_close.month == 12)
@@ -426,10 +430,11 @@ class TradingEnvironmentTestCase(TestCase):
         #  20 21 22 23 24 25 26
         #  27 28 29 30 31
 
-        env = SimulationParameters(
+        params = SimulationParameters(
             period_start=datetime(2007, 12, 31, tzinfo=pytz.utc),
             period_end=datetime(2008, 1, 7, tzinfo=pytz.utc),
             capital_base=100000,
+            env=self.env,
         )
 
         expected_trading_days = (
@@ -445,9 +450,9 @@ class TradingEnvironmentTestCase(TestCase):
         )
 
         num_expected_trading_days = 5
-        self.assertEquals(num_expected_trading_days, env.days_in_period)
+        self.assertEquals(num_expected_trading_days, params.days_in_period)
         np.testing.assert_array_equal(expected_trading_days,
-                                      env.trading_days.tolist())
+                                      params.trading_days.tolist())
 
     @timed(DEFAULT_TIMEOUT)
     def test_market_minute_window(self):

--- a/tests/test_pickle_serialization.py
+++ b/tests/test_pickle_serialization.py
@@ -13,14 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
+from zipline.utils.serialization_utils import (
+    load_with_persistent_ids, dump_with_persistent_ids
+)
 
 from nose_parameterized import parameterized
 from unittest import TestCase
 
 from .serialization_cases import (
     object_serialization_cases,
-    assert_dict_equal
+    assert_dict_equal,
+    cases_env,
 )
 
 
@@ -37,9 +40,9 @@ class PickleSerializationTestCase(TestCase):
         obj = cls(*initargs)
         for k, v in di_vars.items():
             setattr(obj, k, v)
-        state = pickle.dumps(obj)
+        state = dump_with_persistent_ids(obj)
 
-        obj2 = pickle.loads(state)
+        obj2 = load_with_persistent_ids(state, env=cases_env)
         for k, v in di_vars.items():
             setattr(obj2, k, v)
 

--- a/tests/test_rolling_panel.py
+++ b/tests/test_rolling_panel.py
@@ -23,17 +23,21 @@ import pandas as pd
 import pandas.util.testing as tm
 
 from zipline.utils.data import MutableIndexRollingPanel, RollingPanel
-from zipline.finance.trading import with_environment
+from zipline.finance.trading import TradingEnvironment
 
 
 class TestRollingPanel(unittest.TestCase):
-    @with_environment()
-    def test_alignment(self, env):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+
+    def test_alignment(self):
         items = ('a', 'b')
         sids = (1, 2)
 
-        dts = env.market_minute_window(
-            env.open_and_closes.market_open[0], 4,
+        dts = self.env.market_minute_window(
+            self.env.open_and_closes.market_open[0], 4,
         ).values
         rp = RollingPanel(2, items, sids, initial_dates=dts[1:-1])
 
@@ -90,8 +94,7 @@ class TestRollingPanel(unittest.TestCase):
             expected,
         )
 
-    @with_environment()
-    def test_get_current_multiple_call_same_tick(self, env):
+    def test_get_current_multiple_call_same_tick(self):
         """
         In old get_current, each call the get_current would copy the data. Thus
         changing that object would have no side effects.
@@ -104,8 +107,8 @@ class TestRollingPanel(unittest.TestCase):
         items = ('a', 'b')
         sids = (1, 2)
 
-        dts = env.market_minute_window(
-            env.open_and_closes.market_open[0], 4,
+        dts = self.env.market_minute_window(
+            self.env.open_and_closes.market_open[0], 4,
         ).values
         rp = RollingPanel(2, items, sids, initial_dates=dts[1:-1])
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -39,7 +39,7 @@ def gather_bad_dicts(state):
 class SerializationTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.env = TradingEnvironment.instance()
+        cls.env = TradingEnvironment()
 
     @parameterized.expand(object_serialization_cases())
     def test_object_serialization(self,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -27,12 +27,12 @@ from zipline.sources import (DataFrameSource,
                              RandomWalkSource)
 from zipline.utils import tradingcalendar as calendar_nyse
 from zipline.assets import AssetFinder
-from zipline.finance import trading
+from zipline.finance.trading import TradingEnvironment
 
 
 class TestDataFrameSource(TestCase):
     def test_df_source(self):
-        source, df = factory.create_test_df_source()
+        source, df = factory.create_test_df_source(env=None)
         assert isinstance(source.start, pd.lib.Timestamp)
         assert isinstance(source.end, pd.lib.Timestamp)
 
@@ -43,7 +43,7 @@ class TestDataFrameSource(TestCase):
             assert expected_price[0] == sid0.price
 
     def test_df_sid_filtering(self):
-        _, df = factory.create_test_df_source()
+        _, df = factory.create_test_df_source(env=None)
         source = DataFrameSource(df)
         assert 1 not in [event.sid for event in source], \
             "DataFrameSource should only stream selected sid 0, not sid 1."
@@ -65,10 +65,10 @@ class TestDataFrameSource(TestCase):
             self.assertTrue(isinstance(event['arbitrary'], float))
 
     def test_yahoo_bars_to_panel_source(self):
-        trading.environment = trading.TradingEnvironment()
-        finder = AssetFinder(trading.environment.engine)
+        env = TradingEnvironment()
+        finder = AssetFinder(env.engine)
         stocks = ['AAPL', 'GE']
-        trading.environment.write_data(equities_identifiers=stocks)
+        env.write_data(equities_identifiers=stocks)
         start = pd.datetime(1993, 1, 1, 0, 0, 0, 0, pytz.utc)
         end = pd.datetime(2002, 1, 1, 0, 0, 0, 0, pytz.utc)
         data = factory.load_bars_from_yahoo(stocks=stocks,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -103,6 +103,7 @@ def with_algo(f):
             initialize=initialize_with(self, tfm_name, days),
             handle_data=handle_data_wrapper(f),
             sim_params=sim_params,
+            env=self.env,
         )
         algo.run(source)
 
@@ -127,17 +128,19 @@ class TransformTestCase(TestCase):
             data_frequency='daily',
             emission_rate='daily',
         )
-        cls.env = TradingEnvironment.instance()
+        cls.env = TradingEnvironment()
         cls.env.write_data(equities_identifiers=[1, 2, 3])
         cls.sim_and_source = {
             'minute': (minute_sim_ps, factory.create_minutely_trade_source(
                 cls.sids,
                 sim_params=minute_sim_ps,
+                env=cls.env,
             )),
             'daily': (daily_sim_ps, factory.create_trade_source(
                 cls.sids,
                 trade_time_increment=timedelta(days=1),
                 sim_params=daily_sim_ps,
+                env=cls.env,
             )),
         }
 

--- a/tests/test_transforms_talib.py
+++ b/tests/test_transforms_talib.py
@@ -16,6 +16,7 @@
 import pytz
 import numpy as np
 import pandas as pd
+import talib
 
 from datetime import timedelta, datetime
 from unittest import TestCase, skip
@@ -23,21 +24,26 @@ from unittest import TestCase, skip
 from zipline.utils.test_utils import setup_logger, teardown_logger
 
 import zipline.utils.factory as factory
+from zipline.finance.trading import TradingEnvironment
 
 from zipline.test_algorithms import TALIBAlgorithm
 
-import talib
 import zipline.transforms.ta as ta
 
 
 class TestTALIB(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+
     def setUp(self):
         setup_logger(self)
         sim_params = factory.create_simulation_parameters(
             start=datetime(1990, 1, 1, tzinfo=pytz.utc),
             end=datetime(1990, 3, 30, tzinfo=pytz.utc))
         self.source, self.panel = \
-            factory.create_test_panel_ohlc_source(sim_params)
+            factory.create_test_panel_ohlc_source(sim_params, self.env)
 
     def tearDown(self):
         teardown_logger(self)
@@ -60,7 +66,7 @@ class TestTALIB(TestCase):
             sim_params = factory.create_simulation_parameters(
                 start=start, end=end)
             source, panel = \
-                factory.create_test_panel_ohlc_source(sim_params)
+                factory.create_test_panel_ohlc_source(sim_params, self.env)
 
             algo = TALIBAlgorithm(talib=zipline_transform)
             algo.run(source)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -190,6 +190,18 @@ class TradingAlgorithm(object):
 
         self.instant_fill = kwargs.pop('instant_fill', False)
 
+        # If an env has been provided, pop it
+        self.trading_environment = kwargs.pop('env', None)
+
+        if self.trading_environment is None:
+            self.trading_environment = TradingEnvironment()
+
+        # Update the TradingEnvironment with the provided asset metadata
+        self.trading_environment.write_data(
+            equities_data=kwargs.pop('asset_metadata', {}),
+            equities_identifiers=kwargs.pop('identifiers', []),
+        )
+
         # set the capital base
         self.capital_base = kwargs.pop('capital_base', DEFAULT_CAPITAL_BASE)
         self.sim_params = kwargs.pop('sim_params', None)
@@ -197,17 +209,15 @@ class TradingAlgorithm(object):
             self.sim_params = create_simulation_parameters(
                 capital_base=self.capital_base,
                 start=kwargs.pop('start', None),
-                end=kwargs.pop('end', None)
+                end=kwargs.pop('end', None),
+                env=self.trading_environment,
             )
-        self.perf_tracker = PerformanceTracker(self.sim_params)
+        else:
+            self.sim_params.update_internal_from_env(self.trading_environment)
 
-        # Update the TradingEnvironment with the provided asset metadata
-        self.trading_environment = kwargs.pop('env',
-                                              TradingEnvironment.instance())
-        self.trading_environment.write_data(
-            equities_data=kwargs.pop('asset_metadata', {}),
-            equities_identifiers=kwargs.pop('identifiers', []),
-        )
+        # Build a perf_tracker
+        self.perf_tracker = PerformanceTracker(sim_params=self.sim_params,
+                                               env=self.trading_environment)
 
         # Pull in the environment's new AssetFinder for quick reference
         self.asset_finder = self.trading_environment.asset_finder
@@ -436,7 +446,9 @@ class TradingAlgorithm(object):
         if self.perf_tracker is None:
             # HACK: When running with the `run` method, we set perf_tracker to
             # None so that it will be overwritten here.
-            self.perf_tracker = PerformanceTracker(sim_params)
+            self.perf_tracker = PerformanceTracker(
+                sim_params=sim_params, env=self.trading_environment
+            )
 
         self.portfolio_needs_update = True
         self.account_needs_update = True
@@ -495,8 +507,21 @@ class TradingAlgorithm(object):
             # if DataFrame provided, map columns to sids and wrap
             # in DataFrameSource
             copy_frame = source.copy()
+
+            # Build new Assets for identifiers that can't be resolved as
+            # sids/Assets
+            identifiers_to_build = []
+            for identifier in source.columns:
+                if hasattr(identifier, '__int__'):
+                    asset = self.asset_finder.retrieve_asset(sid=identifier,
+                                                             default_none=True)
+                    if asset is None:
+                        identifiers_to_build.append(identifier)
+                else:
+                    identifiers_to_build.append(identifier)
+
             self.trading_environment.write_data(
-                equities_identifiers=source.columns)
+                equities_identifiers=identifiers_to_build)
             copy_frame.columns = \
                 self.asset_finder.map_identifier_index_to_sids(
                     source.columns, source.index[0]
@@ -507,8 +532,21 @@ class TradingAlgorithm(object):
             # If Panel provided, map items to sids and wrap
             # in DataPanelSource
             copy_panel = source.copy()
+
+            # Build new Assets for identifiers that can't be resolved as
+            # sids/Assets
+            identifiers_to_build = []
+            for identifier in source.items:
+                if hasattr(identifier, '__int__'):
+                    asset = self.asset_finder.retrieve_asset(sid=identifier,
+                                                             default_none=True)
+                    if asset is None:
+                        identifiers_to_build.append(identifier)
+                else:
+                    identifiers_to_build.append(identifier)
+
             self.trading_environment.write_data(
-                equities_identifiers=source.items)
+                equities_identifiers=identifiers_to_build)
             copy_panel.items = self.asset_finder.map_identifier_index_to_sids(
                 source.items, source.major_axis[0]
             )
@@ -527,7 +565,9 @@ class TradingAlgorithm(object):
                 self.sim_params.period_end = source.end
             # Changing period_start and period_close might require updating
             # of first_open and last_close.
-            self.sim_params._update_internal()
+            self.sim_params.update_internal_from_env(
+                env=self.trading_environment
+            )
 
         # The sids field of the source is the reference for the universe at
         # the start of the run
@@ -555,6 +595,7 @@ class TradingAlgorithm(object):
                 self.current_universe(),
                 self.sim_params.first_open,
                 self.sim_params.data_frequency,
+                self.trading_environment,
             )
 
         # loop through simulated_trading, each iteration returns a
@@ -1107,7 +1148,8 @@ class TradingAlgorithm(object):
     def add_history(self, bar_count, frequency, field, ffill=True):
         data_frequency = self.sim_params.data_frequency
         history_spec = HistorySpec(bar_count, frequency, field, ffill,
-                                   data_frequency=data_frequency)
+                                   data_frequency=data_frequency,
+                                   env=self.trading_environment)
         self.history_specs[history_spec.key_str] = history_spec
         if self.initialized:
             if self.history_container:
@@ -1120,6 +1162,7 @@ class TradingAlgorithm(object):
                     self.current_universe(),
                     self.sim_params.first_open,
                     self.sim_params.data_frequency,
+                    env=self.trading_environment,
                 )
 
     def get_history_spec(self, bar_count, frequency, field, ffill):
@@ -1132,6 +1175,7 @@ class TradingAlgorithm(object):
                 field,
                 ffill,
                 data_frequency=data_freq,
+                env=self.trading_environment,
             )
             self.history_specs[spec_key] = spec
             if not self.history_container:
@@ -1141,6 +1185,7 @@ class TradingAlgorithm(object):
                     self.datetime,
                     self.sim_params.data_frequency,
                     bar_data=self._most_recent_data,
+                    env=self.trading_environment,
                 )
             self.history_container.ensure_spec(
                 spec, self.datetime, self._most_recent_data,

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -46,6 +46,10 @@ log = Logger('assets.py')
 
 class AssetFinder(object):
 
+    # Token used as a substitute for pickling objects that contain a
+    # reference to an AssetFinder
+    PERSISTENT_TOKEN = "<AssetFinder>"
+
     def __init__(self, engine, allow_sid_assignment=True, fuzzy_char=None):
 
         self.fuzzy_char = fuzzy_char
@@ -160,7 +164,9 @@ class AssetFinder(object):
             else:
                 asset = None
 
-            self._asset_cache[sid] = asset
+            # Cache the asset if it has been retrieved
+            if asset is not None:
+                self._asset_cache[sid] = asset
 
         if asset is not None:
             return asset

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -394,3 +394,15 @@ class NoFurtherDataError(ZiplineError):
     # This accepts an arbitrary message string because it's used in more places
     # that can be usefully templated.
     msg = '{msg}'
+
+
+class PositionTrackerMissingAssetFinder(ZiplineError):
+    """
+    Raised by a PositionTracker if it is asked to update an Asset but does not
+    have an AssetFinder
+    """
+    msg = (
+        "PositionTracker attempted to update its Asset information but does "
+        "not have an AssetFinder. This may be caused by a failure to properly "
+        "de-serialize a TradingAlgorithm."
+    )

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -18,7 +18,6 @@ import logbook
 import math
 import numpy as np
 
-from zipline.finance import trading
 import zipline.utils.math_utils as zp_math
 
 import pandas as pd
@@ -91,10 +90,10 @@ class RiskMetricsCumulative(object):
         'information',
     )
 
-    def __init__(self, sim_params,
+    def __init__(self, sim_params, env,
                  create_first_day_stats=False,
                  account=None):
-        self.treasury_curves = trading.environment.treasury_curves
+        self.treasury_curves = env.treasury_curves
         self.start_date = sim_params.period_start.replace(
             hour=0, minute=0, second=0, microsecond=0
         )
@@ -102,15 +101,12 @@ class RiskMetricsCumulative(object):
             hour=0, minute=0, second=0, microsecond=0
         )
 
-        self.trading_days = trading.environment.days_in_range(
-            self.start_date,
-            self.end_date)
+        self.trading_days = env.days_in_range(self.start_date, self.end_date)
 
         # Hold on to the trading day before the start,
         # used for index of the zero return value when forcing returns
         # on the first day.
-        self.day_before_start = self.start_date - \
-            trading.environment.trading_days.freq
+        self.day_before_start = self.start_date - env.trading_days.freq
 
         last_day = normalize_date(sim_params.period_end)
         if last_day not in self.trading_days:
@@ -120,6 +116,7 @@ class RiskMetricsCumulative(object):
             self.trading_days = self.trading_days.append(last_day)
 
         self.sim_params = sim_params
+        self.env = env
 
         self.create_first_day_stats = create_first_day_stats
 
@@ -276,7 +273,8 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             treasury_period_return = choose_treasury(
                 self.treasury_curves,
                 self.start_date,
-                treasury_end
+                treasury_end,
+                self.env,
             )
             self.daily_treasury[treasury_end] = treasury_period_return
         self.treasury_period_return = self.daily_treasury[treasury_end]
@@ -459,18 +457,17 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         return beta
 
     def __getstate__(self):
-        state_dict = \
-            {k: v for k, v in iteritems(self.__dict__) if
-                (not k.startswith('_') and not k == 'treasury_curves')}
+        state_dict = {k: v for k, v in iteritems(self.__dict__)
+                      if not k.startswith('_')}
 
-        STATE_VERSION = 2
+        STATE_VERSION = 3
         state_dict[VERSION_LABEL] = STATE_VERSION
 
         return state_dict
 
     def __setstate__(self, state):
 
-        OLDEST_SUPPORTED_STATE = 2
+        OLDEST_SUPPORTED_STATE = 3
         version = state.pop(VERSION_LABEL)
 
         if version < OLDEST_SUPPORTED_STATE:
@@ -478,7 +475,3 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
                     saved state is too old.")
 
         self.__dict__.update(state)
-
-        # This are big and we don't need to serialize them
-        # pop them back in now
-        self.treasury_curves = trading.environment.treasury_curves

--- a/zipline/finance/risk/report.py
+++ b/zipline/finance/risk/report.py
@@ -72,7 +72,7 @@ log = logbook.Logger('Risk Report')
 
 
 class RiskReport(object):
-    def __init__(self, algorithm_returns, sim_params,
+    def __init__(self, algorithm_returns, sim_params, env,
                  benchmark_returns=None, algorithm_leverages=None):
         """
         algorithm_returns needs to be a list of daily_return objects
@@ -84,6 +84,7 @@ class RiskReport(object):
 
         self.algorithm_returns = algorithm_returns
         self.sim_params = sim_params
+        self.env = env
         self.benchmark_returns = benchmark_returns
         self.algorithm_leverages = algorithm_leverages
 
@@ -144,6 +145,7 @@ class RiskReport(object):
                 end_date=cur_end,
                 returns=self.algorithm_returns,
                 benchmark_returns=self.benchmark_returns,
+                env=self.env,
                 algorithm_leverages=self.algorithm_leverages,
             )
 
@@ -160,14 +162,14 @@ class RiskReport(object):
         if '_dividend_count' in dir(self):
             state_dict['_dividend_count'] = self._dividend_count
 
-        STATE_VERSION = 1
+        STATE_VERSION = 2
         state_dict[VERSION_LABEL] = STATE_VERSION
 
         return state_dict
 
     def __setstate__(self, state):
 
-        OLDEST_SUPPORTED_STATE = 1
+        OLDEST_SUPPORTED_STATE = 2
         version = state.pop(VERSION_LABEL)
 
         if version < OLDEST_SUPPORTED_STATE:

--- a/zipline/finance/risk/risk.py
+++ b/zipline/finance/risk/risk.py
@@ -62,7 +62,6 @@ import logbook
 import math
 import numpy as np
 
-from zipline.finance import trading
 import zipline.utils.math_utils as zp_math
 
 log = logbook.Logger('Risk')
@@ -203,8 +202,8 @@ def get_treasury_rate(treasury_curves, treasury_duration, day):
     return rate
 
 
-def search_day_distance(end_date, dt):
-    tdd = trading.environment.trading_day_distance(dt, end_date)
+def search_day_distance(end_date, dt, env):
+    tdd = env.trading_day_distance(dt, end_date)
     if tdd is None:
         return None
     assert tdd >= 0
@@ -238,7 +237,7 @@ def select_treasury_duration(start_date, end_date):
 
 
 def choose_treasury(select_treasury, treasury_curves, start_date, end_date,
-                    compound=True):
+                    env, compound=True):
     """
     Find the latest known interest rate for a given duration within a date
     range.
@@ -270,7 +269,7 @@ def choose_treasury(select_treasury, treasury_curves, start_date, end_date,
                                      prev_day)
             if rate is not None:
                 search_day = prev_day
-                search_dist = search_day_distance(end_date, prev_day)
+                search_dist = search_day_distance(end_date, prev_day, env)
                 break
 
         if search_day:

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -23,7 +23,6 @@ import numpy as np
 from . utils.protocol_utils import Enum
 from . utils.math_utils import nanstd, nanmean, nansum
 
-from zipline.finance.trading import with_environment
 from zipline.utils.algo_instance import get_algo_instance
 from zipline.utils.serialization_utils import (
     VERSION_LABEL
@@ -400,8 +399,7 @@ class SIDData(object):
         def daily_get_bars(days):
             return days
 
-        @with_environment()
-        def minute_get_bars(days, env=None):
+        def minute_get_bars(days):
             cls = self.__class__
 
             now = get_algo_instance().datetime
@@ -412,6 +410,7 @@ class SIDData(object):
             if days not in cls._minute_bar_cache:
                 # Cache this calculation to happen once per bar, even if we
                 # use another transform with the same number of days.
+                env = get_algo_instance().trading_environment
                 prev = env.previous_trading_day(now)
                 ds = env.days_in_range(
                     env.add_trading_days(-days + 2, prev),

--- a/zipline/sources/test_source.py
+++ b/zipline/sources/test_source.py
@@ -30,7 +30,6 @@ from zipline.protocol import (
     DATASOURCE_TYPE
 )
 from zipline.gens.utils import hash_args
-from zipline.finance.trading import with_environment
 
 
 def create_trade(sid, price, amount, datetime, source_id="test_factory"):
@@ -51,12 +50,11 @@ def create_trade(sid, price, amount, datetime, source_id="test_factory"):
     return trade
 
 
-@with_environment()
 def date_gen(start,
              end,
+             env,
              delta=timedelta(minutes=1),
-             repeats=None,
-             env=None):
+             repeats=None):
     """
     Utility to generate a stream of dates.
     """
@@ -111,10 +109,11 @@ class SpecificEquityTrades(object):
     delta  : timedelta between internal events
     filter : filter to remove the sids
     """
-    @with_environment()
-    def __init__(self, env=None, *args, **kwargs):
+    def __init__(self, env, *args, **kwargs):
         # We shouldn't get any positional arguments.
         assert len(args) == 0
+
+        self.env = env
 
         # Default to None for event_list and filter.
         self.event_list = kwargs.get('event_list')
@@ -206,12 +205,14 @@ class SpecificEquityTrades(object):
                     end=self.end,
                     delta=self.delta,
                     repeats=len(self.sids),
+                    env=self.env,
                 )
             else:
                 date_generator = date_gen(
                     start=self.start,
                     end=self.end,
-                    delta=self.delta
+                    delta=self.delta,
+                    env=self.env,
                 )
 
             source_id = self.get_hash()

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -28,8 +28,7 @@ from zipline.protocol import Event, DATASOURCE_TYPE
 from zipline.sources import (SpecificEquityTrades,
                              DataFrameSource,
                              DataPanelSource)
-from zipline.finance.trading import SimulationParameters
-from zipline.finance import trading
+from zipline.finance.trading import SimulationParameters, TradingEnvironment
 from zipline.sources.test_source import create_trade
 
 
@@ -44,16 +43,18 @@ def create_simulation_parameters(year=2006, start=None, end=None,
                                  capital_base=float("1.0e5"),
                                  num_days=None, load=None,
                                  data_frequency='daily',
-                                 emission_rate='daily'):
+                                 emission_rate='daily',
+                                 env=None):
     """Construct a complete environment with reasonable defaults"""
+    if env is None:
+        env = TradingEnvironment(load=load)
     if start is None:
         start = datetime(year, 1, 1, tzinfo=pytz.utc)
     if end is None:
         if num_days:
-            trading.environment = trading.TradingEnvironment(load=load)
-            start_index = trading.environment.trading_days.searchsorted(
+            start_index = env.trading_days.searchsorted(
                 start)
-            end = trading.environment.trading_days[start_index + num_days - 1]
+            end = env.trading_days[start_index + num_days - 1]
         else:
             end = datetime(year, 12, 31, tzinfo=pytz.utc)
     sim_params = SimulationParameters(
@@ -62,14 +63,15 @@ def create_simulation_parameters(year=2006, start=None, end=None,
         capital_base=capital_base,
         data_frequency=data_frequency,
         emission_rate=emission_rate,
+        env=env,
     )
 
     return sim_params
 
 
 def create_random_simulation_parameters():
-    trading.environment = trading.TradingEnvironment()
-    treasury_curves = trading.environment.treasury_curves
+    env = TradingEnvironment()
+    treasury_curves = env.treasury_curves
 
     for n in range(100):
 
@@ -92,30 +94,31 @@ check treasury and benchmark data in findb, and re-run the test."""
 
     sim_params = SimulationParameters(
         period_start=start_dt,
-        period_end=end_dt
+        period_end=end_dt,
+        env=env,
     )
 
     return sim_params, start_dt, end_dt
 
 
-def get_next_trading_dt(current, interval):
-    next_dt = pd.Timestamp(current).tz_convert(trading.environment.exchange_tz)
+def get_next_trading_dt(current, interval, env):
+    next_dt = pd.Timestamp(current).tz_convert(env.exchange_tz)
 
     while True:
         # Convert timestamp to naive before adding day, otherwise the when
         # stepping over EDT an hour is added.
         next_dt = pd.Timestamp(next_dt.replace(tzinfo=None))
         next_dt = next_dt + interval
-        next_dt = pd.Timestamp(next_dt, tz=trading.environment.exchange_tz)
+        next_dt = pd.Timestamp(next_dt, tz=env.exchange_tz)
         next_dt_utc = next_dt.tz_convert('UTC')
-        if trading.environment.is_market_hours(next_dt_utc):
+        if env.is_market_hours(next_dt_utc):
             break
-        next_dt = next_dt_utc.tz_convert(trading.environment.exchange_tz)
+        next_dt = next_dt_utc.tz_convert(env.exchange_tz)
 
     return next_dt_utc
 
 
-def create_trade_history(sid, prices, amounts, interval, sim_params,
+def create_trade_history(sid, prices, amounts, interval, sim_params, env,
                          source_id="test_factory"):
     trades = []
     current = sim_params.first_open
@@ -129,7 +132,7 @@ def create_trade_history(sid, prices, amounts, interval, sim_params,
             trade_dt = current
         trade = create_trade(sid, price, amount, trade_dt, source_id)
         trades.append(trade)
-        current = get_next_trading_dt(current, interval)
+        current = get_next_trading_dt(current, interval, env)
 
     assert len(trades) == len(prices)
     return trades
@@ -200,12 +203,12 @@ def create_commission(sid, value, datetime):
     return txn
 
 
-def create_txn_history(sid, priceList, amtList, interval, sim_params):
+def create_txn_history(sid, priceList, amtList, interval, sim_params, env):
     txns = []
     current = sim_params.first_open
 
     for price, amount in zip(priceList, amtList):
-        current = get_next_trading_dt(current, interval)
+        current = get_next_trading_dt(current, interval, env)
 
         txns.append(create_txn(sid, price, amount, current))
         current = current + interval
@@ -222,7 +225,7 @@ def create_returns_from_list(returns, sim_params):
                      data=returns)
 
 
-def create_daily_trade_source(sids, sim_params, concurrent=False):
+def create_daily_trade_source(sids, sim_params, env, concurrent=False):
     """
     creates trade_count trades for each sid in sids list.
     first trade will be on sim_params.period_start, and daily
@@ -233,11 +236,12 @@ def create_daily_trade_source(sids, sim_params, concurrent=False):
         sids,
         timedelta(days=1),
         sim_params,
-        concurrent=concurrent
+        env=env,
+        concurrent=concurrent,
     )
 
 
-def create_minutely_trade_source(sids, sim_params, concurrent=False):
+def create_minutely_trade_source(sids, sim_params, env, concurrent=False):
     """
     creates trade_count trades for each sid in sids list.
     first trade will be on sim_params.period_start, and every minute
@@ -248,16 +252,17 @@ def create_minutely_trade_source(sids, sim_params, concurrent=False):
         sids,
         timedelta(minutes=1),
         sim_params,
-        concurrent=concurrent
+        env=env,
+        concurrent=concurrent,
     )
 
 
-def create_trade_source(sids, trade_time_increment, sim_params,
+def create_trade_source(sids, trade_time_increment, sim_params, env,
                         concurrent=False):
 
     # If the sim_params define an end that is during market hours, that will be
     # used as the end of the data source
-    if trading.environment.is_market_hours(sim_params.period_end):
+    if env.is_market_hours(sim_params.period_end):
         end = sim_params.period_end
     # Otherwise, the last_close after the period_end is used as the end of the
     # data source
@@ -271,14 +276,15 @@ def create_trade_source(sids, trade_time_increment, sim_params,
         'end': end,
         'delta': trade_time_increment,
         'filter': sids,
-        'concurrent': concurrent
+        'concurrent': concurrent,
+        'env': env,
     }
     source = SpecificEquityTrades(*args, **kwargs)
 
     return source
 
 
-def create_test_df_source(sim_params=None, bars='daily'):
+def create_test_df_source(sim_params=None, env=None, bars='daily'):
     if bars == 'daily':
         freq = pd.datetools.BDay()
     elif bars == 'minute':
@@ -286,16 +292,16 @@ def create_test_df_source(sim_params=None, bars='daily'):
     else:
         raise ValueError('%s bars not understood.' % bars)
 
-    if sim_params:
+    if sim_params and bars == 'daily':
         index = sim_params.trading_days
     else:
-        if trading.environment is None:
-            trading.environment = trading.TradingEnvironment()
+        if env is None:
+            env = TradingEnvironment()
 
         start = pd.datetime(1990, 1, 3, 0, 0, 0, 0, pytz.utc)
         end = pd.datetime(1990, 1, 8, 0, 0, 0, 0, pytz.utc)
 
-        days = trading.environment.days_in_range(start, end)
+        days = env.days_in_range(start, end)
 
         if bars == 'daily':
             index = days
@@ -303,7 +309,7 @@ def create_test_df_source(sim_params=None, bars='daily'):
             index = pd.DatetimeIndex([], freq=freq)
 
             for day in days:
-                day_index = trading.environment.market_minutes_for_day(day)
+                day_index = env.market_minutes_for_day(day)
                 index = index.append(day_index)
 
     x = np.arange(1, len(index) + 1)
@@ -313,17 +319,17 @@ def create_test_df_source(sim_params=None, bars='daily'):
     return DataFrameSource(df), df
 
 
-def create_test_panel_source(sim_params=None, source_type=None):
+def create_test_panel_source(sim_params=None, env=None, source_type=None):
     start = sim_params.first_open \
         if sim_params else pd.datetime(1990, 1, 3, 0, 0, 0, 0, pytz.utc)
 
     end = sim_params.last_close \
         if sim_params else pd.datetime(1990, 1, 8, 0, 0, 0, 0, pytz.utc)
 
-    if trading.environment is None:
-        trading.environment = trading.TradingEnvironment()
+    if env is None:
+        env = TradingEnvironment()
 
-    index = trading.environment.days_in_range(start, end)
+    index = env.days_in_range(start, end)
 
     price = np.arange(0, len(index))
     volume = np.ones(len(index)) * 1000
@@ -343,17 +349,14 @@ def create_test_panel_source(sim_params=None, source_type=None):
     return DataPanelSource(panel), panel
 
 
-def create_test_panel_ohlc_source(sim_params=None):
+def create_test_panel_ohlc_source(sim_params, env):
     start = sim_params.first_open \
         if sim_params else pd.datetime(1990, 1, 3, 0, 0, 0, 0, pytz.utc)
 
     end = sim_params.last_close \
         if sim_params else pd.datetime(1990, 1, 8, 0, 0, 0, 0, pytz.utc)
 
-    if trading.environment is None:
-        trading.environment = trading.TradingEnvironment()
-
-    index = trading.environment.days_in_range(start, end)
+    index = env.days_in_range(start, end)
     price = np.arange(0, len(index)) + 100
     high = price * 1.05
     low = price * 0.95

--- a/zipline/utils/serialization_utils.py
+++ b/zipline/utils/serialization_utils.py
@@ -13,6 +13,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from six import BytesIO
+import pickle
+from functools import partial
+
+from zipline.assets import AssetFinder
+from zipline.finance.trading import TradingEnvironment
+
 # Label for the serialization version field in the state returned by
 # __getstate__.
 VERSION_LABEL = '_stateversion_'
+
+
+def _persistent_id(obj):
+    if isinstance(obj, AssetFinder):
+        return AssetFinder.PERSISTENT_TOKEN
+    if isinstance(obj, TradingEnvironment):
+        return TradingEnvironment.PERSISTENT_TOKEN
+    return None
+
+
+def _persistent_load(persid, env):
+    if persid == AssetFinder.PERSISTENT_TOKEN:
+        return env.asset_finder
+    if persid == TradingEnvironment.PERSISTENT_TOKEN:
+        return env
+
+
+def dump_with_persistent_ids(obj, protocol=None):
+    """
+    Performs a pickle dump on the given object, substituting all references to
+    a TradingEnvironment or AssetFinder with tokenized representations.
+
+    All arguments are passed to pickle.Pickler and are described therein.
+    """
+    file = BytesIO()
+    pickler = pickle.Pickler(file, protocol)
+    pickler.persistent_id = _persistent_id
+    pickler.dump(obj)
+    return file.getvalue()
+
+
+def load_with_persistent_ids(str, env):
+    """
+    Performs a pickle load on the given string, substituting the given
+    TradingEnvironment in to any tokenized representations of a
+    TradingEnvironment or AssetFinder.
+
+    Parameters
+    __________
+    str : String
+        The string representation of the object to be unpickled.
+    env : TradingEnvironment
+        The TradingEnvironment to be inserted to the unpickled object.
+
+    Returns
+    _______
+    obj
+       An unpickled object formed from the parameter 'str'.
+    """
+    file = BytesIO(str)
+    unpickler = pickle.Unpickler(file)
+    unpickler.persistent_load = partial(_persistent_load, env=env)
+    return unpickler.load()

--- a/zipline/utils/simfactory.py
+++ b/zipline/utils/simfactory.py
@@ -72,7 +72,8 @@ def create_test_zipline(**config):
         trade_source = factory.create_daily_trade_source(
             sid_list,
             test_algo.sim_params,
-            concurrent=concurrent_trades
+            test_algo.trading_environment,
+            concurrent=concurrent_trades,
         )
     if trade_source:
         test_algo.set_sources([trade_source])


### PR DESCRIPTION
This commit removes the ability to reference a shared TradingEnvironment through the zipline.finance.trading module. In place, the classes that require a TradingEnvironment, or its child AssetFinder, contain their own references to those objects. 

This commit also adds serialization utilities that allow for the pickling/unpickling of objects without unintentionally their TradingEnvironments or AssetFinders.