### PR TITLE
ENH: Return asset-indexed DataFrame for data.factors.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -242,6 +242,9 @@ class AssetFinder(object):
         else:
             raise SidNotFound(sid=sid)
 
+    def retrieve_all(self, sids, default_none=False):
+        return [self.retrieve_asset(sid) for sid in sids]
+
     def _retrieve_equity(self, sid):
         try:
             return self._equity_cache[sid]

--- a/zipline/modelling/engine.py
+++ b/zipline/modelling/engine.py
@@ -482,6 +482,12 @@ class SimpleFFCEngine(object):
         return DataFrame(
             dict(zip(factor_names, factor_outputs)),
             index=MultiIndex.from_arrays(
-                [raw_dates_index, raw_assets_index],
+                [
+                    raw_dates_index,
+                    # FUTURE OPTIMIZATION:
+                    # Avoid duplicate lookups by grouping and only looking up
+                    # each unique sid once.
+                    self._finder.retrieve_all(raw_assets_index),
+                ],
             )
         ).tz_localize('UTC', level=0)


### PR DESCRIPTION
This makes ordering with the returned assets much easier, and there's no
performance degradation for non-broadcasting operations on the Index.

Timings
-------

    from random import sample
    finder = AssetFinder(create_table=False, assets.db')
    assets = load_8000_assets(finder)
    AAPL = finder.retrieve_asset(24)
    RANDOM_ASSETS = sample(assets, 500)
    df = DataFrame(
        index=assets,
        data=np.random.randn(len(assets), 4),
        columns=['a', 'b', 'c', 'd'],
    )
    df_int = DataFrame(
        index=map(int, assets),
        data=np.random.randn(len(assets), 4),
        columns=['a', 'b', 'c', 'd'],
    )

    %timeit df.loc[24]
    %timeit df_int.loc[24]

    10000 loops, best of 3: 45.3 µs per loop
    10000 loops, best of 3: 44.7 µs per loop

    %timeit df.loc[AAPL]
    %timeit df_int.loc[AAPL]

    10000 loops, best of 3: 45.1 µs per loop
    10000 loops, best of 3: 44.8 µs per loop

    %timeit df.loc[RANDOM_ASSETS]
    %timeit df_int.loc[RANDOM_ASSETS]

    1000 loops, best of 3: 1.53 ms per loop
    100 loops, best of 3: 2.18 ms per loop

    %timeit df.sum()
    %timeit df_int.sum()

    10000 loops, best of 3: 56 µs per loop
    10000 loops, best of 3: 55.7 µs per loop

    %timeit df.index == 3
    %timeit df_int.index == 3

    1000 loops, best of 3: 253 µs per loop
    100000 loops, best of 3: 6.76 µs per loop

    %timeit df.iloc[:50]
    %timeit df_int.iloc[:50]

    10000 loops, best of 3: 44.3 µs per loop
    10000 loops, best of 3: 44 µs per loop