### PR TITLE
TEST: Run nosetests with timings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - conda install --yes -c https://conda.binstar.org/Quantopian numpy=$NUMPY_VERSION pandas=$PANDAS_VERSION scipy==$SCIPY_VERSION matplotlib Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
-  - pip install --upgrade pip nose-timer coverage
+  - pip install --upgrade pip coverage
   - pip install -e .[dev]
 before_script:
   - "flake8 zipline tests"

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -2,6 +2,7 @@
 nose==1.3.7
 nose-parameterized==0.5.0
 nose-ignore-docstring==0.2
+nose-timer==0.5.0
 xlrd==0.9.4
 
 # These are required by mock or its dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 verbosity=2
 detailed-errors=1
 with-ignore-docstrings=1
+with-timer=1
 
 [metadata]
 description-file = README.md


### PR DESCRIPTION
We already did this on travis.  Make it part of the normal test workflow
instead of a special case for travis.