### PR TITLE
Top bottom filters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ ext_modules = LazyCythonizingList([
     ('zipline.assets._assets', ['zipline/assets/_assets.pyx']),
     ('zipline.lib.adjusted_array', ['zipline/lib/adjusted_array.pyx']),
     ('zipline.lib.adjustment', ['zipline/lib/adjustment.pyx']),
+    ('zipline.lib.rank', ['zipline/lib/rank.pyx']),
     (
         'zipline.data.ffc.loaders._us_equity_pricing',
         ['zipline/data/ffc/loaders/_us_equity_pricing.pyx']

--- a/tests/modelling/base.py
+++ b/tests/modelling/base.py
@@ -1,0 +1,114 @@
+"""
+Base class for FFC unit tests.
+"""
+from functools import wraps
+from unittest import TestCase
+
+from numpy import arange, prod
+from numpy.random import randn, seed as random_seed
+from pandas import date_range, Int64Index, DataFrame
+from six import iteritems
+
+from zipline.assets import AssetFinder
+from zipline.modelling.engine import SimpleFFCEngine
+from zipline.modelling.graph import TermGraph
+from zipline.utils.test_utils import make_simple_asset_info, ExplodingObject
+from zipline.utils.tradingcalendar import trading_day
+
+
+def with_defaults(**default_funcs):
+    """
+    Decorator for providing dynamic default values for a method.
+
+    Usages:
+
+    @with_defaults(foo=lambda self: self.x + self.y)
+    def func(self, foo):
+        ...
+
+    If a value is passed for `foo`, it will be used. Otherwise the function
+    supplied to `with_defaults` will be called with `self` as an argument.
+    """
+    def decorator(f):
+        @wraps(f)
+        def method(self, *args, **kwargs):
+            for name, func in iteritems(default_funcs):
+                if name not in kwargs:
+                    kwargs[name] = func(self)
+            return f(self, *args, **kwargs)
+        return method
+    return decorator
+
+
+with_default_shape = with_defaults(shape=lambda self: self.default_shape)
+
+
+class BaseFFCTestCase(TestCase):
+
+    def setUp(self):
+        self.__calendar = date_range('2014', '2015', freq=trading_day)
+        self.__assets = assets = Int64Index(arange(1, 20))
+        self.__finder = AssetFinder(
+            make_simple_asset_info(
+                assets,
+                self.__calendar[0],
+                self.__calendar[-1],
+            ),
+            db_path=':memory:',
+            create_table=True,
+        )
+        self.__mask = self.__finder.lifetimes(self.__calendar[-10:])
+
+    @property
+    def default_shape(self):
+        """Default shape for methods that build test data."""
+        return self.__mask.shape
+
+    def run_terms(self, terms, initial_workspace, mask=None):
+        """
+        Compute the given terms, seeding the workspace of our FFCEngine with
+        `initial_workspace`.
+
+        Parameters
+        ----------
+        terms : dict
+            Mapping from termname -> term object.
+
+        Returns
+        -------
+        results : dict
+            Mapping from termname -> computed result.
+        """
+        engine = SimpleFFCEngine(
+            ExplodingObject(),
+            self.__calendar,
+            self.__finder,
+        )
+        mask = mask if mask is not None else self.__mask
+        return engine.compute_chunk(TermGraph(terms), mask, initial_workspace)
+
+    def build_mask(self, array):
+        ndates, nassets = array.shape
+        return DataFrame(
+            array,
+            # Use the **last** N dates rather than the first N so that we have
+            # space for lookbacks.
+            index=self.__calendar[-ndates:],
+            columns=self.__assets[:nassets],
+            dtype=bool,
+        )
+
+    @with_default_shape
+    def arange_data(self, shape, dtype=float):
+        """
+        Build a block of testing data from numpy.arange.
+        """
+        return arange(prod(shape), dtype=dtype).reshape(shape)
+
+    @with_default_shape
+    def randn_data(self, seed, shape):
+        """
+        Build a block of testing data from numpy.random.randn.
+        """
+        random_seed(seed)
+        return randn(*shape)

--- a/tests/modelling/test_factor.py
+++ b/tests/modelling/test_factor.py
@@ -1,21 +1,16 @@
 """
 Tests for Factor terms.
 """
-from unittest import TestCase
-
 from numpy import (
     array,
+    ones,
 )
-from numpy.testing import assert_array_equal
-from pandas import (
-    DataFrame,
-    date_range,
-    Int64Index,
-)
-from six import iteritems
 
 from zipline.errors import UnknownRankMethod
 from zipline.modelling.factor import TestingFactor
+from zipline.utils.test_utils import check_arrays
+
+from .base import BaseFFCTestCase
 
 
 class F(TestingFactor):
@@ -23,23 +18,17 @@ class F(TestingFactor):
     window_length = 0
 
 
-class FactorTestCase(TestCase):
+class FactorTestCase(BaseFFCTestCase):
 
     def setUp(self):
+        super(FactorTestCase, self).setUp()
         self.f = F()
-        self.dates = date_range('2014-01-01', periods=5, freq='D')
-        self.assets = Int64Index(range(5))
-        self.mask = DataFrame(True, index=self.dates, columns=self.assets)
-
-    def tearDown(self):
-        pass
 
     def test_bad_input(self):
-
         with self.assertRaises(UnknownRankMethod):
             self.f.rank("not a real rank method")
 
-    def test_rank(self):
+    def test_rank_ascending(self):
 
         # Generated with:
         # data = arange(25).reshape(5, 5).transpose() % 4
@@ -47,7 +36,7 @@ class FactorTestCase(TestCase):
                       [1, 2, 3, 0, 1],
                       [2, 3, 0, 1, 2],
                       [3, 0, 1, 2, 3],
-                      [0, 1, 2, 3, 0]])
+                      [0, 1, 2, 3, 0]], dtype=float)
         expected_ranks = {
             'ordinal': array([[1., 3., 4., 5., 2.],
                               [2., 4., 5., 1., 3.],
@@ -76,14 +65,73 @@ class FactorTestCase(TestCase):
                             [1., 2., 3., 4., 1.]]),
         }
 
-        # Test with the default, which should be 'ordinal'.
-        default_result = self.f.rank().compute_from_arrays([data], self.mask)
-        assert_array_equal(default_result, expected_ranks['ordinal'])
-
-        # Test with each method passed explicitly.
-        for method, expected_result in iteritems(expected_ranks):
-            result = self.f.rank(method=method).compute_from_arrays(
-                [data],
-                self.mask,
+        def check(terms):
+            results = self.run_terms(
+                terms,
+                initial_workspace={self.f: data},
+                mask=self.build_mask(ones((5, 5))),
             )
-            assert_array_equal(result, expected_ranks[method])
+            for method in terms:
+                check_arrays(results[method], expected_ranks[method])
+
+        check({meth: self.f.rank(method=meth) for meth in expected_ranks})
+        check({
+            meth: self.f.rank(method=meth, ascending=True)
+            for meth in expected_ranks
+        })
+        # Not passing a method should default to ordinal.
+        check({'ordinal': self.f.rank()})
+        check({'ordinal': self.f.rank(ascending=True)})
+
+    def test_rank_descending(self):
+
+        # Generated with:
+        # data = arange(25).reshape(5, 5).transpose() % 4
+        data = array([[0, 1, 2, 3, 0],
+                      [1, 2, 3, 0, 1],
+                      [2, 3, 0, 1, 2],
+                      [3, 0, 1, 2, 3],
+                      [0, 1, 2, 3, 0]], dtype=float)
+        expected_ranks = {
+            'ordinal': array([[4., 3., 2., 1., 5.],
+                              [3., 2., 1., 5., 4.],
+                              [2., 1., 5., 4., 3.],
+                              [1., 5., 4., 3., 2.],
+                              [4., 3., 2., 1., 5.]]),
+            'average': array([[4.5, 3., 2., 1., 4.5],
+                              [3.5, 2., 1., 5., 3.5],
+                              [2.5, 1., 5., 4., 2.5],
+                              [1.5, 5., 4., 3., 1.5],
+                              [4.5, 3., 2., 1., 4.5]]),
+            'min': array([[4., 3., 2., 1., 4.],
+                          [3., 2., 1., 5., 3.],
+                          [2., 1., 5., 4., 2.],
+                          [1., 5., 4., 3., 1.],
+                          [4., 3., 2., 1., 4.]]),
+            'max': array([[5., 3., 2., 1., 5.],
+                          [4., 2., 1., 5., 4.],
+                          [3., 1., 5., 4., 3.],
+                          [2., 5., 4., 3., 2.],
+                          [5., 3., 2., 1., 5.]]),
+            'dense': array([[4., 3., 2., 1., 4.],
+                            [3., 2., 1., 4., 3.],
+                            [2., 1., 4., 3., 2.],
+                            [1., 4., 3., 2., 1.],
+                            [4., 3., 2., 1., 4.]]),
+        }
+
+        def check(terms):
+            results = self.run_terms(
+                terms,
+                initial_workspace={self.f: data},
+                mask=self.build_mask(ones((5, 5))),
+            )
+            for method in terms:
+                check_arrays(results[method], expected_ranks[method])
+
+        check({
+            meth: self.f.rank(method=meth, ascending=False)
+            for meth in expected_ranks
+        })
+        # Not passing a method should default to ordinal.
+        check({'ordinal': self.f.rank(ascending=False)})

--- a/tests/modelling/test_filter.py
+++ b/tests/modelling/test_filter.py
@@ -1,28 +1,54 @@
 """
 Tests for filter terms.
 """
-from unittest import TestCase
+from operator import and_
 
 from numpy import (
     arange,
+    argsort,
     array,
     eye,
     float64,
+    full_like,
     nan,
     nanpercentile,
-    ones_like,
+    ones,
     putmask,
-)
-from numpy.testing import assert_array_equal
-
-from pandas import (
-    DataFrame,
-    date_range,
-    Int64Index,
 )
 
 from zipline.errors import BadPercentileBounds
 from zipline.modelling.factor import TestingFactor
+from zipline.utils.test_utils import check_arrays
+
+from .base import BaseFFCTestCase
+
+
+def rowwise_rank(array):
+    """
+    Take a 2D array and return the 0-indexed sorted position of each element in
+    the array for each row.
+
+    Example
+    -------
+    In [5]: data
+    Out[5]:
+    array([[-0.141, -1.103, -1.0171,  0.7812,  0.07  ],
+           [ 0.926,  0.235, -0.7698,  1.4552,  0.2061],
+           [ 1.579,  0.929, -0.557 ,  0.7896, -1.6279],
+           [-1.362, -2.411, -1.4604,  1.4468, -0.1885],
+           [ 1.272,  1.199, -3.2312, -0.5511, -1.9794]])
+
+    In [7]: argsort(argsort(data))
+    Out[7]:
+    array([[2, 0, 1, 4, 3],
+           [3, 2, 0, 4, 1],
+           [4, 3, 1, 2, 0],
+           [2, 0, 1, 4, 3],
+           [4, 3, 0, 2, 1]])
+    """
+    # note that unlike scipy.stats.rankdata, the output here is 0-indexed, not
+    # 1-indexed.
+    return argsort(argsort(array))
 
 
 class SomeFactor(TestingFactor):
@@ -30,23 +56,17 @@ class SomeFactor(TestingFactor):
     window_length = 0
 
 
-class FilterTestCase(TestCase):
+class SomeOtherFactor(TestingFactor):
+    inputs = ()
+    window_length = 0
+
+
+class FilterTestCase(BaseFFCTestCase):
 
     def setUp(self):
+        super(FilterTestCase, self).setUp()
         self.f = SomeFactor()
-        self.dates = date_range('2014-01-01', periods=5, freq='D')
-        self.assets = Int64Index(range(5))
-        self.mask = DataFrame(True, index=self.dates, columns=self.assets)
-
-    def tearDown(self):
-        pass
-
-    def maskframe(self, array):
-        return DataFrame(
-            array,
-            index=date_range('2014-01-01', periods=array.shape[0], freq='D'),
-            columns=arange(array.shape[1]),
-        )
+        self.g = SomeOtherFactor()
 
     def test_bad_percentiles(self):
         f = self.f
@@ -61,156 +81,214 @@ class FilterTestCase(TestCase):
             with self.assertRaises(BadPercentileBounds):
                 f.percentile_between(min_, max_)
 
-    def test_rank_percentile_nice_partitions(self):
-        # Test case with nicely-defined partitions.
+    def test_top(self):
+        counts = 2, 3, 10
+        data = self.randn_data(seed=5)  # Arbitrary seed choice.
+        results = self.run_terms(
+            terms={'top_' + str(c): self.f.top(c) for c in counts},
+            initial_workspace={self.f: data},
+        )
+        for c in counts:
+            result = results['top_' + str(c)]
+
+            # Check that `min(c, num_assets)` assets passed each day.
+            passed_per_day = result.sum(axis=1)
+            check_arrays(
+                passed_per_day,
+                full_like(passed_per_day, min(c, data.shape[1])),
+            )
+
+            # Check that the top `c` assets passed.
+            expected = rowwise_rank(-data) < c
+            check_arrays(result, expected)
+
+    def test_bottom(self):
+        counts = 2, 3, 10
+        data = self.randn_data(seed=5)  # Arbitrary seed choice.
+        results = self.run_terms(
+            terms={'bottom_' + str(c): self.f.bottom(c) for c in counts},
+            initial_workspace={self.f: data},
+        )
+        for c in counts:
+            result = results['bottom_' + str(c)]
+
+            # Check that `min(c, num_assets)` assets passed each day.
+            passed_per_day = result.sum(axis=1)
+            check_arrays(
+                passed_per_day,
+                full_like(passed_per_day, min(c, data.shape[1])),
+            )
+
+            # Check that the bottom `c` assets passed.
+            expected = rowwise_rank(data) < c
+            check_arrays(result, expected)
+
+    def test_percentile_between(self):
+
+        quintiles = range(5)
+        filter_names = ['pct_' + str(q) for q in quintiles]
+        iter_quintiles = zip(filter_names, quintiles)
+
+        terms = {
+            name: self.f.percentile_between(q * 20.0, (q + 1) * 20.0)
+            for name, q in zip(filter_names, quintiles)
+        }
+
+        # Test with 5 columns and no NaNs.
         eye5 = eye(5, dtype=float64)
-        eye6 = eye(6, dtype=float64)
-        nanmask = array([[0, 0, 0, 0, 0, 1],
-                         [1, 0, 0, 0, 0, 0],
-                         [0, 1, 0, 0, 0, 0],
-                         [0, 0, 1, 0, 0, 0],
-                         [0, 0, 0, 1, 0, 0],
-                         [0, 0, 0, 0, 1, 0]], dtype=bool)
-        nandata = eye6.copy()
-        putmask(nandata, nanmask, nan)
-
-        for quintile in range(5):
-            factor = self.f.percentile_between(
-                quintile * 20.0,
-                (quintile + 1) * 20.0,
-            )
-            # Test w/o any NaNs
-            result = factor.compute_from_arrays(
-                [eye5],
-                self.maskframe(ones_like(eye5, dtype=bool)),
-            )
-            # Test with NaNs in the data.
-            nandata_result = factor.compute_from_arrays(
-                [nandata],
-                self.maskframe(ones_like(nandata, dtype=bool)),
-            )
-            # Test with Falses in the mask.
-            nanmask_result = factor.compute_from_arrays(
-                [eye6],
-                self.maskframe(~nanmask),
-            )
-
-            assert_array_equal(nandata_result, nanmask_result)
-
+        results = self.run_terms(
+            terms,
+            initial_workspace={self.f: eye5},
+            mask=self.build_mask(ones((5, 5))),
+        )
+        for name, quintile in iter_quintiles:
+            result = results[name]
             if quintile < 4:
-                # There are 4 0s and one 1 in each row, so the first 4
+                # There are four 0s and one 1 in each row, so the first 4
                 # quintiles should be all the locations with zeros in the input
                 # array.
-                assert_array_equal(result, ~eye5.astype(bool))
-                # Should reject all the ones, plus the nans.
-                assert_array_equal(
-                    nandata_result,
-                    ~(nanmask | eye6.astype(bool))
-                )
-
+                check_arrays(result, ~eye5.astype(bool))
             else:
-                # The last quintile should contain all the 1s.
-                assert_array_equal(result, eye(5, dtype=bool))
-                # Should accept all the 1s.
-                assert_array_equal(nandata_result, eye(6, dtype=bool))
+                # The top quintile should match the sole 1 in each row.
+                check_arrays(result, eye5.astype(bool))
 
-    def test_rank_percentile_nasty_partitions(self):
-        # Test case with nasty partitions: divide up 5 assets into quartiles.
-        data = arange(25, dtype=float).reshape(5, 5) % 4
-        nandata = data.copy()
-        nandata[eye(5, dtype=bool)] = nan
-        for quartile in range(4):
-            lower_bound = quartile * 25.0
-            upper_bound = (quartile + 1) * 25.0
-            factor = self.f.percentile_between(lower_bound, upper_bound)
+        # Test with 6 columns, no NaNs, and one masked entry per day.
+        eye6 = eye(6, dtype=float64)
+        mask = array([[1, 1, 1, 1, 1, 0],
+                      [0, 1, 1, 1, 1, 1],
+                      [1, 0, 1, 1, 1, 1],
+                      [1, 1, 0, 1, 1, 1],
+                      [1, 1, 1, 0, 1, 1],
+                      [1, 1, 1, 1, 0, 1]], dtype=bool)
 
-            # There isn't a nice definition of correct behavior here, so for
-            # now we guarantee the behavior of numpy.nanpercentile.
-
-            result = factor.compute_from_arrays([data], self.mask)
-            min_value = nanpercentile(data, lower_bound, axis=1, keepdims=True)
-            max_value = nanpercentile(data, upper_bound, axis=1, keepdims=True)
-            assert_array_equal(
-                result,
-                (min_value <= data) & (data <= max_value),
-            )
-
-            nanresult = factor.compute_from_arrays([nandata], self.mask)
-            min_value = nanpercentile(
-                nandata,
-                lower_bound,
-                axis=1,
-                keepdims=True,
-            )
-            max_value = nanpercentile(
-                nandata,
-                upper_bound,
-                axis=1,
-                keepdims=True,
-            )
-            assert_array_equal(
-                nanresult,
-                (min_value <= nandata) & (nandata <= max_value),
-            )
-
-    def test_sequenced_filter(self):
-        first = SomeFactor() < 1
-        first_input = eye(5)
-        first_result = first.compute_from_arrays([first_input], self.mask)
-        assert_array_equal(first_result, ~eye(5, dtype=bool))
-
-        # Second should pick out the fourth column.
-        second = SomeFactor().eq(3.0)
-        second_input = arange(25, dtype=float).reshape(5, 5) % 5
-
-        sequenced = first.then(second)
-
-        result = sequenced.compute_from_arrays(
-            [first_result, second_input],
-            self.mask,
+        results = self.run_terms(
+            terms,
+            initial_workspace={self.f: eye6},
+            mask=self.build_mask(mask)
         )
-        expected_result = (first_result & (second_input == 3.0))
-        assert_array_equal(result, expected_result)
+        for name, quintile in iter_quintiles:
+            result = results[name]
+            if quintile < 4:
+                # Should keep all values that were 0 in the base data and were
+                # 1 in the mask.
+                check_arrays(result, mask & (~eye6.astype(bool))),
+            else:
+                # Should keep all the 1s in the base data.
+                check_arrays(result, eye6.astype(bool))
+
+        # Test with 6 columns, no mask, and one NaN per day.  Should have the
+        # same outcome as if we had masked the NaNs.
+        # In particular, the NaNs should never pass any filters.
+        eye6_withnans = eye6.copy()
+        putmask(eye6_withnans, ~mask, nan)
+        results = self.run_terms(
+            terms,
+            initial_workspace={self.f: eye6},
+            mask=self.build_mask(mask)
+        )
+        for name, quintile in iter_quintiles:
+            result = results[name]
+            if quintile < 4:
+                # Should keep all values that were 0 in the base data and were
+                # 1 in the mask.
+                check_arrays(result, mask & (~eye6.astype(bool))),
+            else:
+                # Should keep all the 1s in the base data.
+                check_arrays(result, eye6.astype(bool))
+
+    def test_percentile_nasty_partitions(self):
+        # Test percentile with nasty partitions: divide up 5 assets into
+        # quartiles.
+        # There isn't a nice mathematical definition of correct behavior here,
+        # so for now we guarantee the behavior of numpy.nanpercentile.  This is
+        # mostly for regression testing in case we write our own specialized
+        # percentile calculation at some point in the future.
+
+        data = arange(25, dtype=float).reshape(5, 5) % 4
+        quartiles = range(4)
+        filter_names = ['pct_' + str(q) for q in quartiles]
+
+        terms = {
+            name: self.f.percentile_between(q * 25.0, (q + 1) * 25.0)
+            for name, q in zip(filter_names, quartiles)
+        }
+        results = self.run_terms(
+            terms,
+            initial_workspace={self.f: data},
+            mask=self.build_mask(ones((5, 5))),
+        )
+
+        for name, quartile in zip(filter_names, quartiles):
+            result = results[name]
+            lower = quartile * 25.0
+            upper = (quartile + 1) * 25.0
+            expected = and_(
+                nanpercentile(data, lower, axis=1, keepdims=True) <= data,
+                data <= nanpercentile(data, upper, axis=1, keepdims=True),
+            )
+            check_arrays(result, expected)
+
+    def test_sequenced_filter_order_independent(self):
+        data = self.arange_data() % 5
+        results = self.run_terms(
+            {
+                # Sequencing is equivalent to &ing for commutative filters.
+                'sequenced': (1.5 < self.f).then(self.f < 3.5),
+                'anded': (1.5 < self.f) & (self.f < 3.5),
+            },
+            initial_workspace={self.f: data},
+        )
+        expected = (1.5 < data) & (data < 3.5)
+
+        check_arrays(results['sequenced'], expected)
+        check_arrays(results['anded'], expected)
 
     def test_sequenced_filter_order_dependent(self):
-        f = SomeFactor() < 1
+
+        first = self.f < 1
         f_input = eye(5)
-        f_result = f.compute_from_arrays([f_input], self.mask)
-        assert_array_equal(f_result, ~eye(5, dtype=bool))
 
-        g = SomeFactor().percentile_between(80, 100)
-        g_input = arange(25, dtype=float).reshape(5, 5) % 5
-        g_result = g.compute_from_arrays([g_input], self.mask)
-        assert_array_equal(g_result, g_input == 4)
+        second = self.g.percentile_between(80, 100)
+        g_input = arange(25, dtype=float).reshape(5, 5)
 
-        result = f.then(g).compute_from_arrays(
-            [f_result, g_input],
-            self.mask,
+        initial_mask = self.build_mask(ones((5, 5)))
+
+        terms = {
+            'first': first,
+            'second': second,
+            'sequenced': first.then(second),
+        }
+
+        results = self.run_terms(
+            terms,
+            initial_workspace={self.f: f_input, self.g: g_input},
+            mask=initial_mask,
         )
-        # Input data is strictly increasing, so the result should be the top
-        # value not filtered by first.
-        expected_result = array(
+
+        # First should pass everything but the diagonal.
+        check_arrays(results['first'], ~eye(5, dtype=bool))
+
+        # Second should pass the largest value each day.  Each row is strictly
+        # increasing, so we always select the last value.
+        expected_second = array(
             [[0, 0, 0, 0, 1],
              [0, 0, 0, 0, 1],
              [0, 0, 0, 0, 1],
              [0, 0, 0, 0, 1],
-             [0, 0, 0, 1, 0]],
+             [0, 0, 0, 0, 1]],
             dtype=bool,
         )
-        assert_array_equal(result, expected_result)
+        check_arrays(results['second'], expected_second)
 
-        result = g.then(f).compute_from_arrays(
-            [g_result, f_input],
-            self.mask,
-        )
-
-        # Percentile calculated first, then diagonal is removed.
-        expected_result = array(
+        # When sequencing, we should remove the diagonal as an option before
+        # computing percentiles.  On the last day, we should get the
+        # second-largest value, rather than the largest.
+        expected_sequenced = array(
             [[0, 0, 0, 0, 1],
              [0, 0, 0, 0, 1],
              [0, 0, 0, 0, 1],
              [0, 0, 0, 0, 1],
-             [0, 0, 0, 0, 0]],
+             [0, 0, 0, 1, 0]],  # Different from previous!
             dtype=bool,
         )
-        assert_array_equal(result, expected_result)
+        check_arrays(results['sequenced'], expected_sequenced)

--- a/tests/modelling/test_filter.py
+++ b/tests/modelling/test_filter.py
@@ -48,7 +48,7 @@ class FilterTestCase(TestCase):
             columns=arange(array.shape[1]),
         )
 
-    def test_bad_input(self):
+    def test_bad_percentiles(self):
         f = self.f
 
         bad_percentiles = [

--- a/tests/modelling/test_term.py
+++ b/tests/modelling/test_term.py
@@ -4,7 +4,6 @@ Tests for Term.
 from itertools import product
 from unittest import TestCase
 
-from networkx import topological_sort
 from numpy import (
     float32,
     uint32,
@@ -20,8 +19,8 @@ from zipline.errors import (
     TermInputsNotSpecified,
     WindowLengthNotSpecified,
 )
-from zipline.modelling.engine import build_dependency_graph
 from zipline.modelling.factor import Factor
+from zipline.modelling.graph import TermGraph
 from zipline.modelling.expression import NUMEXPR_MATH_FUNCS
 
 
@@ -69,6 +68,18 @@ def gen_equivalent_factors():
     yield SomeFactorAlias()
 
 
+def to_dict(l):
+    """
+    Convert a list to a dict with keys drawn from '0', '1', '2', ...
+
+    Example
+    -------
+    >>> to_dict([2, 3, 4])
+    {'0': 2, '1': 3, '2': 4}
+    """
+    return dict(zip(map(str, range(len(l))), l))
+
+
 class DependencyResolutionTestCase(TestCase):
 
     def setup(self):
@@ -81,12 +92,9 @@ class DependencyResolutionTestCase(TestCase):
         """
         Test dependency resolution for a single factor.
         """
-
-        build_dependency_graph([SomeFactor()])
-
         def check_output(graph):
 
-            resolution_order = topological_sort(graph)
+            resolution_order = list(graph.ordered())
 
             self.assertEqual(len(resolution_order), 3)
             self.assertEqual(
@@ -98,29 +106,29 @@ class DependencyResolutionTestCase(TestCase):
             self.assertEqual(graph.node[SomeDataSet.bar]['extra_rows'], 4)
 
         for foobar in gen_equivalent_factors():
-            check_output(build_dependency_graph([foobar]))
+            check_output(TermGraph(to_dict([foobar])))
 
     def test_single_factor_instance_args(self):
         """
         Test dependency resolution for a single factor with arguments passed to
         the constructor.
         """
-        graph = build_dependency_graph(
-            [SomeFactor([SomeDataSet.bar, SomeDataSet.buzz], window_length=5)]
-        )
-        resolution_order = topological_sort(graph)
+        bar, buzz = SomeDataSet.bar, SomeDataSet.buzz
+        graph = TermGraph(to_dict([SomeFactor([bar, buzz], window_length=5)]))
+
+        resolution_order = list(graph.ordered())
 
         self.assertEqual(len(resolution_order), 3)
         self.assertEqual(
             set([resolution_order[0], resolution_order[1]]),
-            set([SomeDataSet.bar, SomeDataSet.buzz]),
+            set([bar, buzz]),
         )
         self.assertEqual(
             resolution_order[-1],
-            SomeFactor([SomeDataSet.bar, SomeDataSet.buzz], window_length=5),
+            SomeFactor([bar, buzz], window_length=5),
         )
-        self.assertEqual(graph.node[SomeDataSet.bar]['extra_rows'], 4)
-        self.assertEqual(graph.node[SomeDataSet.buzz]['extra_rows'], 4)
+        self.assertEqual(graph.extra_rows[bar], 4)
+        self.assertEqual(graph.extra_rows[buzz], 4)
 
     def test_reuse_atomic_terms(self):
         """
@@ -129,8 +137,8 @@ class DependencyResolutionTestCase(TestCase):
         f1 = SomeFactor([SomeDataSet.foo, SomeDataSet.bar])
         f2 = SomeOtherFactor([SomeDataSet.bar, SomeDataSet.buzz])
 
-        graph = build_dependency_graph([f1, f2])
-        resolution_order = topological_sort(graph)
+        graph = TermGraph(to_dict([f1, f2]))
+        resolution_order = list(graph.ordered())
 
         # bar should only appear once.
         self.assertEqual(len(resolution_order), 5)

--- a/zipline/lib/rank.pyx
+++ b/zipline/lib/rank.pyx
@@ -1,0 +1,53 @@
+"""
+Functions for ranking and sorting.
+"""
+cimport cython
+from numpy cimport (
+    float64_t,
+    import_array,
+    intp_t,
+    ndarray,
+    NPY_DOUBLE,
+    NPY_MERGESORT,
+    PyArray_ArgSort,
+    PyArray_DIMS,
+    PyArray_EMPTY,
+)
+from numpy import nan
+
+import_array()
+
+
+cdef double NAN = nan
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.embedsignature(True)
+def rankdata_2d_ordinal(ndarray[float64_t, ndim=2] array):
+    """
+    Equivalent to:
+
+    numpy.apply_over_axis(scipy.stats.rankdata, 1, array, method='ordinal')
+    """
+    cdef:
+        int nrows, ncols
+        ndarray[intp_t, ndim=2] sort_idxs
+        ndarray[float64_t, ndim=2] out
+
+    nrows = array.shape[0]
+    ncols = array.shape[1]
+
+    # scipy.stats.rankdata explicitly uses MERGESORT instead of QUICKSORT for
+    # the ordinal branch.  c.f. commit ab21d2fee2d27daca0b2c161bbb7dba7e73e70ba
+    sort_idxs = PyArray_ArgSort(array, 1, NPY_MERGESORT)
+
+    # Roughly, "out = np.empty_like(array)"
+    out = PyArray_EMPTY(2, PyArray_DIMS(array), NPY_DOUBLE, False)
+
+    cdef intp_t i, j
+    for i in range(nrows):
+        for j in range(ncols):
+            out[i, sort_idxs[i, j]] = j + 1.0
+
+    return out

--- a/zipline/modelling/engine.py
+++ b/zipline/modelling/engine.py
@@ -325,6 +325,7 @@ class SimpleFFCEngine(object):
                     self._inputs_for_term(term, workspace, extra_rows),
                     base_mask_for_term,
                 )
+                assert(workspace[term].shape == base_mask_for_term.shape)
 
         out = {}
         for name, term in iteritems(graph.outputs):

--- a/zipline/modelling/engine.py
+++ b/zipline/modelling/engine.py
@@ -66,12 +66,7 @@ def build_dependency_graph(terms):
     dependencies = DiGraph()
     parents = set()
     for term in terms:
-        _add_to_graph(
-            term,
-            dependencies,
-            parents,
-            extra_rows=0,
-        )
+        _add_to_graph(term, dependencies, parents, extra_rows=0)
         # No parents should be left between top-level terms.
         assert not parents
     return dependencies

--- a/zipline/modelling/engine.py
+++ b/zipline/modelling/engine.py
@@ -149,10 +149,10 @@ class NoOpFFCEngine(FFCEngine):
     FFCEngine that doesn't do anything.
     """
 
-    def factor_matrix(self, terms, start, end):
+    def factor_matrix(self, terms, start_date, end_date):
         return DataFrame(
             index=MultiIndex.from_product(
-                [date_range(start=start, end=end, freq='D'), ()],
+                [date_range(start=start_date, end=end_date, freq='D'), ()],
             ),
             columns=sorted(terms.keys())
         )

--- a/zipline/modelling/graph.py
+++ b/zipline/modelling/graph.py
@@ -1,0 +1,116 @@
+"""
+FFC-specific extensions to networkx.DiGraph
+"""
+from networkx import (
+    DiGraph,
+    topological_sort,
+)
+from six import itervalues, iteritems
+
+
+class CyclicDependency(Exception):
+    pass
+
+
+class TermGraph(DiGraph):
+    """
+    Graph represention of FFC Term dependencies
+
+    Each node in the graph has an `extra_rows` attribute, indicating how many,
+    if any, extra rows we should compute for the node.  Extra rows are most
+    often needed when a term is an input to a rolling window computation.  For
+    example, if we compute a 30 day moving average of price from day X to day
+    Y, we need to load price data for the range from day (X - 29) to day Y.
+
+    Parameters
+    ----------
+    terms : dict
+        A dict mapping names to terms.
+
+    Attributes
+    ----------
+    outputs
+    extra_rows
+    max_extra_rows
+
+    Methods
+    -------
+    ordered()
+        Return a topologically-sorted iterator over the terms in self.
+    """
+    def __init__(self, terms):
+        super(TermGraph, self).__init__(self)
+        parents = set()
+        for term in itervalues(terms):
+            self._add_to_graph(term, parents, extra_rows=0)
+            # No parents should be left between top-level terms.
+            assert not parents
+
+        self._outputs = terms
+        self._extra_rows = {
+            term: attrs['extra_rows']
+            for term, attrs in iteritems(self.node)
+        }
+        self._max_extra_rows = max(itervalues(self._extra_rows))
+        self._ordered = topological_sort(self)
+
+    @property
+    def outputs(self):
+        """
+        Dict mapping names to designated output terms.
+        """
+        return self._outputs
+
+    @property
+    def extra_rows(self):
+        """
+        Dict mapping term -> number of extra rows to compute for term.
+        """
+        return self._extra_rows
+
+    @property
+    def max_extra_rows(self):
+        """
+        Maximum number of extra rows required to compute any term in the graph.
+        """
+        return self._max_extra_rows
+
+    def ordered(self):
+        """
+        Return a topologically-sorted iterator over the terms in `self`.
+        """
+        return iter(self._ordered)
+
+    def _add_to_graph(self, term, parents, extra_rows):
+        """
+        Add `term` and all its inputs to the graph.
+        """
+        # If we've seen this node already as a parent of the current traversal,
+        # it means we have an unsatisifiable dependency.  This should only be
+        # possible if the term's inputs are mutated after construction.
+        if term in parents:
+            raise CyclicDependency(term)
+        parents.add(term)
+
+        try:
+            existing = self.node[term]
+        except KeyError:
+            # `term` is not yet in the graph: add it with the specified number
+            # of extra rows.
+            self.add_node(term, extra_rows=extra_rows)
+        else:
+            # `term` is already in the graph because we've been traversed by
+            # another parent.  Ensure that we have enough extra rows to satisfy
+            # all of our parents.
+            existing['extra_rows'] = max(extra_rows, existing['extra_rows'])
+
+        extra_rows_for_subterms = extra_rows + term.extra_input_rows
+        for subterm in term.inputs:
+            self._add_to_graph(
+                subterm,
+                parents,
+                extra_rows=extra_rows_for_subterms
+            )
+            self.add_edge(subterm, term)
+
+        parents.remove(term)

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -322,3 +322,18 @@ def check_arrays(left, right, err_msg='', verbose=True):
     if type(left) != type(right):
         raise AssertionError("%s != %s" % (type(left), type(right)))
     return assert_array_equal(left, right, err_msg=err_msg, verbose=True)
+
+
+class UnexpectedAttributeAccess(Exception):
+    pass
+
+
+class ExplodingObject(object):
+    """
+    Object that will raise an exception on any attribute access.
+
+    Useful for verifying that an object is never touched during a
+    function/method call.
+    """
+    def __getattribute__(self, name):
+        raise UnexpectedAttributeAccess(name)


### PR DESCRIPTION
ENH: Improvements to rank()
======================

- Add an `ascending=True` keyword to `rank()`.

- Add `top(N)` and `bottom(N)` methods to Factor.  These return Filters
  that pass the top and bottom N elements each day.

- Add a slightly faster path for rank(method='ordinal').  I had
  originally thought the fast path was 2-3x faster because I had my
  benchmark data axes flipped.  The actual speedup is only 5-10%, which
  means it probably wasn't worth the effort to Cythonize...but we have a
  slightly faster version now so we might as well use it.

- Refactor test_filter and test_factor to make it easier to implement
  and test transformations on factors.  These tests now subclass
  BaseFFCTestCase, which provides facilities for passing a dict of terms
  and an "initial_workspace", the values for which are used by
  SimpleFFCEngine rather than needing to manually manage the inputs and
  outputs of each term.