### PR TITLE
PERF: Re-use the faster get_open_and_closes from tradingcalendar

### DIFF
--- a/zipline/utils/tradingcalendar.py
+++ b/zipline/utils/tradingcalendar.py
@@ -390,7 +390,7 @@ def get_open_and_close(day, early_closes):
     return market_open, market_close
 
 
-def get_open_and_closes(trading_days, early_closes):
+def get_open_and_closes(trading_days, early_closes, get_open_and_close):
     open_and_closes = pd.DataFrame(index=trading_days,
                                    columns=('market_open', 'market_close'))
 
@@ -401,4 +401,5 @@ def get_open_and_closes(trading_days, early_closes):
 
     return open_and_closes
 
-open_and_closes = get_open_and_closes(trading_days, early_closes)
+open_and_closes = get_open_and_closes(trading_days, early_closes,
+                                      get_open_and_close)

--- a/zipline/utils/tradingcalendar_bmf.py
+++ b/zipline/utils/tradingcalendar_bmf.py
@@ -18,7 +18,8 @@ import pytz
 
 from datetime import datetime
 from dateutil import rrule
-from zipline.utils.tradingcalendar import end, canonicalize_datetime
+from zipline.utils.tradingcalendar import end, canonicalize_datetime, \
+    get_open_and_closes
 
 start = pd.Timestamp('1994-01-01', tz='UTC')
 
@@ -288,33 +289,27 @@ def get_early_closes(start, end):
 early_closes = get_early_closes(start, end)
 
 
-def get_open_and_closes(trading_days, early_closes):
-    open_and_closes = pd.DataFrame(index=trading_days,
-                                   columns=('market_open', 'market_close'))
-    for day in trading_days:
-        # only "early close" event in Bovespa actually is a late start
-        # as the market only opens at 1pm
-        open_hour = 13 if day in quarta_cinzas else 10
-        market_open = pd.Timestamp(
-            datetime(
-                year=day.year,
-                month=day.month,
-                day=day.day,
-                hour=open_hour,
-                minute=00),
-            tz='America/Sao_Paulo').tz_convert('UTC')
-        market_close = pd.Timestamp(
-            datetime(
-                year=day.year,
-                month=day.month,
-                day=day.day,
-                hour=16),
-            tz='America/Sao_Paulo').tz_convert('UTC')
+def get_open_and_close(day, early_closes):
+    # only "early close" event in Bovespa actually is a late start
+    # as the market only opens at 1pm
+    open_hour = 13 if day in quarta_cinzas else 10
+    market_open = pd.Timestamp(
+        datetime(
+            year=day.year,
+            month=day.month,
+            day=day.day,
+            hour=open_hour,
+            minute=00),
+        tz='America/Sao_Paulo').tz_convert('UTC')
+    market_close = pd.Timestamp(
+        datetime(
+            year=day.year,
+            month=day.month,
+            day=day.day,
+            hour=16),
+        tz='America/Sao_Paulo').tz_convert('UTC')
 
-        open_and_closes.loc[day, 'market_open'] = market_open
-        open_and_closes.loc[day, 'market_close'] = market_close
+    return market_open, market_close
 
-    return open_and_closes
-
-
-open_and_closes = get_open_and_closes(trading_days, early_closes)
+open_and_closes = get_open_and_closes(trading_days, early_closes,
+                                      get_open_and_close)


### PR DESCRIPTION
Updated tradingcalendar_bmf and _tse to use the faster get_open_and_closes from tradingcalendar.

Before:
```
In [1]: %time import zipline.utils.tradingcalendar
CPU times: user 1.48 s, sys: 139 ms, total: 1.61 s
Wall time: 1.73 s

In [2]: %time import zipline.utils.tradingcalendar_bmf
CPU times: user 12.7 s, sys: 108 ms, total: 12.8 s
Wall time: 13.1 s

In [3]: %time import zipline.utils.tradingcalendar_tse
CPU times: user 12.1 s, sys: 108 ms, total: 12.2 s
Wall time: 12.4 s
```
After:
```
In [1]: %time import zipline.utils.tradingcalendar
CPU times: user 1.27 s, sys: 103 ms, total: 1.38 s
Wall time: 1.44 s

In [2]: %time import zipline.utils.tradingcalendar_bmf
CPU times: user 1.31 s, sys: 26.4 ms, total: 1.34 s
Wall time: 1.65 s

In [3]: %time import zipline.utils.tradingcalendar_tse
CPU times: user 773 ms, sys: 7.93 ms, total: 781 ms
Wall time: 782 ms
```