### PR TITLE
MAINT: Moves market_minutes_for_day into tradingcalendar

### DIFF
--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -354,8 +354,7 @@ class TradingEnvironment(object):
         return todays_minutes[0], todays_minutes[1]
 
     def market_minutes_for_day(self, stamp):
-        market_open, market_close = self.get_open_and_close(stamp)
-        return pd.date_range(market_open, market_close, freq='T')
+        return tradingcalendar.market_minutes_for_day(stamp)
 
     def open_close_window(self, start, count, offset=0, step=1):
         """

--- a/zipline/utils/tradingcalendar.py
+++ b/zipline/utils/tradingcalendar.py
@@ -403,3 +403,9 @@ def get_open_and_closes(trading_days, early_closes, get_open_and_close):
 
 open_and_closes = get_open_and_closes(trading_days, early_closes,
                                       get_open_and_close)
+
+
+def market_minutes_for_day(stamp):
+    index = open_and_closes.index.get_loc(stamp.date())
+    todays_minutes = open_and_closes.values[index]
+    return pd.date_range(todays_minutes[0], todays_minutes[1], freq='T')


### PR DESCRIPTION
This makes the function accessible directly from tradingcalendar. It previously was a method of TradingEnvironment, which meant you needed an env to use it.