### PR TITLE
MAINT: AssetFinder now takes fuzzy characters on look-up, not init

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -303,7 +303,7 @@ class AssetFinderTestCase(TestCase):
             ]
         )
         self.env.write_data(equities_df=frame)
-        finder = AssetFinder(self.env.engine, fuzzy_char='@')
+        finder = self.env.asset_finder
         asset_0, asset_1, asset_2 = (
             finder.retrieve_asset(i) for i in range(3)
         )
@@ -318,7 +318,7 @@ class AssetFinderTestCase(TestCase):
             # Adding an unnecessary fuzzy shouldn't matter.
             self.assertEqual(
                 asset_1,
-                finder.lookup_symbol('test@1', as_of, fuzzy=True)
+                finder.lookup_symbol('test@1', as_of, fuzzy_char='@')
             )
 
             # Shouldn't find this with no fuzzy_str passed.
@@ -326,7 +326,7 @@ class AssetFinderTestCase(TestCase):
             # Should find exact match.
             self.assertEqual(
                 asset_1,
-                finder.lookup_symbol('test1', as_of, fuzzy=True),
+                finder.lookup_symbol('test1', as_of, fuzzy_char='@'),
             )
 
     def test_lookup_symbol_resolve_multiple(self):

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -87,9 +87,8 @@ class AssetFinder(object):
     # reference to an AssetFinder
     PERSISTENT_TOKEN = "<AssetFinder>"
 
-    def __init__(self, engine, allow_sid_assignment=True, fuzzy_char=None):
+    def __init__(self, engine, allow_sid_assignment=True):
 
-        self.fuzzy_char = fuzzy_char
         self.allow_sid_assignment = allow_sid_assignment
 
         self.engine = engine
@@ -330,26 +329,26 @@ class AssetFinder(object):
                     ))
                 )
 
-    def lookup_symbol(self, symbol, as_of_date, fuzzy=False):
+    def lookup_symbol(self, symbol, as_of_date, fuzzy_char=None):
         """
         If a fuzzy string is provided, then we try various symbols based on
         the provided symbol.  This is to facilitate mapping from a broker's
         symbol to ours in cases where mapping to the broker's symbol loses
         information. For example, if we have CMCS_A, but a broker has CMCSA,
-        when the broker provides CMCSA, it can also provide fuzzy='_',
+        when the broker provides CMCSA, it can also provide fuzzy_char='_',
         so we can find a match by inserting an underscore.
         """
 
         symbol = symbol.upper()
         ad_value = pd.Timestamp(normalize_date(as_of_date)).value
 
-        if not fuzzy:
+        if fuzzy_char is None:
             try:
                 return self.lookup_symbol_resolve_multiple(symbol, as_of_date)
             except SymbolNotFound:
                 return None
 
-        fuzzy = symbol.replace(self.fuzzy_char, '')
+        fuzzy = symbol.replace(fuzzy_char, '')
 
         equities_cols = self.equities.c
         candidates = sa.select((equities_cols.sid,)).where(


### PR DESCRIPTION
Its more graceful for many applications to provide the Finder with a character on look-up, rather than provide a single fixed character on init.