### PR TITLE
ENH: Simplifies AssetFinder symbol lookup by making fuzzy lookup the …

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -503,7 +503,7 @@ class TestMiscellaneousAPI(TestCase):
         self.assertEqual(result.symbol, 'DUP')
 
         # By first calling set_symbol_lookup_date, the relevant asset
-        # should be returned by lookup_symbol_resolve_multiple
+        # should be returned by lookup_symbol
         for i, date in enumerate(dates):
             algo.set_symbol_lookup_date(date)
             result = algo.symbol('DUP')

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -292,12 +292,11 @@ class AssetFinderTestCase(TestCase):
             [
                 {
                     'sid': i,
-                    'symbol':  'TEST@%d' % i,
+                    'symbol':  'TEST.%d' % i,
                     'company_name': "company%d" % i,
                     'start_date': as_of.value,
                     'end_date': as_of.value,
-                    'exchange': uuid.uuid4().hex,
-                    'fuzzy': 'TEST%d' % i
+                    'exchange': uuid.uuid4().hex
                 }
                 for i in range(3)
             ]
@@ -308,25 +307,26 @@ class AssetFinderTestCase(TestCase):
             finder.retrieve_asset(i) for i in range(3)
         )
 
-        for i in range(2):  # we do it twice to test for caching bugs
+        # we do it twice to catch caching bugs
+        for i in range(2):
+            # Shouldn't find this with no fuzzy_str passed.
             self.assertIsNone(finder.lookup_symbol('test', as_of))
+            self.assertIsNone(finder.lookup_symbol('test1', as_of))
             self.assertEqual(
                 asset_1,
-                finder.lookup_symbol('test@1', as_of)
+                finder.lookup_symbol('test.1', as_of)
             )
 
             # Adding an unnecessary fuzzy shouldn't matter.
             self.assertEqual(
                 asset_1,
-                finder.lookup_symbol('test@1', as_of, fuzzy=True)
+                finder.lookup_symbol('test/1', as_of)
             )
 
-            # Shouldn't find this with no fuzzy_str passed.
-            self.assertIsNone(finder.lookup_symbol('test1', as_of))
             # Should find exact match.
             self.assertEqual(
                 asset_1,
-                finder.lookup_symbol('test1', as_of, fuzzy=True),
+                finder.lookup_symbol('test-1', as_of),
             )
 
     def test_lookup_symbol_resolve_multiple(self):

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -309,10 +309,13 @@ class AssetFinderTestCase(TestCase):
 
         # we do it twice to catch caching bugs
         for i in range(2):
-            self.assertIsNone(finder.lookup_symbol('test', as_of))
-            self.assertIsNone(finder.lookup_symbol('test1', as_of))
+            with self.assertRaises(SymbolNotFound):
+                finder.lookup_symbol('test', as_of)
+            with self.assertRaises(SymbolNotFound):
+                finder.lookup_symbol('test1', as_of)
             # '@' is not a supported delimiter
-            self.assertIsNone(finder.lookup_symbol('test@1', as_of))
+            with self.assertRaises(SymbolNotFound):
+                finder.lookup_symbol('test@1', as_of)
 
             # Adding an unnecessary fuzzy shouldn't matter.
             for fuzzy_char in ['-', '/', '_', '.']:
@@ -333,8 +336,10 @@ class AssetFinderTestCase(TestCase):
 
         # Try combos of looking up PRTYHRD with and without a time or fuzzy
         # Both non-fuzzys get no result
-        self.assertIsNone(finder.lookup_symbol('PRTYHRD', None))
-        self.assertIsNone(finder.lookup_symbol('PRTYHRD', dt))
+        with self.assertRaises(SymbolNotFound):
+            finder.lookup_symbol('PRTYHRD', None)
+        with self.assertRaises(SymbolNotFound):
+            finder.lookup_symbol('PRTYHRD', dt)
         # Both fuzzys work
         self.assertEqual(0, finder.lookup_symbol('PRTYHRD', None, fuzzy=True))
         self.assertEqual(0, finder.lookup_symbol('PRTYHRD', dt, fuzzy=True))
@@ -379,8 +384,7 @@ class AssetFinderTestCase(TestCase):
         finder = AssetFinder(self.env.engine)
         for _ in range(2):  # Run checks twice to test for caching bugs.
             with self.assertRaises(SymbolNotFound):
-                finder.lookup_symbol('non_existing', dates[0],
-                                     default_None=False)
+                finder.lookup_symbol('non_existing', dates[0])
 
             with self.assertRaises(MultipleSymbolsFound):
                 finder.lookup_symbol('existing', None)
@@ -388,11 +392,7 @@ class AssetFinderTestCase(TestCase):
             for i, date in enumerate(dates):
                 # Verify that we correctly resolve multiple symbols using
                 # the supplied date
-                result = finder.lookup_symbol(
-                    'existing',
-                    date,
-                    default_None=False,
-                )
+                result = finder.lookup_symbol('existing', date)
                 self.assertEqual(result.symbol, 'EXISTING')
                 self.assertEqual(result.sid, i)
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -312,24 +312,15 @@ class AssetFinderTestCase(TestCase):
             # Shouldn't find this with no fuzzy_str passed.
             self.assertIsNone(finder.lookup_symbol('test', as_of))
             self.assertIsNone(finder.lookup_symbol('test1', as_of))
-            self.assertEqual(
-                asset_1,
-                finder.lookup_symbol('test.1', as_of)
-            )
+            self.assertEqual(asset_1, finder.lookup_symbol('test.1', as_of))
 
             # Adding an unnecessary fuzzy shouldn't matter.
-            self.assertEqual(
-                asset_1,
-                finder.lookup_symbol('test/1', as_of)
-            )
+            self.assertEqual(asset_1, finder.lookup_symbol('test/1', as_of))
 
             # Should find exact match.
-            self.assertEqual(
-                asset_1,
-                finder.lookup_symbol('test-1', as_of),
-            )
+            self.assertEqual(asset_1, finder.lookup_symbol('test-1', as_of))
 
-    def test_lookup_symbol_resolve_multiple(self):
+    def test_lookup_symbol(self):
 
         # Incrementing by two so that start and end dates for each
         # generated Asset don't overlap (each Asset's end_date is the
@@ -351,19 +342,21 @@ class AssetFinderTestCase(TestCase):
         finder = AssetFinder(self.env.engine)
         for _ in range(2):  # Run checks twice to test for caching bugs.
             with self.assertRaises(SymbolNotFound):
-                finder.lookup_symbol_resolve_multiple('non_existing', dates[0])
+                finder.lookup_symbol('non_existing', dates[0],
+                                     default_None=False)
 
             with self.assertRaises(MultipleSymbolsFound):
-                finder.lookup_symbol_resolve_multiple('existing', None)
+                finder.lookup_symbol('existing', None)
 
             for i, date in enumerate(dates):
                 # Verify that we correctly resolve multiple symbols using
                 # the supplied date
-                result = finder.lookup_symbol_resolve_multiple(
+                result = finder.lookup_symbol(
                     'existing',
                     date,
+                    default_None=False,
                 )
-                self.assertEqual(result.symbol, 'existing')
+                self.assertEqual(result.symbol, 'EXISTING')
                 self.assertEqual(result.sid, i)
 
     @parameterized.expand(
@@ -422,11 +415,11 @@ class AssetFinderTestCase(TestCase):
         )
 
         self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].symbol, 'real')
+        self.assertEqual(results[0].symbol, 'REAL')
         self.assertEqual(results[0].sid, 0)
-        self.assertEqual(results[1].symbol, 'also_real')
+        self.assertEqual(results[1].symbol, 'ALSO_REAL')
         self.assertEqual(results[1].sid, 1)
-        self.assertEqual(results[2].symbol, 'real_but_old')
+        self.assertEqual(results[2].symbol, 'REAL_BUT_OLD')
         self.assertEqual(results[2].sid, 2)
 
         self.assertEqual(len(missing), 2)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -752,7 +752,6 @@ class TradingAlgorithm(object):
         return self.asset_finder.lookup_symbol(
             symbol_str,
             as_of_date=_lookup_date,
-            default_None=False,
         )
 
     @api_method

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -749,9 +749,10 @@ class TradingAlgorithm(object):
         _lookup_date = self._symbol_lookup_date if self._symbol_lookup_date is not None \
             else self.sim_params.period_end
 
-        return self.asset_finder.lookup_symbol_resolve_multiple(
+        return self.asset_finder.lookup_symbol(
             symbol_str,
-            as_of_date=_lookup_date
+            as_of_date=_lookup_date,
+            default_None=False,
         )
 
     @api_method

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -412,6 +412,14 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
         )
         equities_output = equities_output.join(split_symbols)
 
+        # Upper-case all symbol data
+        equities_output['symbol'] = \
+            equities_output.symbol.str.upper()
+        equities_output['company_symbol'] = \
+            equities_output.company_symbol.str.upper()
+        equities_output['share_class_symbol'] = \
+            equities_output.share_class_symbol.str.upper()
+
         # Convert date columns to UNIX Epoch integers (nanoseconds)
         equities_output['start_date'] = \
             equities_output['start_date'].apply(self.convert_datetime)

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -63,7 +63,6 @@ _equities_defaults = {
     'end_date': 2 ** 62 - 1,
     'first_traded': None,
     'exchange': None,
-    'fuzzy': None,
 }
 
 # Default values for the futures DataFrame
@@ -308,7 +307,6 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
             sa.Column('end_date', sa.Integer),
             sa.Column('first_traded', sa.Integer),
             sa.Column('exchange', sa.Text),
-            sa.Column('fuzzy', sa.Text),
         )
         self.futures_exchanges = sa.Table(
             'futures_exchanges',
@@ -405,6 +403,8 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
         if ('company_name' in data.equities.columns) \
                 and ('asset_name' not in data.equities.columns):
             data.equities['asset_name'] = data.equities['company_name']
+        if ('file_name' in data.equities.columns):
+            data.equities['symbol'] = data.equities['file_name']
 
         equities_output = _generate_output_dataframe(
             data_subset=data.equities,

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -4,7 +4,9 @@ from abc import (
 )
 from collections import namedtuple
 
+import re
 import pandas as pd
+import numpy as np
 from six import with_metaclass
 import sqlalchemy as sa
 
@@ -34,7 +36,10 @@ FUTURE_TABLE_FIELDS = ASSET_TABLE_FIELDS | {
 }
 
 # Expected fields for an Equity's metadata
-EQUITY_TABLE_FIELDS = ASSET_TABLE_FIELDS
+EQUITY_TABLE_FIELDS = ASSET_TABLE_FIELDS | {
+    'company_symbol',
+    'share_class_symbol',
+}
 
 EXCHANGE_TABLE_FIELDS = frozenset({
     'exchange',
@@ -87,6 +92,43 @@ _root_symbols_defaults = {
     'description': None,
     'exchange': None,
 }
+
+# Fuzzy symbol delimiters that may break up a company symbol and share class
+_fuzzy_symbol_delimiter_regex = r'[./\-_]'
+_fuzzy_symbol_default_triggers = frozenset({np.nan, None, ''})
+
+
+def split_fuzzy_symbol(fuzzy_symbol):
+    """
+    Takes in a symbol that may be fuzzy and splits it in to a company symbol
+    and share class symbol.
+
+    Parameters
+    ----------
+    fuzzy_symbol : str
+        The possibly-fuzzy symbol to be split
+
+    Returns
+    -------
+    ( str, str )
+        A tuple of ( company_symbol, share_class_symbol )
+    """
+    # return blank strings for any bad fuzzy symbols, like NaN or None
+    if fuzzy_symbol in _fuzzy_symbol_default_triggers:
+        return ('', '')
+
+    split_list = re.split(pattern=_fuzzy_symbol_delimiter_regex,
+                          string=fuzzy_symbol,
+                          maxsplit=1)
+
+    # Break the list up in to its two components, the company symbol and the
+    # share class symbol
+    company_symbol = split_list[0]
+    if len(split_list) > 1:
+        share_class_symbol = split_list[1]
+    else:
+        share_class_symbol = ''
+    return (company_symbol, share_class_symbol)
 
 
 def _generate_output_dataframe(data_subset, defaults):
@@ -163,7 +205,6 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
     """
     def write_all(self,
                   engine,
-                  fuzzy_char=None,
                   allow_sid_assignment=True,
                   constraints=True):
         """ Write pre-supplied data to SQLite.
@@ -172,8 +213,6 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
         ----------
         engine : Engine
             An SQLAlchemy engine to a SQL database.
-        fuzzy_char : str, optional
-            A string for use in fuzzy matching.
         allow_sid_assignment: bool, optional
             If True then the class can assign sids where necessary.
         constraints : bool, optional
@@ -192,7 +231,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
             self._write_exchanges(data.exchanges, txn)
             self._write_root_symbols(data.root_symbols, txn)
             self._write_futures(data.futures, txn)
-            self._write_equities(data.equities, fuzzy_char, txn)
+            self._write_equities(data.equities, txn)
 
     def _write_exchanges(self, exchanges, bind=None):
         recs = exchanges.reset_index().rename_axis(
@@ -222,11 +261,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
             self.asset_router.insert().values([(record['sid'], 'future')])\
                 .execute(bind=bind)
 
-    def _write_equities(self, equities, fuzzy_char, bind=None):
-        # Apply fuzzy matching.
-        if fuzzy_char:
-            equities['fuzzy'] = equities['symbol'].str.replace(fuzzy_char, '')
-
+    def _write_equities(self, equities, bind=None):
         recs = equities.reset_index().rename_axis(
             {'index': 'sid'},
             1,
@@ -258,6 +293,8 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 primary_key=constraints,
             ),
             sa.Column('symbol', sa.Text),
+            sa.Column('company_symbol', sa.Text),
+            sa.Column('share_class_symbol', sa.Text),
             sa.Column('asset_name', sa.Text),
             sa.Column('start_date', sa.Integer, default=0),
             sa.Column('end_date', sa.Integer),
@@ -365,6 +402,15 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
             data_subset=data.equities,
             defaults=_equities_defaults,
         )
+
+        # Split symbols to company_symbols and share_class_symbols
+        tuple_series = equities_output['symbol'].apply(split_fuzzy_symbol)
+        split_symbols = pd.DataFrame(
+            tuple_series.tolist(),
+            columns=['company_symbol', 'share_class_symbol'],
+            index=tuple_series.index
+        )
+        equities_output = equities_output.join(split_symbols)
 
         # Convert date columns to UNIX Epoch integers (nanoseconds)
         equities_output['start_date'] = \

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -261,16 +261,14 @@ class AssetFinder(object):
         self._future_cache[sid] = future
         return future
 
-    def lookup_symbol(self, symbol, as_of_date, default_None=True,
-                      fuzzy=False):
+    def lookup_symbol(self, symbol, as_of_date, fuzzy=False):
         """
         Return matching Equity of name symbol in database.
 
         If multiple Equities are found and as_of_date is not set,
         raises MultipleSymbolsFound.
 
-        If no Equity was active at as_of_date raises SymbolNotFound, or None
-        if default_None is true.
+        If no Equity was active at as_of_date raises SymbolNotFound.
         """
 
         # Format inputs
@@ -337,10 +335,7 @@ class AssetFinder(object):
                 if sid is not None:
                     return self._retrieve_equity(sid)
 
-            if default_None:
-                return None
-            else:
-                raise SymbolNotFound(symbol=symbol)
+            raise SymbolNotFound(symbol=symbol)
 
         else:
             # If this is a fuzzy look-up, check if there is exactly one match
@@ -359,10 +354,7 @@ class AssetFinder(object):
             if len(sids) == 1:
                 return self._retrieve_equity(sids[0]['sid'])
             elif not sids:
-                if default_None:
-                    return None
-                else:
-                    raise SymbolNotFound(symbol=symbol)
+                raise SymbolNotFound(symbol=symbol)
             else:
                 raise MultipleSymbolsFound(
                     symbol=symbol,
@@ -477,8 +469,7 @@ class AssetFinder(object):
         elif isinstance(asset_convertible, string_types):
             try:
                 matches.append(
-                    self.lookup_symbol(asset_convertible, as_of_date,
-                                       default_None=False)
+                    self.lookup_symbol(asset_convertible, as_of_date)
                 )
             except SymbolNotFound:
                 missing.append(asset_convertible)

--- a/zipline/utils/security_list.py
+++ b/zipline/utils/security_list.py
@@ -6,6 +6,8 @@ import pandas as pd
 import pytz
 import zipline
 
+from zipline.errors import SymbolNotFound
+
 
 DATE_FORMAT = "%Y%m%d"
 zipline_dir = os.path.dirname(zipline.__file__)
@@ -70,12 +72,13 @@ class SecurityList(object):
 
     def update_current(self, effective_date, symbols, change_func):
         for symbol in symbols:
-            asset = self.asset_finder.lookup_symbol(
-                symbol,
-                as_of_date=effective_date
-            )
+            try:
+                asset = self.asset_finder.lookup_symbol(
+                    symbol,
+                    as_of_date=effective_date
+                )
             # Pass if no Asset exists for the symbol
-            if asset is None:
+            except SymbolNotFound:
                 continue
             change_func(asset.sid)
 


### PR DESCRIPTION
…default

This branch adds two columns to the equities table: 'company_symbol' and 'share_class_symbol'.

Whenever a symbol is looked up in the equities table, the symbol is split on the first-occurring share class delimiter, and the search is performed using the split-up company and share-class symbols.

The symbols column is preserved, and its value is unchanged. This means that the Equity object returned has the 'symbol' columns value, meaning that the delimiter in the returned Equity is whatever delimiter came in on the original insertion.

@jdricklefs This is the change we discussed.
@kglowinski Thank you for your help!