### PR TITLE
Remove need for position values from lazy

### DIFF
--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -75,6 +75,7 @@ import logbook
 
 import numpy as np
 
+from collections import namedtuple
 from zipline.assets import Future
 
 try:
@@ -90,9 +91,47 @@ import zipline.protocol as zp
 from zipline.utils.serialization_utils import (
     VERSION_LABEL
 )
+from zipline.finance.performance.position_tracker import calc_position_stats
 
 log = logbook.Logger('Performance')
 TRADE_TYPE = zp.DATASOURCE_TYPE.TRADE
+
+
+PeriodStats = namedtuple('PeriodStats',
+                         ['net_liquidation',
+                          'gross_leverage',
+                          'net_leverage'])
+
+
+def calc_net_liquidation(ending_cash, long_value, short_value):
+    return ending_cash + long_value + short_value
+
+
+def calc_gross_leverage(gross_exposure, net_liq):
+    if net_liq != 0:
+        return gross_exposure / net_liq
+
+    return np.inf
+
+
+def calc_net_leverage(net_exposure, net_liq):
+    if net_liq != 0:
+        return net_exposure / net_liq
+
+    return np.inf
+
+
+def calc_period_stats(pos_stats, ending_cash):
+    net_liq = calc_net_liquidation(ending_cash,
+                                   pos_stats.long_value,
+                                   pos_stats.short_value)
+    gross_leverage = calc_gross_leverage(pos_stats.gross_exposure, net_liq)
+    net_leverage = calc_net_leverage(pos_stats.net_exposure, net_liq)
+
+    return PeriodStats(
+        net_liquidation=net_liq,
+        gross_leverage=gross_leverage,
+        net_leverage=net_leverage)
 
 
 class PerformancePeriod(object):
@@ -178,8 +217,9 @@ class PerformancePeriod(object):
 
     def calculate_performance(self):
         pt = self.position_tracker
-        self.ending_value = pt.calculate_positions_value()
-        self.ending_exposure = pt.calculate_positions_exposure()
+        pos_stats = calc_position_stats(pt)
+        self.ending_value = pos_stats.net_value
+        self.ending_exposure = pos_stats.net_exposure
 
         total_at_start = self.starting_cash + self.starting_value
         self.ending_cash = self.starting_cash + self.period_cash_flow
@@ -245,27 +285,10 @@ class PerformancePeriod(object):
     def position_amounts(self):
         return self.position_tracker.position_amounts
 
-    @property
-    def _net_liquidation_value(self):
-        pt = self.position_tracker
-        return self.ending_cash + pt._long_value() + pt._short_value()
-
-    def _gross_leverage(self):
-        net_liq = self._net_liquidation_value
-        if net_liq != 0:
-            return self.position_tracker._gross_exposure() / net_liq
-
-        return np.inf
-
-    def _net_leverage(self):
-        net_liq = self._net_liquidation_value
-        if net_liq != 0:
-            return self.position_tracker._net_exposure() / net_liq
-
-        return np.inf
-
     def __core_dict(self):
-        pt = self.position_tracker
+        pos_stats = calc_position_stats(self.position_tracker)
+        period_stats = calc_period_stats(pos_stats, self.ending_cash)
+
         rval = {
             'ending_value': self.ending_value,
             'ending_exposure': self.ending_exposure,
@@ -281,14 +304,14 @@ class PerformancePeriod(object):
             'returns': self.returns,
             'period_open': self.period_open,
             'period_close': self.period_close,
-            'gross_leverage': self._gross_leverage(),
-            'net_leverage': self._net_leverage(),
-            'short_exposure': pt._short_exposure(),
-            'long_exposure': pt._long_exposure(),
-            'short_value': pt._short_value(),
-            'long_value': pt._long_value(),
-            'longs_count': pt._longs_count(),
-            'shorts_count': pt._shorts_count()
+            'gross_leverage': period_stats.gross_leverage,
+            'net_leverage': period_stats.net_leverage,
+            'short_exposure': pos_stats.short_exposure,
+            'long_exposure': pos_stats.long_exposure,
+            'short_value': pos_stats.short_value,
+            'long_value': pos_stats.long_value,
+            'longs_count': pos_stats.longs_count,
+            'shorts_count': pos_stats.shorts_count,
         }
 
         return rval
@@ -367,6 +390,10 @@ class PerformancePeriod(object):
     def as_account(self):
         account = self._account_store
 
+        pt = self.position_tracker
+        pos_stats = calc_position_stats(pt)
+        period_stats = calc_period_stats(pos_stats, self.ending_cash)
+
         # If no attribute is found on the PerformancePeriod resort to the
         # following default values. If an attribute is found use the existing
         # value. For instance, a broker may provide updates to these
@@ -402,11 +429,12 @@ class PerformancePeriod(object):
                     self.ending_cash / (self.ending_cash + self.ending_value))
         account.day_trades_remaining = \
             getattr(self, 'day_trades_remaining', float('inf'))
-        account.leverage = \
-            getattr(self, 'leverage', self._gross_leverage())
-        account.net_leverage = self._net_leverage()
-        account.net_liquidation = \
-            getattr(self, 'net_liquidation', self._net_liquidation_value)
+        account.leverage = getattr(self, 'leverage',
+                                   period_stats.gross_leverage)
+        account.net_leverage = period_stats.net_leverage
+
+        account.net_liquidation = getattr(self, 'net_liquidation',
+                                          period_stats.net_liquidation)
         return account
 
     def __getstate__(self):

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -353,30 +353,6 @@ class PositionTracker(object):
                 price, amount, multiplier in iter_amount_price_multiplier
             ]
 
-    @property
-    def position_exposures(self):
-        iter_amount_price_multiplier = zip(
-            itervalues(self._position_amounts),
-            itervalues(self._position_last_sale_prices),
-            itervalues(self._position_exposure_multipliers),
-        )
-        return [
-            price * amount * multiplier for
-            price, amount, multiplier in iter_amount_price_multiplier
-        ]
-
-    def calculate_positions_value(self):
-        if len(self.position_values) == 0:
-            return np.float64(0)
-
-        return sum(self.position_values)
-
-    def calculate_positions_exposure(self):
-        if len(self.position_exposures) == 0:
-            return np.float64(0)
-
-        return sum(self.position_exposures)
-
     def handle_split(self, split):
         if split.sid in self.positions:
             # Make the position object handle the split. It returns the

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -45,8 +45,8 @@ def calc_position_values(amounts,
                          last_sale_prices,
                          value_multipliers):
     iter_amount_price_multiplier = zip(
-        itervalues(amounts),
-        itervalues(last_sale_prices),
+        amounts,
+        last_sale_prices,
         itervalues(value_multipliers),
     )
     return [
@@ -66,8 +66,8 @@ def calc_position_exposures(amounts,
                             last_sale_prices,
                             exposure_multipliers):
     iter_amount_price_multiplier = zip(
-        itervalues(amounts),
-        itervalues(last_sale_prices),
+        amounts,
+        last_sale_prices,
         itervalues(exposure_multipliers),
     )
     return [
@@ -116,10 +116,18 @@ def calc_net_exposure(position_exposures):
 
 
 def calc_position_stats(pt):
-    amounts = pt._position_amounts
-    last_sale_prices = pt._position_last_sale_prices
+
+    sids = []
+    amounts = []
+    last_sale_prices = []
     position_value_multipliers = pt._position_value_multipliers
     position_exposure_multipliers = pt._position_exposure_multipliers
+
+    for pos in pt.positions:
+        sids.append(pos.sid)
+        amounts.append(pos.amount)
+        last_sale_prices(pt._data_portal.get_current_price_data(
+            pos.sid, 'close'))
 
     position_values = calc_position_values(
         amounts,

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -4,6 +4,7 @@ import logbook
 import numpy as np
 import pandas as pd
 from pandas.lib import checknull
+from collections import namedtuple
 try:
     # optional cython based OrderedDict
     from cyordereddict import OrderedDict
@@ -25,6 +26,136 @@ from zipline.errors import PositionTrackerMissingAssetFinder
 from . position import positiondict
 
 log = logbook.Logger('Performance')
+
+
+PositionStats = namedtuple('PositionStats',
+                           ['net_exposure',
+                            'gross_value',
+                            'gross_exposure',
+                            'short_value',
+                            'short_exposure',
+                            'shorts_count',
+                            'long_value',
+                            'long_exposure',
+                            'longs_count',
+                            'net_value'])
+
+
+def calc_position_values(amounts,
+                         last_sale_prices,
+                         value_multipliers):
+    iter_amount_price_multiplier = zip(
+        itervalues(amounts),
+        itervalues(last_sale_prices),
+        itervalues(value_multipliers),
+    )
+    return [
+        price * amount * multiplier for
+        price, amount, multiplier in iter_amount_price_multiplier
+    ]
+
+
+def calc_net_value(position_values):
+    if len(position_values) == 0:
+        return np.float64(0)
+
+    return sum(position_values)
+
+
+def calc_position_exposures(amounts,
+                            last_sale_prices,
+                            exposure_multipliers):
+    iter_amount_price_multiplier = zip(
+        itervalues(amounts),
+        itervalues(last_sale_prices),
+        itervalues(exposure_multipliers),
+    )
+    return [
+        price * amount * multiplier for
+        price, amount, multiplier in iter_amount_price_multiplier
+    ]
+
+
+def calc_long_value(position_values):
+    return sum(i for i in position_values if i > 0)
+
+
+def calc_short_value(position_values):
+    return sum(i for i in position_values if i < 0)
+
+
+def calc_long_exposure(position_exposures):
+    return sum(i for i in position_exposures if i > 0)
+
+
+def calc_short_exposure(position_exposures):
+    return sum(i for i in position_exposures if i < 0)
+
+
+def calc_longs_count(position_exposures):
+    return sum(1 for i in position_exposures if i > 0)
+
+
+def calc_shorts_count(position_exposures):
+    return sum(1 for i in position_exposures if i < 0)
+
+
+def calc_gross_exposure(long_exposure, short_exposure):
+    return long_exposure + abs(short_exposure)
+
+
+def calc_gross_value(long_value, short_value):
+    return long_value + abs(short_value)
+
+
+def calc_net_exposure(position_exposures):
+    if len(position_exposures) == 0:
+        return np.float64(0)
+
+    return sum(position_exposures)
+
+
+def calc_position_stats(pt):
+    amounts = pt._position_amounts
+    last_sale_prices = pt._position_last_sale_prices
+    position_value_multipliers = pt._position_value_multipliers
+    position_exposure_multipliers = pt._position_exposure_multipliers
+
+    position_values = calc_position_values(
+        amounts,
+        last_sale_prices,
+        position_value_multipliers
+    )
+
+    position_exposures = calc_position_exposures(
+        amounts,
+        last_sale_prices,
+        position_exposure_multipliers
+    )
+
+    long_value = calc_long_value(position_values)
+    short_value = calc_short_value(position_values)
+    gross_value = calc_gross_value(long_value, short_value)
+    long_exposure = calc_long_exposure(position_exposures)
+    short_exposure = calc_short_exposure(position_exposures)
+    gross_exposure = calc_gross_exposure(long_exposure, short_exposure)
+    net_exposure = calc_net_exposure(position_exposures)
+    longs_count = calc_longs_count(position_exposures)
+    shorts_count = calc_shorts_count(position_exposures)
+    net_value = calc_net_value(position_values)
+
+    return PositionStats(
+        long_value=long_value,
+        gross_value=gross_value,
+        short_value=short_value,
+        long_exposure=long_exposure,
+        short_exposure=short_exposure,
+        gross_exposure=gross_exposure,
+        net_exposure=net_exposure,
+        longs_count=longs_count,
+        shorts_count=shorts_count,
+        net_value=net_value
+    )
 
 
 class PositionTracker(object):
@@ -245,36 +376,6 @@ class PositionTracker(object):
             return np.float64(0)
 
         return sum(self.position_exposures)
-
-    def _longs_count(self):
-        return sum(1 for i in self.position_exposures if i > 0)
-
-    def _long_exposure(self):
-        return sum(i for i in self.position_exposures if i > 0)
-
-    def _long_value(self):
-        return sum(i for i in self.position_values if i > 0)
-
-    def _shorts_count(self):
-        return sum(1 for i in self.position_exposures if i < 0)
-
-    def _short_exposure(self):
-        return sum(i for i in self.position_exposures if i < 0)
-
-    def _short_value(self):
-        return sum(i for i in self.position_values if i < 0)
-
-    def _gross_exposure(self):
-        return self._long_exposure() + abs(self._short_exposure())
-
-    def _gross_value(self):
-        return self._long_value() + abs(self._short_value())
-
-    def _net_exposure(self):
-        return self.calculate_positions_exposure()
-
-    def _net_value(self):
-        return self.calculate_positions_value()
 
     def handle_split(self, split):
         if split.sid in self.positions:


### PR DESCRIPTION
Only access position values once during stat calc.

Instead of calculating the position values for each stat result, e.g.
gross_exposure, net_liquidity etc. get the positions upfront and then
calculate the period and position stats in order, passing each value
explicitly to the ones that follow it in the dependency chain.

On the path for wiring up DataPortal, so that the upkeep of
last_sale_price can be removed in favor accessing those values on demand.
