### PR TITLE
Enable test algorithm

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -100,7 +100,10 @@ from zipline.algorithm import TradingAlgorithm
 from zipline.finance.trading import TradingEnvironment
 from zipline.finance.commission import PerShare
 
-from .utils.test_utils import create_data_portal
+from .utils.test_utils import (
+    create_data_portal,
+    create_data_portal_from_trade_history
+)
 
 # Because test cases appear to reuse some resources.
 
@@ -1443,11 +1446,21 @@ class TestAccountControls(TestCase):
 
         cls.tempdir = TempDirectory()
 
-        cls.data_portal = create_data_portal(
-            cls.env,
-            cls.tempdir,
+        trade_history = factory.create_trade_history(
+            cls.sidint,
+            [10.0, 10.0, 11.0, 11.0],
+            [100, 100, 100, 300],
+            timedelta(days=1),
             cls.sim_params,
-            [cls.sidint]
+            cls.env,
+        )
+
+        cls.data_portal = create_data_portal_from_trade_history(
+            cls.tempdir,
+            cls.sidint,
+            trade_history,
+            cls.sim_params,
+            cls.env,
         )
 
     @classmethod

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -750,11 +750,30 @@ class TestAlgoScript(TestCase):
 
         cls.env.write_data(equities_data=equities_metadata)
 
-        cls.data_portal = create_data_portal(
-            cls.env,
+        days = 251
+
+        trades_by_sid = {
+            0: factory.create_trade_history(
+                0,
+                [10.0] * days,
+                [100] * days,
+                timedelta(days=1),
+                cls.sim_params,
+                cls.env),
+            3: factory.create_trade_history(
+                3,
+                [10.0] * days,
+                [100] * days,
+                timedelta(days=1),
+                cls.sim_params,
+                cls.env)
+        }
+
+        cls.data_portal = create_data_portal_from_trade_history(
             cls.tempdir,
+            trades_by_sid,
             cls.sim_params,
-            cls.sids,
+            cls.env,
         )
 
         cls.zipline_test_config = {
@@ -1445,19 +1464,20 @@ class TestAccountControls(TestCase):
 
         cls.tempdir = TempDirectory()
 
-        trade_history = factory.create_trade_history(
-            cls.sidint,
-            [10.0, 10.0, 11.0, 11.0],
-            [100, 100, 100, 300],
-            timedelta(days=1),
-            cls.sim_params,
-            cls.env,
-        )
+        trades_by_sid = {
+            cls.sidint: factory.create_trade_history(
+                cls.sidint,
+                [10.0, 10.0, 11.0, 11.0],
+                [100, 100, 100, 300],
+                timedelta(days=1),
+                cls.sim_params,
+                cls.env,
+            )
+        }
 
         cls.data_portal = create_data_portal_from_trade_history(
             cls.tempdir,
-            cls.sidint,
-            trade_history,
+            trades_by_sid,
             cls.sim_params,
             cls.env,
         )

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -769,12 +769,10 @@ class TestAlgoScript(TestCase):
                 cls.env)
         }
 
-        cls.data_portal = create_data_portal_from_trade_history(
-            cls.tempdir,
-            trades_by_sid,
-            cls.sim_params,
-            cls.env,
-        )
+        cls.data_portal = create_data_portal_from_trade_history(cls.env,
+                                                                cls.tempdir,
+                                                                cls.sim_params,
+                                                                trades_by_sid)
 
         cls.zipline_test_config = {
             'sid': 0,
@@ -909,8 +907,9 @@ def handle_data(context, data):
         trades = factory.create_daily_trade_source(
             [0], self.sim_params, self.env)
         tempdir = TempDirectory()
-        data_portal = create_data_portal_from_trade_history(
-            tempdir, {0: trades}, self.sim_params, self.env)
+        data_portal = create_data_portal_from_trade_history(self.env, tempdir,
+                                                            self.sim_params,
+                                                            {0: trades})
         test_algo.data_portal = data_portal
 
         self.zipline_test_config['algorithm'] = test_algo
@@ -1480,12 +1479,10 @@ class TestAccountControls(TestCase):
             )
         }
 
-        cls.data_portal = create_data_portal_from_trade_history(
-            cls.tempdir,
-            trades_by_sid,
-            cls.sim_params,
-            cls.env,
-        )
+        cls.data_portal = create_data_portal_from_trade_history(cls.env,
+                                                                cls.tempdir,
+                                                                cls.sim_params,
+                                                                trades_by_sid)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -906,6 +906,12 @@ def handle_data(context, data):
             env=self.env,
         )
         set_algo_instance(test_algo)
+        trades = factory.create_daily_trade_source(
+            [0], self.sim_params, self.env)
+        tempdir = TempDirectory()
+        data_portal = create_data_portal_from_trade_history(
+            tempdir, {0: trades}, self.sim_params, self.env)
+        test_algo.data_portal = data_portal
 
         self.zipline_test_config['algorithm'] = test_algo
         self.zipline_test_config['trade_count'] = 100
@@ -923,8 +929,7 @@ def handle_data(context, data):
 # https://www.dropbox.com/s/ulrk2qt0nrtrigb/Volume%20Share%20Worksheet.xlsx
         self.zipline_test_config['expected_transactions'] = 67
 
-        zipline = simfactory.create_test_zipline(
-            **self.zipline_test_config)
+        zipline = test_algo.get_generator()
         output, _ = assert_single_position(self, zipline)
 
         # confirm the slippage and commission on a sample

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -828,7 +828,6 @@ def handle_data(context, data):
             env=self.env,
         )
         test_algo.run(self.data_portal)
-        import pdb; pdb.set_trace()
         z = 5
 
         # set_algo_instance(test_algo)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -874,71 +874,73 @@ def handle_data(context, data):
         # self.assertEqual(expected_price, transaction['price'])
 
     def test_volshare_slippage(self):
-        # verify order -> transaction -> portfolio position.
-        # --------------
-        test_algo = TradingAlgorithm(
-            script="""
-from zipline.api import *
-
-def initialize(context):
-    model = slippage.VolumeShareSlippage(
-                            volume_limit=.3,
-                            price_impact=0.05
-                       )
-    set_slippage(model)
-    set_commission(commission.PerShare(0.02))
-    context.count = 2
-    context.incr = 0
-
-def handle_data(context, data):
-    if context.incr < context.count:
-        # order small lots to be sure the
-        # order will fill in a single transaction
-        order(sid(0), 5000)
-    record(price=data[0].price)
-    record(volume=data[0].volume)
-    record(incr=context.incr)
-    context.incr += 1
-    """,
-            sim_params=self.sim_params,
-            env=self.env,
-        )
-        set_algo_instance(test_algo)
-        trades = factory.create_daily_trade_source(
-            [0], self.sim_params, self.env)
         tempdir = TempDirectory()
-        data_portal = create_data_portal_from_trade_history(self.env, tempdir,
-                                                            self.sim_params,
-                                                            {0: trades})
-        test_algo.data_portal = data_portal
+        try:
+            # verify order -> transaction -> portfolio position.
+            # --------------
+            test_algo = TradingAlgorithm(
+                script="""
+    from zipline.api import *
 
-        self.zipline_test_config['algorithm'] = test_algo
-        self.zipline_test_config['trade_count'] = 100
+    def initialize(context):
+        model = slippage.VolumeShareSlippage(
+                                volume_limit=.3,
+                                price_impact=0.05
+                           )
+        set_slippage(model)
+        set_commission(commission.PerShare(0.02))
+        context.count = 2
+        context.incr = 0
 
-        # 67 will be used inside assert_single_position
-        # to confirm we have as many transactions as expected.
-        # The algo places 2 trades of 5000 shares each. The trade
-        # events have volume ranging from 100 to 950. The volume cap
-        # of 0.3 limits the trade volume to a range of 30 - 316 shares.
-        # The spreadsheet linked below calculates the total position
-        # size over each bar, and predicts 67 txns will be required
-        # to fill the two orders. The number of bars and transactions
-        # differ because some bars result in multiple txns. See
-        # spreadsheet for details:
-# https://www.dropbox.com/s/ulrk2qt0nrtrigb/Volume%20Share%20Worksheet.xlsx
-        self.zipline_test_config['expected_transactions'] = 67
+    def handle_data(context, data):
+        if context.incr < context.count:
+            # order small lots to be sure the
+            # order will fill in a single transaction
+            order(sid(0), 5000)
+        record(price=data[0].price)
+        record(volume=data[0].volume)
+        record(incr=context.incr)
+        context.incr += 1
+        """,
+                sim_params=self.sim_params,
+                env=self.env,
+            )
+            set_algo_instance(test_algo)
+            trades = factory.create_daily_trade_source(
+                [0], self.sim_params, self.env)
+            data_portal = create_data_portal_from_trade_history(
+                self.env, tempdir, self.sim_params, {0: trades})
+            test_algo.data_portal = data_portal
 
-        zipline = test_algo.get_generator()
-        output, _ = assert_single_position(self, zipline)
+            self.zipline_test_config['algorithm'] = test_algo
+            self.zipline_test_config['trade_count'] = 100
 
-        # confirm the slippage and commission on a sample
-        # transaction
-        per_share_commish = 0.02
-        perf = output[1]
-        transaction = perf['daily_perf']['transactions'][0]
-        commish = transaction['amount'] * per_share_commish
-        self.assertEqual(commish, transaction['commission'])
-        self.assertEqual(2.029, transaction['price'])
+            # 67 will be used inside assert_single_position
+            # to confirm we have as many transactions as expected.
+            # The algo places 2 trades of 5000 shares each. The trade
+            # events have volume ranging from 100 to 950. The volume cap
+            # of 0.3 limits the trade volume to a range of 30 - 316 shares.
+            # The spreadsheet linked below calculates the total position
+            # size over each bar, and predicts 67 txns will be required
+            # to fill the two orders. The number of bars and transactions
+            # differ because some bars result in multiple txns. See
+            # spreadsheet for details:
+    # https://www.dropbox.com/s/ulrk2qt0nrtrigb/Volume%20Share%20Worksheet.xlsx
+            self.zipline_test_config['expected_transactions'] = 67
+
+            zipline = test_algo.get_generator()
+            output, _ = assert_single_position(self, zipline)
+
+            # confirm the slippage and commission on a sample
+            # transaction
+            per_share_commish = 0.02
+            perf = output[1]
+            transaction = perf['daily_perf']['transactions'][0]
+            commish = transaction['amount'] * per_share_commish
+            self.assertEqual(commish, transaction['commission'])
+            self.assertEqual(2.029, transaction['price'])
+        finally:
+            tempdir.cleanup()
 
     def test_algo_record_vars(self):
         test_algo = TradingAlgorithm(

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -64,12 +64,11 @@ def create_data_portal(env, tempdir, sim_params, sids):
         )
 
 
-def create_data_portal_from_trade_history(
-        tempdir, trades_by_sid, sim_params, env):
+def create_data_portal_from_trade_history(env, tempdir, sim_params,
+                                          trades_by_sid):
     if sim_params.data_frequency == "daily":
         path = os.path.join(tempdir.path, "testdaily.bcolz")
         assets = {}
-        length = sim_params.days_in_period
         for sidint, trades in trades_by_sid.iteritems():
             opens = []
             highs = []

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -65,30 +65,31 @@ def create_data_portal(env, tempdir, sim_params, sids):
 
 
 def create_data_portal_from_trade_history(
-        tempdir, sidint, trades, sim_params, env):
+        tempdir, trades_by_sid, sim_params, env):
     if sim_params.data_frequency == "daily":
         path = os.path.join(tempdir.path, "testdaily.bcolz")
         assets = {}
         length = sim_params.days_in_period
-        opens = []
-        highs = []
-        lows = []
-        closes = []
-        volumes = []
-        for trade in trades:
-            opens.append(trade.open_price)
-            highs.append(trade.high)
-            lows.append(trade.low)
-            closes.append(trade.close_price)
-            volumes.append(trade.volume)
-        assets[sidint] = pd.DataFrame({
-            "open": np.array(opens),
-            "high": np.array(highs),
-            "low": np.array(lows),
-            "close": np.array(closes),
-            "volume": np.array(volumes),
-            "day": [day.value for day in sim_params.trading_days]
-        }, index=sim_params.trading_days)
+        for sidint, trades in trades_by_sid.iteritems():
+            opens = []
+            highs = []
+            lows = []
+            closes = []
+            volumes = []
+            for trade in trades:
+                opens.append(trade.open_price)
+                highs.append(trade.high)
+                lows.append(trade.low)
+                closes.append(trade.close_price)
+                volumes.append(trade.volume)
+            assets[sidint] = pd.DataFrame({
+                "open": np.array(opens),
+                "high": np.array(highs),
+                "low": np.array(lows),
+                "close": np.array(closes),
+                "volume": np.array(volumes),
+                "day": [day.value for day in sim_params.trading_days]
+            }, index=sim_params.trading_days)
 
         DailyBarWriterFromDataFrames(assets).write(
             path,

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -62,3 +62,71 @@ def create_data_portal(env, tempdir, sim_params, sids):
             sim_params=sim_params,
             asset_finder=env.asset_finder
         )
+
+
+def create_data_portal_from_trade_history(
+        tempdir, sidint, trades, sim_params, env):
+    if sim_params.data_frequency == "daily":
+        path = os.path.join(tempdir.path, "testdaily.bcolz")
+        assets = {}
+        length = sim_params.days_in_period
+        opens = []
+        highs = []
+        lows = []
+        closes = []
+        volumes = []
+        for trade in trades:
+            opens.append(trade.open_price)
+            highs.append(trade.high)
+            lows.append(trade.low)
+            closes.append(trade.close_price)
+            volumes.append(trade.volume)
+        assets[sidint] = pd.DataFrame({
+            "open": np.array(opens),
+            "high": np.array(highs),
+            "low": np.array(lows),
+            "close": np.array(closes),
+            "volume": np.array(volumes),
+            "day": [day.value for day in sim_params.trading_days]
+        }, index=sim_params.trading_days)
+
+        DailyBarWriterFromDataFrames(assets).write(
+            path,
+            sim_params.trading_days,
+            assets
+        )
+
+        return DataPortal(
+            env,
+            daily_equities_path=path,
+            sim_params=sim_params,
+            asset_finder=env.asset_finder
+        )
+    else:
+        assets = {}
+
+        minutes = env.minutes_for_days_in_range(
+            sim_params.first_open,
+            sim_params.last_close
+        )
+
+        length = len(minutes)
+
+        for sid_idx, sid in enumerate(sids):
+            assets[sid] = pd.DataFrame({
+                "open": np.array(range(10, 10 + length)) + sid_idx,
+                "high": np.array(range(15, 15 + length)) + sid_idx,
+                "low": np.array(range(8, 8 + length)) + sid_idx,
+                "close": np.array(range(10, 10 + length)) + sid_idx,
+                "volume": np.array(range(1, length + 1)) + sid_idx,
+                "minute": minutes
+            }, index=minutes)
+
+        MinuteBarWriterFromDataFrames().write(tempdir.path, assets)
+
+        return DataPortal(
+            env,
+            minutes_equities_path=tempdir.path,
+            sim_params=sim_params,
+            asset_finder=env.asset_finder
+        )

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -424,11 +424,6 @@ class TradingAlgorithm(object):
         processed by the zipline, and False for those that should be
         skipped.
         """
-
-        if not self.initialized:
-            self.initialize(*self.initialize_args, **self.initialize_kwargs)
-            self.initialized = True
-
         if self.perf_tracker is None:
             # Build a perf_tracker
             self.perf_tracker = PerformanceTracker(
@@ -444,6 +439,10 @@ class TradingAlgorithm(object):
                 sim_params=sim_params, env=self.trading_environment,
                 data_portal=self.data_portal
             )
+
+        if not self.initialized:
+            self.initialize(*self.initialize_args, **self.initialize_kwargs)
+            self.initialized = True
 
         self.portfolio_needs_update = True
         self.account_needs_update = True

--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -314,10 +314,13 @@ class FixedSlippage(SlippageModel):
         self.spread = spread
 
     def process_order(self, event, order, dt):
+
+        price = self.data_portal.get_current_price_data(order.sid, 'close')
         return create_transaction(
-            event,
+            order.sid,
+            dt,
             order,
-            event.price + (self.spread / 2.0 * order.direction),
+            price + (self.spread / 2.0 * order.direction),
             order.amount,
         )
 

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -188,6 +188,10 @@ class AlgorithmSimulator(object):
                     perf_tracker_benchmark_returns[trading_day] = 0.001
                     # use the last dt as market close
                     yield self.get_message(trading_day)
+
+                    self.algo.portfolio_needs_update = True
+                    self.algo.account_needs_update = True
+                    self.algo.performance_needs_update = True
             else:
                 for day_idx, trading_day in enumerate(trading_days):
                     day_offset = (day_idx + first_trading_day_idx) * 390
@@ -207,6 +211,10 @@ class AlgorithmSimulator(object):
                     perf_tracker_benchmark_returns[trading_day] = 0.001
                     # use the last dt as market close
                     yield self.get_message(trading_day)
+
+                    self.algo.portfolio_needs_update = True
+                    self.algo.account_needs_update = True
+                    self.algo.performance_needs_update = True
 
         risk_message = self.algo.perf_tracker.handle_simulation_end()
         yield risk_message

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -102,7 +102,7 @@ def assert_single_position(test, zipline):
         test.assertEqual(
             order['status'],
             ORDER_STATUS.FILLED,
-            "")
+            order)
 
     test.assertEqual(
         len(closing_positions),


### PR DESCRIPTION
@jbredeche these patches enable more of test_algorithm, by using the old trade data to create DataPortal's, up to the point of discovering a bug in when orders are filled in test_volshare_slippage