### PR TITLE
Begin unlocking test_perf_tracking tests.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -132,7 +132,8 @@ def create_txn(trade_event, price, amount):
     of a given trade event.
     """
     mock_order = Order(trade_event.dt, trade_event.sid, amount, id=None)
-    return create_transaction(trade_event, mock_order, price, amount)
+    return create_transaction(trade_event, trade_event.dt,
+                              mock_order, price, amount)
 
 
 def benchmark_events_in_range(sim_params, env):

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -26,6 +26,7 @@ import operator
 import unittest
 from nose_parameterized import parameterized
 import nose.tools as nt
+from testfixtures import TempDirectory
 import pytz
 import itertools
 
@@ -51,6 +52,10 @@ from zipline.utils.serialization_utils import (
 import zipline.protocol as zp
 from zipline.protocol import Event, DATASOURCE_TYPE
 from zipline.sources.data_frame_source import DataPanelSource
+from .utils.test_utils import (
+    create_data_portal,
+    create_data_portal_from_trade_history
+)
 
 logger = logging.getLogger('Test Perf Tracking')
 
@@ -977,6 +982,7 @@ class TestPositionPerformance(unittest.TestCase):
         del cls.env
 
     def setUp(self):
+        self.tempdir = TempDirectory()
         self.sim_params, self.dt, self.end_dt = \
             create_random_simulation_parameters()
 
@@ -1594,19 +1600,33 @@ shares in position"
                       net_liquidation=1300.0)
 
     def test_cost_basis_calc(self):
+        sim_params = factory.create_simulation_parameters(
+            num_days=4, env=self.env
+        )
         history_args = (
             1,
             [10, 11, 11, 12],
             [100, 100, 100, 100],
-            onesec,
-            self.sim_params,
+            oneday,
+            sim_params,
             self.env
         )
         trades = factory.create_trade_history(*history_args)
         transactions = factory.create_txn_history(*history_args)
 
-        pt = perf.PositionTracker(self.env.asset_finder)
-        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder)
+        data_portal = create_data_portal_from_trade_history(
+            self.env,
+            self.tempdir,
+            sim_params,
+            {1: trades})
+
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pp = perf.PerformancePeriod(
+            1000.0,
+            self.env.asset_finder,
+            period_open=sim_params.period_start,
+            period_close=sim_params.period_end,
+        )
         pp.position_tracker = pt
 
         average_cost = 0
@@ -1615,9 +1635,6 @@ shares in position"
             pp.handle_execution(txn)
             average_cost = (average_cost * i + txn.price) / (i + 1)
             self.assertEqual(pp.positions[1].cost_basis, average_cost)
-
-        for trade in trades:
-            pt.update_last_sale(trade)
 
         pp.calculate_performance()
 

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -170,8 +170,8 @@ class DataPortal(object):
         if asset in self.sources_map:
             # go find this asset in our custom sources
             try:
-                return self.sources_map[asset].loc[self.current_day].\
-                    loc[column]
+                # TODO: Change to index both dt and column at once.
+                return self.sources_map[asset].loc[dt].loc[column]
             except:
                 log.error(
                     "Could not find price for asset={0}, current_day={1},"
@@ -209,7 +209,7 @@ class DataPortal(object):
                     "because it only started trading on {2}!".
                     format(
                         str(asset),
-                        str(self.current_day),
+                        str(dt),
                         str(asset_data_start_date)
                     )
                 )
@@ -218,7 +218,7 @@ class DataPortal(object):
 
             # figure out how many days it's been between now and when this
             # asset starting trading
-            window_offset = trading_days.searchsorted(self.current_day) - \
+            window_offset = trading_days.searchsorted(dt) - \
                 trading_days.searchsorted(asset_data_start_date)
 
             # and use that offset to find our lookup index

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -33,7 +33,7 @@ class DataPortal(object):
                  sid_path_func=None):
         self.env = env
         self.current_dt = None
-        self.current_day = None
+        self.current_day = sim_params.period_start
         self.cur_data_offset = 0
 
         self.views = {}
@@ -163,7 +163,10 @@ class DataPortal(object):
 
         return carray
 
-    def get_current_price_data(self, asset, column):
+    def get_current_price_data(self, asset, column, dt=None):
+        if dt is None:
+            dt = self.current_day
+
         if asset in self.sources_map:
             # go find this asset in our custom sources
             try:
@@ -193,17 +196,21 @@ class DataPortal(object):
             asset_file_index = daily_attrs['first_row'][str(asset_int)]
 
             # find when the asset started trading
-            asset_start_trading_date = \
-                self.asset_finder.retrieve_asset(asset).start_date
+            # TODO: only access this info once.
+            calendar = daily_attrs['calendar']
+            asset_data_start_date = \
+                pd.Timestamp(
+                    calendar[daily_attrs['calendar_offset'][str(asset_int)]],
+                    tz='UTC')
 
-            if self.current_day < asset_start_trading_date:
+            if dt < asset_data_start_date:
                 raise ValueError(
                     "Cannot fetch daily data for {0} for {1} "
                     "because it only started trading on {2}!".
                     format(
                         str(asset),
                         str(self.current_day),
-                        str(asset_start_trading_date)
+                        str(asset_data_start_date)
                     )
                 )
 
@@ -212,7 +219,7 @@ class DataPortal(object):
             # figure out how many days it's been between now and when this
             # asset starting trading
             window_offset = trading_days.searchsorted(self.current_day) - \
-                trading_days.searchsorted(asset_start_trading_date)
+                trading_days.searchsorted(asset_data_start_date)
 
             # and use that offset to find our lookup index
             lookup_idx = asset_file_index + window_offset

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -217,7 +217,7 @@ class PerformancePeriod(object):
 
     def calculate_performance(self):
         pt = self.position_tracker
-        pos_stats = calc_position_stats(pt)
+        pos_stats = calc_position_stats(pt, self.period_close)
         self.ending_value = pos_stats.net_value
         self.ending_exposure = pos_stats.net_exposure
 

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -115,7 +115,7 @@ def calc_net_exposure(position_exposures):
     return sum(position_exposures)
 
 
-def calc_position_stats(pt):
+def calc_position_stats(pt, dt=None):
 
     sids = []
     amounts = []
@@ -127,7 +127,7 @@ def calc_position_stats(pt):
         sids.append(sid)
         amounts.append(pos.amount)
         last_sale_prices.append(pt._data_portal.get_current_price_data(
-            sid, 'close'))
+            sid, 'close', dt))
 
     position_values = calc_position_values(
         amounts,


### PR DESCRIPTION
- Add a 'dt' arg to get_current_price, so that the `current_day` member
  does not need to be mutated when using just the perf period and
  tracker.

- Change the frequency of the test data to daily from one second(?!)

- Create a data_portal in the test using sim_params which cover just the
  range of the test data.

This makes it possible to at least run:
$ nosetests -x tests/test_perf_tracking.py:TestPositionPerformance

Albeit, with a failure in the pnl result.

TODO: Figure out why transactions are generated past the end of the
sim_params.