### PR TITLE
evening delivery

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -14,10 +14,10 @@ def create_data_portal(env, tempdir, sim_params, sids):
         length = sim_params.days_in_period
         for sid_idx, sid in enumerate(sids):
             assets[sid] = pd.DataFrame({
-                "open": (np.array(range(10, 10 + length)) + sid_idx) * 1000,
-                "high": (np.array(range(15, 15 + length)) + sid_idx) * 1000,
-                "low": (np.array(range(8, 8 + length)) + sid_idx) * 1000,
-                "close": (np.array(range(10, 10 + length)) + sid_idx) * 1000,
+                "open": (np.array(range(10, 10 + length)) + sid_idx),
+                "high": (np.array(range(15, 15 + length)) + sid_idx),
+                "low": (np.array(range(8, 8 + length)) + sid_idx),
+                "close": (np.array(range(10, 10 + length)) + sid_idx),
                 "volume": np.array(range(100, 100 + length)) + sid_idx,
                 "day": [day.value for day in sim_params.trading_days]
             }, index=sim_params.trading_days)

--- a/zipline/finance/controls.py
+++ b/zipline/finance/controls.py
@@ -183,7 +183,6 @@ class MaxOrderSize(TradingControl):
         Fail if the magnitude of the given order exceeds either self.max_shares
         or self.max_notional.
         """
-
         if self.asset is not None and self.asset != asset:
             return
 
@@ -240,7 +239,6 @@ class MaxPositionSize(TradingControl):
         greater in shares than self.max_shares or greater in dollar value than
         self.max_notional.
         """
-
         if self.asset is not None and self.asset != asset:
             return
 

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -445,15 +445,19 @@ class PositionTracker(object):
         return net_cash_payment
 
     def maybe_create_close_position_transaction(self, event):
-        if not self._position_amounts.get(event.sid):
+        if not self.positions.get(event.sid):
             return None
+
+        amount = self.positions.get(event.sid).amount
+
         if 'price' in event:
             price = event.price
         else:
             price = self._position_last_sale_prices[event.sid]
+
         txn = Transaction(
             sid=event.sid,
-            amount=(-1 * self._position_amounts[event.sid]),
+            amount=(-1 * amount),
             dt=event.dt,
             price=price,
             commission=0,

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -259,8 +259,11 @@ class RiskMetricsPeriod(object):
         if len(self.algorithm_returns) < 2:
             return 0.0, 0.0, 0.0, 0.0, []
 
+        # FIXME NEED BENCHMARK FIX
+        benchmark_returns = self.benchmark_returns.fillna(method='bfill')
+
         returns_matrix = np.vstack([self.algorithm_returns,
-                                    self.benchmark_returns])
+                                    benchmark_returns])
         C = np.cov(returns_matrix, ddof=1)
         eigen_values = la.eigvals(C)
         condition_number = max(eigen_values) / min(eigen_values)

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -126,8 +126,8 @@ class Event(object):
         return pd.Series(self.__dict__, index=index)
 
 
-# class Order(Event):
-#     pass
+class Order(Event):
+    pass
 
 
 class Portfolio(object):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -481,6 +481,7 @@ class SetMaxOrderCountAlgorithm(TradingAlgorithm):
     def initialize(self, count):
         self.order_count = 0
         self.set_max_order_count(count)
+        self.minute_count = 0
 
 
 class SetLongOnlyAlgorithm(TradingAlgorithm):


### PR DESCRIPTION
1) more tests passing
2) temporarily patched some stuff in position_tracker to get more tests passing (read from underlying source of truth instead of from the cache that wasn't being written to correctly)
3) fixed a serious bug in the tradesim loop.  have to handle blotter open orders bookkeeping before calling handle_data, so that the current state of open orders is correct.
4) added a temporary bandaid around beta calculation to make tests not blow up beta calculation.