### PR TITLE
Use period close for perf period calcs.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -1171,19 +1171,30 @@ class TestPositionPerformance(unittest.TestCase):
             verify that the performance period calculates properly for a
             single buy transaction
         """
+        sim_params = factory.create_simulation_parameters(
+            num_days=4, env=self.env
+        )
         # post some trades in the market
         trades = factory.create_trade_history(
             1,
             [10, 10, 10, 11],
             [100, 100, 100, 100],
             onesec,
-            self.sim_params,
+            sim_params,
             env=self.env
         )
 
+        data_portal = create_data_portal_from_trade_history(
+            self.env,
+            self.tempdir,
+            sim_params,
+            {1: trades})
+
         txn = create_txn(trades[1], 10.0, 100)
-        pt = perf.PositionTracker(self.env.asset_finder)
-        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder,
+                                    period_open=sim_params.period_start,
+                                    period_close=sim_params.period_end)
         pp.position_tracker = pt
 
         pt.execute_transaction(txn)

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -286,7 +286,8 @@ class PerformancePeriod(object):
         return self.position_tracker.position_amounts
 
     def __core_dict(self):
-        pos_stats = calc_position_stats(self.position_tracker)
+        pos_stats = calc_position_stats(self.position_tracker,
+                                        self.period_close)
         period_stats = calc_period_stats(pos_stats, self.ending_cash)
 
         rval = {
@@ -391,7 +392,7 @@ class PerformancePeriod(object):
         account = self._account_store
 
         pt = self.position_tracker
-        pos_stats = calc_position_stats(pt)
+        pos_stats = calc_position_stats(pt, self.period_close)
         period_stats = calc_period_stats(pos_stats, self.ending_cash)
 
         # If no attribute is found on the PerformancePeriod resort to the


### PR DESCRIPTION
Enable another perf_tracker test by using the period end as the dt on
more perf period calculations.

So that the data_portal 'current_day' does not need to be updated by the
tests that are just touching perf period and tracker.

This may lead the way to no longer maintaining 'current_day/dt' at all
in data_portal.

Enables:

$ nosetests -x tests/test_perf_tracking.py:TestPositionPerformance.test_long_position
test_long_position (tests.test_perf_tracking.TestPositionPerformance) ... ok