### PR TITLE
Pre-lazy changes to test_perf_tracking

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -144,7 +144,9 @@ def benchmark_events_in_range(sim_params, env):
     ]
 
 
-def calculate_results(host,
+def calculate_results(sim_params,
+                      env,
+                      benchmark_events,
                       trade_events,
                       dividend_events=None,
                       splits=None,
@@ -175,7 +177,7 @@ def calculate_results(host,
     txns = txns or []
     splits = splits or []
 
-    perf_tracker = perf.PerformanceTracker(host.sim_params, host.env)
+    perf_tracker = perf.PerformanceTracker(sim_params, env)
 
     if dividend_events is not None:
         dividend_frame = pd.DataFrame(
@@ -190,7 +192,7 @@ def calculate_results(host,
     trade_events = sorted(trade_events, key=lambda ev: (ev.dt, ev.source_id))
 
     # Add a benchmark event for each date.
-    trades_plus_bm = date_sorted_sources(trade_events, host.benchmark_events)
+    trades_plus_bm = date_sorted_sources(trade_events, benchmark_events)
 
     # Filter out benchmark events that are later than the last trade date.
     filtered_trades_plus_bm = (filt_event for filt_event in trades_plus_bm
@@ -293,7 +295,9 @@ class TestSplitPerformance(unittest.TestCase):
             ),
         ]
 
-        results = calculate_results(self, events, txns=txns, splits=splits)
+        results = calculate_results(self.sim_params, self.env,
+                                    self.benchmark_events,
+                                    events, txns=txns, splits=splits)
 
         # should have 33 shares (at $60 apiece) and $20 in cash
         self.assertEqual(2, len(results))
@@ -417,7 +421,11 @@ class TestCommissionEvents(unittest.TestCase):
 
         # Insert a purchase order.
         txns = [create_txn(events[0], 20, 1)]
-        results = calculate_results(self, events, txns=txns)
+        results = calculate_results(self.sim_params,
+                                    self.env,
+                                    self.benchmark_events,
+                                    events,
+                                    txns=txns)
 
         # Validate that we lost 320 dollars from our cash pool.
         self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
@@ -476,7 +484,11 @@ class TestCommissionEvents(unittest.TestCase):
 
         events.append(cash_adjustment)
 
-        results = calculate_results(self, events, txns=txns)
+        results = calculate_results(self.sim_params,
+                                    self.env,
+                                    self.benchmark_events,
+                                    events,
+                                    txns=txns)
         # Validate that we lost 300 dollars from our cash pool.
         self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
                          9700)
@@ -499,7 +511,10 @@ class TestCommissionEvents(unittest.TestCase):
         cash_adjustment = factory.create_commission(1, 300.0, cash_adj_dt)
         events.append(cash_adjustment)
 
-        results = calculate_results(self, events)
+        results = calculate_results(self.sim_params,
+                                    self.env,
+                                    self.benchmark_events,
+                                    events)
         # Validate that we lost 300 dollars from our cash pool.
         self.assertEqual(results[-1]['cumulative_perf']['ending_cash'],
                          9700)
@@ -559,7 +574,9 @@ class TestDividendPerformance(unittest.TestCase):
         # Simulate a transaction being filled prior to the ex_date.
         txns = [create_txn(events[0], 10.0, 100)]
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -613,7 +630,9 @@ class TestDividendPerformance(unittest.TestCase):
         txns = [create_txn(events[0], 10.0, 100)]
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -659,7 +678,9 @@ class TestDividendPerformance(unittest.TestCase):
         txns = [create_txn(events[1], 10.0, 100)]
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -702,7 +723,9 @@ class TestDividendPerformance(unittest.TestCase):
         txns = [buy_txn, sell_txn]
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -744,7 +767,9 @@ class TestDividendPerformance(unittest.TestCase):
         txns = [buy_txn, sell_txn]
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -788,7 +813,9 @@ class TestDividendPerformance(unittest.TestCase):
         txns = [create_txn(events[1], 10.0, 100)]
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -833,7 +860,9 @@ class TestDividendPerformance(unittest.TestCase):
         txns = [create_txn(events[1], 10.0, -100)]
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,
@@ -871,7 +900,9 @@ class TestDividendPerformance(unittest.TestCase):
         )
 
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
         )
@@ -919,7 +950,9 @@ class TestDividendPerformance(unittest.TestCase):
         # Simulate a transaction being filled prior to the ex_date.
         txns = [create_txn(events[0], 10.0, 100)]
         results = calculate_results(
-            self,
+            self.sim_params,
+            self.env,
+            self.benchmark_events,
             events,
             dividend_events=[dividend],
             txns=txns,

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -44,7 +44,7 @@ from zipline.finance.trading import SimulationParameters
 from zipline.finance.blotter import Order
 from zipline.finance.commission import PerShare, PerTrade, PerDollar
 from zipline.finance.trading import TradingEnvironment
-from zipline.utils.factory import create_random_simulation_parameters
+from zipline.utils.factory import create_simulation_parameters
 from zipline.utils.serialization_utils import (
     loads_with_persistent_ids, dumps_with_persistent_ids
 )
@@ -262,8 +262,7 @@ class TestSplitPerformance(unittest.TestCase):
     def setUp(self):
         self.env = TradingEnvironment()
         self.env.write_data(equities_identifiers=[1])
-        self.sim_params, self.dt, self.end_dt = \
-            create_random_simulation_parameters()
+        self.sim_params = create_simulation_parameters(num_days=2)
         # start with $10,000
         self.sim_params.capital_base = 10e3
 
@@ -367,11 +366,9 @@ class TestCommissionEvents(unittest.TestCase):
         self.env.write_data(
             equities_identifiers=[0, 1, 133]
         )
-        self.sim_params, self.dt, self.end_dt = \
-            create_random_simulation_parameters()
+        self.sim_params = create_simulation_parameters(num_days=5)
 
-        logger.info("sim_params: %s, dt: %s, end_dt: %s" %
-                    (self.sim_params, self.dt, self.end_dt))
+        logger.info("sim_params: %s" % self.sim_params)
 
         self.sim_params.capital_base = 10e3
 
@@ -520,8 +517,7 @@ class TestDividendPerformance(unittest.TestCase):
         del cls.env
 
     def setUp(self):
-        self.sim_params, self.dt, self.end_dt = \
-            create_random_simulation_parameters()
+        self.sim_params = create_simulation_parameters(num_days=6)
         self.sim_params.capital_base = 10e3
 
         self.benchmark_events = benchmark_events_in_range(self.sim_params,
@@ -977,8 +973,7 @@ class TestPositionPerformance(unittest.TestCase):
         del cls.env
 
     def setUp(self):
-        self.sim_params, self.dt, self.end_dt = \
-            create_random_simulation_parameters()
+        self.sim_params = create_simulation_parameters(num_days=4)
 
         self.finder = self.env.asset_finder
         self.benchmark_events = benchmark_events_in_range(self.sim_params,
@@ -2079,7 +2074,7 @@ class TestPerformanceTracker(unittest.TestCase):
 
     def test_handle_sid_removed_from_universe(self):
         # post some trades in the market
-        sim_params, _, _ = create_random_simulation_parameters()
+        sim_params = create_simulation_parameters(num_days=5)
         events = factory.create_trade_history(
             1,
             [10, 10, 10, 10, 10],

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -18,7 +18,6 @@
 Factory functions to prepare useful data.
 """
 import pytz
-import random
 
 import pandas as pd
 import numpy as np
@@ -67,38 +66,6 @@ def create_simulation_parameters(year=2006, start=None, end=None,
     )
 
     return sim_params
-
-
-def create_random_simulation_parameters():
-    env = TradingEnvironment()
-    treasury_curves = env.treasury_curves
-
-    for n in range(100):
-
-        random_index = random.randint(
-            0,
-            len(treasury_curves) - 1
-        )
-
-        start_dt = treasury_curves.index[random_index]
-        end_dt = start_dt + timedelta(days=365)
-
-        now = datetime.utcnow().replace(tzinfo=pytz.utc)
-
-        if end_dt <= now:
-            break
-
-    assert end_dt <= now, """
-failed to find a suitable daterange after 100 attempts. please double
-check treasury and benchmark data in findb, and re-run the test."""
-
-    sim_params = SimulationParameters(
-        period_start=start_dt,
-        period_end=end_dt,
-        env=env,
-    )
-
-    return sim_params, start_dt, end_dt
 
 
 def get_next_trading_dt(current, interval, env):


### PR DESCRIPTION
These changes are spun out of the lazy-mainline branch.

- Remove create_random_simulation_parameters, since the tests on that branch which use a `DataPortal` use a more exactly sized sim_params created by `create_simulation_parameters`. Also, the randomness was causing some debug issues while working on changing the test_perf_tracking suite to use the new style data access.

- Make `calculate_results` take in a sim_params (and other) parameters, since on that branch some test_cases create their own sim_params, and thus can't be shared on the TestCase instance.