### PR TITLE
Correctly tests for duplicate symbols and remove _convert_asset_str_fields

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -65,14 +65,14 @@ def build_lookup_generic_cases():
         [
             {
                 'sid': 0,
-                'symbol': 'duplicated_0',
+                'symbol': 'duplicated',
                 'start_date': dupe_0_start.value,
                 'end_date': dupe_0_end.value,
                 'exchange': '',
             },
             {
                 'sid': 1,
-                'symbol': 'duplicated_1',
+                'symbol': 'duplicated',
                 'start_date': dupe_1_start.value,
                 'end_date': dupe_1_end.value,
                 'exchange': '',
@@ -109,8 +109,8 @@ def build_lookup_generic_cases():
         (finder, 1, None, assets[1]),
         (finder, 2, None, assets[2]),
         # Duplicated symbol with resolution date
-        (finder, 'duplicated_0', dupe_0_start, dupe_0),
-        (finder, 'duplicated_1', dupe_1_start, dupe_1),
+        (finder, 'duplicated', dupe_0_start, dupe_0),
+        (finder, 'duplicated', dupe_1_start, dupe_1),
         # Unique symbol, with or without resolution date.
         (finder, 'unique', unique_start, unique),
         (finder, 'unique', None, unique),
@@ -125,11 +125,11 @@ def build_lookup_generic_cases():
         (finder, (0, 1), None, assets[:-1]),
         (finder, iter((0, 1)), None, assets[:-1]),
         # Iterables of symbols.
-        (finder, ('duplicated_0', 'unique'), dupe_0_start, [dupe_0, unique]),
-        (finder, ('duplicated_1', 'unique'), dupe_1_start, [dupe_1, unique]),
+        (finder, ('duplicated', 'unique'), dupe_0_start, [dupe_0, unique]),
+        (finder, ('duplicated', 'unique'), dupe_1_start, [dupe_1, unique]),
         # Mixed types
         (finder,
-         ('duplicated_0', 2, 'unique', 1, dupe_1),
+         ('duplicated', 2, 'unique', 1, dupe_1),
          dupe_0_start,
          [dupe_0, assets[2], unique, assets[1], dupe_1]),
     ]

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -63,16 +63,6 @@ _asset_timestamp_fields = frozenset({
 })
 
 
-def _convert_asset_str_fields(dict):
-    """
-    Takes in a dict of Asset init args and converts from unicode to string
-    where applicable
-    """
-    for key, value in dict.items():
-        if key in _asset_str_fields:
-            dict[key] = str(value)
-
-
 def _convert_asset_timestamp_fields(dict):
     """
     Takes in a dict of Asset init args and converts dates to pd.Timestamps
@@ -228,7 +218,6 @@ class AssetFinder(object):
         # Convert 'data' from a RowProxy object to a dict, to allow assignment
         data = dict(data.items())
         if data:
-            _convert_asset_str_fields(data)
             _convert_asset_timestamp_fields(data)
 
             equity = Equity(**data)
@@ -251,7 +240,6 @@ class AssetFinder(object):
         # Convert 'data' from a RowProxy object to a dict, to allow assignment
         data = dict(data.items())
         if data:
-            _convert_asset_str_fields(data)
             _convert_asset_timestamp_fields(data)
 
             future = Future(**data)


### PR DESCRIPTION
PR to address two issues:
1) In the process of an earlier refactoring, the symbol names in `build_lookup_generic_cases()` were changed to be different, meaning we were no longer testing the relevant functionality of `lookup_generic`. The symbol names have been updated to once again be the same.
2) `_convert_asset_str_fields()` is no longer required. `_convert_asset_str_fields()` was added to address the fact that the unicode returned by SQLAlchemy was causing test failures, in particular `test_repr` and `test_root_symbols` failed because of the leading 'u' character in the unicode of python-2.x. Later it was pointed out that this method would behave differently in python 2 and 3, in particular the `str()` method would return bytes in python 2 and unicode in python 3. After investigating it was found that the `_convert_asset_str_fields()` was no longer  necessary. It is unclear why the original tests were failing. It is not due to SQLAlchemy versions, as tests pass for version >1 and <1.

Addresses issued raised in: https://github.com/quantopian/zipline/issues/740