### PR TITLE
Add lookup_future_symbol method and future_symbol API method

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -425,6 +425,31 @@ class TestMiscellaneousAPI(TestCase):
         self.assertIsInstance(algo.sid(3), Equity)
         self.assertIsInstance(algo.sid(4), Equity)
 
+    def test_future_symbol(self):
+        """ Tests the future_symbol API function.
+        """
+        algo = TradingAlgorithm(env=self.env)
+        algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
+
+        # Check that we get the correct fields for the CLG06 symbol
+        cl = algo.future_symbol('CLG06')
+        self.assertEqual(cl.sid, 5)
+        self.assertEqual(cl.symbol, 'CLG06')
+        self.assertEqual(cl.root_symbol, 'CL')
+        self.assertEqual(cl.start_date, pd.Timestamp('2005-12-01', tz='UTC'))
+        self.assertEqual(cl.notice_date, pd.Timestamp('2005-12-20', tz='UTC'))
+        self.assertEqual(cl.expiration_date,
+                         pd.Timestamp('2006-01-20', tz='UTC'))
+
+        with self.assertRaises(SymbolNotFound):
+            algo.future_symbol('')
+
+        with self.assertRaises(SymbolNotFound):
+            algo.future_symbol('PLAY')
+
+        with self.assertRaises(SymbolNotFound):
+            algo.future_symbol('FOOBAR')
+
     def test_future_chain(self):
         """ Tests the future_chain API function.
         """

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -770,6 +770,28 @@ class TradingAlgorithm(object):
         return self.asset_finder.retrieve_asset(a_sid)
 
     @api_method
+    def future_symbol(self, symbol):
+        """ Lookup a futures contract with a given symbol.
+
+        Parameters
+        ----------
+        symbol : str
+            The symbol of the desired contract.
+
+        Returns
+        -------
+        Future
+            A Future object.
+
+        Raises
+        ------
+        SymbolNotFound
+            Raised when no contract named 'symbol' is found.
+
+        """
+        return self.asset_finder.lookup_future_symbol(symbol)
+
+    @api_method
     def future_chain(self, root_symbol, as_of_date=None):
         """ Look up a future chain with the specified parameters.
 

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -326,7 +326,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 nullable=False,
                 primary_key=True,
             ),
-            sa.Column('symbol', sa.Text),
+            sa.Column('symbol', sa.Text, unique=True, index=True),
             sa.Column(
                 'root_symbol',
                 sa.Text,


### PR DESCRIPTION
cc @jfkirk @warren-oneill @yankees714 

Opening up this PR to discuss the addition of a `future_symbol()` API method and an internal `lookup_future_symbol()` method. 

I have added an index to the symbol column in the futures SQL table to speed up lookup times, and while I was at it I felt it that an SQL UNIQUE constraint would also be relevant since there should never be a collision of futures symbols. Note that this change initially caused one of the existing tests (which duplicates an entry in this column) to fail, so the test has been changed.
Update: the root symbols coming from our data provider are unique, and hence the symbols of individual contracts are unique. Hence it makes sense to impose the UNQIUE constraint.

Outstanding:

- [x] Refactor failing test or remove UNIQUE constraint.
- [x] Add future_symbol API method.
- [x] Take into account the changes in https://github.com/quantopian/zipline/pull/746
- [x] Add more tests. 
- [x] Move lookup_future_symbol tests to their own class, or more appropriate place. 
