### PR TITLE
Write faster

### DIFF
--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -310,7 +310,8 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
         constraints : bool, optional
             If True, create SQL ForeignKey and PrimaryKey constraints.
         """
-        self.sql_metadata = metadata = sa.MetaData(bind=engine)
+        metadata = sa.MetaData(bind=engine)
+
         self.equities = sa.Table(
             'equities',
             metadata,

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -191,8 +191,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
 
     def write_all(self,
                   engine,
-                  allow_sid_assignment=True,
-                  constraints=True):
+                  allow_sid_assignment=True):
         """ Write pre-supplied data to SQLite.
 
         Parameters
@@ -210,7 +209,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
         # Begin an SQL transaction.
         with engine.begin() as txn:
             # Create SQL tables.
-            self.init_db(txn, constraints)
+            self.init_db(txn)
             # Get the data to add to SQL.
             data = self.load_data()
             # Write the data to SQL.
@@ -252,7 +251,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
     def _write_equities(self, equities, bind):
         self._write_assets(equities, self.equities, 'equity', bind)
 
-    def init_db(self, engine, constraints=True):
+    def init_db(self, engine):
         """Connect to database and create tables.
 
         Parameters
@@ -272,7 +271,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 sa.Integer,
                 unique=True,
                 nullable=False,
-                primary_key=constraints,
+                primary_key=True,
             ),
             sa.Column('symbol', sa.Text),
             sa.Column('company_symbol', sa.Text, index=True),
@@ -292,7 +291,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 sa.Text,
                 unique=True,
                 nullable=False,
-                primary_key=constraints,
+                primary_key=True,
             ),
             sa.Column('timezone', sa.Text),
         )
@@ -304,7 +303,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 sa.Text,
                 unique=True,
                 nullable=False,
-                primary_key=constraints,
+                primary_key=True,
             ),
             sa.Column('root_symbol_id', sa.Integer),
             sa.Column('sector', sa.Text),
@@ -312,8 +311,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
             sa.Column(
                 'exchange',
                 sa.Text,
-                *((sa.ForeignKey(self.futures_exchanges.c.exchange),)
-                  if constraints else ())
+                sa.ForeignKey(self.futures_exchanges.c.exchange),
             ),
         )
         self.futures_contracts = sa.Table(
@@ -324,14 +322,13 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 sa.Integer,
                 unique=True,
                 nullable=False,
-                primary_key=constraints,
+                primary_key=True,
             ),
             sa.Column('symbol', sa.Text),
             sa.Column(
                 'root_symbol',
                 sa.Text,
-                *((sa.ForeignKey(self.futures_root_symbols.c.root_symbol),)
-                  if constraints else ())
+                sa.ForeignKey(self.futures_root_symbols.c.root_symbol),
             ),
             sa.Column('asset_name', sa.Text),
             sa.Column('start_date', sa.Integer, default=0, nullable=False),
@@ -340,8 +337,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
             sa.Column(
                 'exchange',
                 sa.Text,
-                *((sa.ForeignKey(self.futures_exchanges.c.exchange),)
-                  if constraints else ())
+                sa.ForeignKey(self.futures_exchanges.c.exchange),
             ),
             sa.Column('notice_date', sa.Integer, nullable=False),
             sa.Column('expiration_date', sa.Integer, nullable=False),
@@ -356,7 +352,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 sa.Integer,
                 unique=True,
                 nullable=False,
-                primary_key=constraints),
+                primary_key=True),
             sa.Column('asset_type', sa.Text),
         )
         # Create the SQL tables if they do not already exist.

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -13,6 +13,8 @@ import sqlalchemy as sa
 from zipline.errors import SidAssignmentError
 from zipline.assets._assets import Asset
 
+SQLITE_MAX_VARIABLE_NUMBER = 999
+
 # Define a namedtuple for use with the load_data and _load_data methods
 AssetData = namedtuple('AssetData', 'equities futures exchanges root_symbols')
 
@@ -164,7 +166,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
         Returns data in standard format.
 
     """
-    CHUNK_SIZE = 999
+    CHUNK_SIZE = SQLITE_MAX_VARIABLE_NUMBER
 
     def __init__(self, equities=None, futures=None, exchanges=None,
                  root_symbols=None):

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -16,44 +16,6 @@ from zipline.assets._assets import Asset
 # Define a namedtuple for use with the load_data and _load_data methods
 AssetData = namedtuple('AssetData', 'equities futures exchanges root_symbols')
 
-# Expected fields for an Asset's metadata
-ASSET_TABLE_FIELDS = frozenset({
-    'sid',
-    'symbol',
-    'asset_name',
-    'start_date',
-    'end_date',
-    'first_traded',
-    'exchange',
-})
-
-# Expected fields for a Future's metadata
-FUTURE_TABLE_FIELDS = ASSET_TABLE_FIELDS | {
-    'notice_date',
-    'expiration_date',
-    'auto_close_date',
-    'contract_multiplier',
-}
-
-# Expected fields for an Equity's metadata
-EQUITY_TABLE_FIELDS = ASSET_TABLE_FIELDS | {
-    'company_symbol',
-    'share_class_symbol',
-    'fuzzy_symbol',
-}
-
-EXCHANGE_TABLE_FIELDS = frozenset({
-    'exchange',
-    'timezone',
-})
-
-ROOT_SYMBOL_TABLE_FIELDS = frozenset({
-    'root_symbol',
-    'root_symbol_id',
-    'sector',
-    'description',
-    'exchange',
-})
 
 # Default values for the equities DataFrame
 _equities_defaults = {

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -162,21 +162,21 @@ def _generate_output_dataframe(data_subset, defaults):
     """
     # The columns provided.
     cols = set(data_subset.columns)
-    desired_cols = {col for col in defaults.keys()}
+    desired_cols = set(defaults)
 
     # Drop columns with unrecognised headers.
-    data_subset.drop(cols - (cols & desired_cols),
+    data_subset.drop(cols - desired_cols,
                      axis=1,
                      inplace=True)
 
     # Get those columns which we need but
     # for which no data has been supplied.
-    need = desired_cols - set(data_subset.columns)
+    need = desired_cols - cols
 
     # Combine the users supplied data with our required columns.
     output = pd.concat(
         (data_subset, pd.DataFrame(
-            _dict_subset(defaults, need),
+            {k: defaults[k] for k in need},
             data_subset.index,
         )),
         axis=1,
@@ -184,13 +184,6 @@ def _generate_output_dataframe(data_subset, defaults):
     )
 
     return output
-
-
-def _dict_subset(dict_, subset):
-    res = {}
-    for k in subset:
-        res[k] = dict_[k]
-    return res
 
 
 class AssetDBWriter(with_metaclass(ABCMeta)):

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -21,7 +21,7 @@ from logbook import Logger
 import numpy as np
 import pandas as pd
 from pandas.tseries.tools import normalize_date
-from six import with_metaclass, string_types
+from six import with_metaclass, string_types, viewkeys
 import sqlalchemy as sa
 from toolz import compose
 
@@ -64,10 +64,9 @@ def _convert_asset_timestamp_fields(dict):
     """
     Takes in a dict of Asset init args and converts dates to pd.Timestamps
     """
-    for key, value in dict.items():
-        if key in _asset_timestamp_fields:
-            value = pd.Timestamp(value, tz='UTC')
-            dict[key] = None if pd.isnull(value) else value
+    for key in (_asset_timestamp_fields & viewkeys(dict)):
+        value = pd.Timestamp(dict[key], tz='UTC')
+        dict[key] = None if pd.isnull(value) else value
 
 
 class AssetFinder(object):

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -82,36 +82,12 @@ class AssetFinder(object):
 
         self.engine = engine
         metadata = sa.MetaData(bind=engine)
-        self.equities = sa.Table(
-            'equities',
-            metadata,
-            autoload=True,
-            autoload_with=engine,
-        )
-        self.futures_exchanges = sa.Table(
-            'futures_exchanges',
-            metadata,
-            autoload=True,
-            autoload_with=engine,
-        )
-        self.futures_root_symbols = sa.Table(
-            'futures_root_symbols',
-            metadata,
-            autoload=True,
-            autoload_with=engine,
-        )
-        self.futures_contracts = sa.Table(
-            'futures_contracts',
-            metadata,
-            autoload=True,
-            autoload_with=engine,
-        )
-        self.asset_router = sa.Table(
-            'asset_router',
-            metadata,
-            autoload=True,
-            autoload_with=engine,
-        )
+
+        table_names = ['equities', 'futures_exchanges', 'futures_root_symbols',
+                       'futures_contracts', 'asset_router']
+        metadata.reflect(only=table_names)
+        for table_name in table_names:
+            setattr(self, table_name, metadata.tables[table_name])
 
         # Cache for lookup of assets by sid, the objects in the asset lookp may
         # be shared with the results from equity and future lookup caches.

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -204,7 +204,7 @@ class AssetFinder(object):
             raise SidNotFound(sid=sid)
 
     def retrieve_all(self, sids, default_none=False):
-        return [self.retrieve_asset(sid) for sid in sids]
+        return [self.retrieve_asset(sid, default_none) for sid in sids]
 
     def _retrieve_equity(self, sid):
         """

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -68,8 +68,9 @@ def _convert_asset_timestamp_fields(dict):
     Takes in a dict of Asset init args and converts dates to pd.Timestamps
     """
     for key, value in dict.items():
-        if (key in _asset_timestamp_fields) and (value is not None):
-            dict[key] = pd.Timestamp(value, tz='UTC')
+        if key in _asset_timestamp_fields:
+            value = pd.Timestamp(value, tz='UTC')
+            dict[key] = None if pd.isnull(value) else value
 
 
 class AssetFinder(object):

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -551,7 +551,7 @@ class AssetFinder(object):
 
         # Handle missing assets
         if len(missing) > 0:
-            warnings.warn("Missing assets for identifiers: " + missing)
+            warnings.warn("Missing assets for identifiers: %s" % missing)
 
         # Return a list of the sids of the found assets
         return [asset.sid for asset in matches]

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -121,7 +121,10 @@ class TradingEnvironment(object):
         else:
             self.engine = engine = asset_db_path
 
-        self.asset_finder = AssetFinder(engine)
+        if engine is not None:
+            self.asset_finder = AssetFinder(engine)
+        else:
+            self.asset_finder = None
 
     def write_data(self,
                    engine=None,

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -196,7 +196,7 @@ class TradingEnvironment(object):
             .write_all(self.engine, allow_sid_assignment=allow_sid_assignment)
 
     def _write_data_dicts(self, equities=None, futures=None, exchanges=None,
-                          root_symbols=None, allow_sid_assignment=True):
+                          root_symbols=None):
         AssetDBWriterFromDictionary(equities, futures, exchanges, root_symbols)\
             .write_all(self.engine)
 

--- a/zipline/pipeline/loaders/_adjustments.pyx
+++ b/zipline/pipeline/loaders/_adjustments.pyx
@@ -28,6 +28,9 @@ ctypedef object DatetimeIndex_t
 ctypedef object Int64Index_t
 
 from zipline.lib.adjustment import Float64Multiply
+from zipline.assets.asset_writer import (
+    SQLITE_MAX_VARIABLE_NUMBER as SQLITE_MAX_IN_STATEMENT,
+)
 
 _SID_QUERY_TEMPLATE = """
 SELECT DISTINCT sid FROM {0}
@@ -44,7 +47,6 @@ FROM {0}
 WHERE sid IN ({1}) AND effective_date >= {2} AND effective_date <= {3}
 """
 
-cdef int SQLITE_MAX_IN_STATEMENT = 999
 EPOCH = Timestamp(0, tz='UTC')
 
 cdef set _get_sids_from_table(object db,


### PR DESCRIPTION
Speeds up the writing of all the assets to the assets.db, mostly by chunking the inserts in groups of 999 rows and by using vectorized computations for the date parsing.

Went from about 20s locally to about 5s.