### PR TITLE
Enable split handling in perf tracker.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -214,8 +214,6 @@ def calculate_results(sim_params,
             # Process txns for this date.
             perf_tracker.process_transaction(txn)
 
-        perf_tracker.position_tracker.sync_last_sale_prices(date)
-
         try:
             commissions_for_date = commissions[date]
             for comm in commissions_for_date:
@@ -225,7 +223,7 @@ def calculate_results(sim_params,
 
         try:
             splits_for_date = splits[date]
-            perf_tracker.position_tracker.handle_splits(splits_for_date)
+            perf_tracker.handle_splits(splits_for_date)
         except KeyError:
             pass
 
@@ -277,7 +275,9 @@ class TestSplitPerformance(unittest.TestCase):
     def test_split_long_position(self):
         events = factory.create_trade_history(
             1,
-            [20, 20],
+            # TODO: Should we provide adjusted prices in the tests, or provide
+            # raw prices and adjust via DataPortal?
+            [20, 60],
             [100, 100],
             oneday,
             self.sim_params,
@@ -324,7 +324,8 @@ class TestSplitPerformance(unittest.TestCase):
 
         self.assertTrue(
             zp_math.tolerant_equals(8020,
-                                    daily_perf['ending_cash'], 1))
+                                    daily_perf['ending_cash'], 1),
+            "ending_cash was {0}".format(daily_perf['ending_cash']))
 
         # Validate that the account attributes were updated.
         account = results[1]['account']

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -114,11 +114,7 @@ class Position(object):
         # adjust the cost basis to the nearest cent, e.g., 60.0
         new_cost_basis = round(self.cost_basis * ratio, 2)
 
-        # adjust the last sale price
-        new_last_sale_price = round(self.last_sale_price * ratio, 2)
-
         self.cost_basis = new_cost_basis
-        self.last_sale_price = new_last_sale_price
         self.amount = full_share_count
 
         return_cash = round(float(fractional_share_count * new_cost_basis), 2)

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -332,8 +332,8 @@ class PerformanceTracker(object):
 
         log.info("Ignoring DIVIDEND event.")
 
-    def process_split(self, event):
-        leftover_cash = self.position_tracker.handle_splits(event)
+    def handle_splits(self, splits):
+        leftover_cash = self.position_tracker.handle_splits(splits)
         if leftover_cash > 0:
             self.cumulative_performance.handle_cash_payment(leftover_cash)
             self.todays_performance.handle_cash_payment(leftover_cash)


### PR DESCRIPTION
Call handle_splits in perf_tracker so that the cash adjustment is
applied to the perf period.

Also, provide adjusted prices to the data_portal, this piece will need
to be fixed when data_portal supports adjusted spot prices.

Fixes last remaining test in test_perf_tracking:

```
$ nosetests -x tests/test_perf_tracking.py:TestSplitPerformance
test_split_long_position (tests.test_perf_tracking.TestSplitPerformance) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.262s

OK
```