### PR TITLE
MAINT: Improves handling of contract date info in lookup_future_chain

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -888,6 +888,18 @@ class TestFutureChain(TestCase):
         cl = FutureChain(self.asset_finder, lambda: '2006-02-01', 'CL')
         self.assertEqual(cl[-1], 3)
 
+    def test_iter(self):
+        """ Test the __iter__ method of FutureChain.
+        """
+        cl = FutureChain(self.asset_finder, lambda: '2005-12-01', 'CL')
+        for i, contract in enumerate(cl):
+            self.assertEqual(contract, i)
+
+        # First contract is now invalid, so sids will be offset by one
+        cl = FutureChain(self.asset_finder, lambda: '2005-12-21', 'CL')
+        for i, contract in enumerate(cl):
+            self.assertEqual(contract, i + 1)
+
     def test_root_symbols(self):
         """ Test that different variations on root symbols are handled
         as expected.

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -346,6 +346,7 @@ class AssetDBWriter(with_metaclass(ABCMeta)):
                 'root_symbol',
                 sa.Text,
                 sa.ForeignKey(self.futures_root_symbols.c.root_symbol),
+                index=True
             ),
             sa.Column('asset_name', sa.Text),
             sa.Column('start_date', sa.Integer, default=0, nullable=False),


### PR DESCRIPTION
Improves the query for futures contract to use the date that comes first in time (between `notice_date` and `expiration_date`) to determine contract validity. If one of these is missing, we'll use the other.

Also modifies the query to order the resulting contracts by their `expiration_date` if available, and to use their `notice_date` if not.