### PR TITLE
Write all dividend payout data to adjustments.db

### DIFF
--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -1,0 +1,147 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from numpy import (
+    arange,
+    datetime64,
+)
+from pandas import (
+    DataFrame,
+    Timestamp,
+)
+from testfixtures import TempDirectory
+
+from zipline.pipeline.loaders.synthetic import SyntheticDailyBarWriter
+from zipline.finance.trading import TradingEnvironment
+
+from zipline.data.us_equity_pricing import (
+    BcolzDailyBarSpotReader,
+    NoDataOnDate
+)
+
+
+# Test calendar ranges over the month of May and June 2015
+#      May 2015
+# Su Mo Tu We Th Fr Sa
+#                1  2
+#  3  4  5  6  7  8  9
+# 10 11 12 13 14 15 16
+# 17 18 19 20 21 22 23
+# 24 25 26 27 28 29 30
+# 31
+
+
+#      June 2015
+# Mo Tu We Th Fr Sa Su
+#  1  2  3  4  5  6  7
+#  8  9 10 11 12 13 14
+# 15 16 17 18 19 20 21
+# 22 23 24 25 26 27 28
+# 29 30
+TEST_CALENDAR_START = Timestamp('2015-05-01', tz='UTC')
+TEST_CALENDAR_STOP = Timestamp('2015-06-30', tz='UTC')
+
+
+# One asset for each of the cases enumerated in load_raw_arrays_from_bcolz.
+EQUITY_INFO = DataFrame(
+    [
+        # 1) The equity's trades start and end before query.
+        {'start_date': '2015-06-01', 'end_date': '2015-06-05'},
+        # 2) The equity's trades start and end after query.
+        {'start_date': '2015-06-22', 'end_date': '2015-06-30'},
+        # 3) The equity's data covers all dates in range.
+        {'start_date': '2015-06-02', 'end_date': '2015-06-30'},
+        # 4) The equity's trades start before the query start, but stop
+        #    before the query end.
+        {'start_date': '2015-06-01', 'end_date': '2015-06-15'},
+        # 5) The equity's trades start and end during the query.
+        {'start_date': '2015-06-12', 'end_date': '2015-06-18'},
+        # 6) The equity's trades start during the query, but extend through
+        #    the whole query.
+        {'start_date': '2015-06-15', 'end_date': '2015-06-25'},
+    ],
+    index=arange(1, 7),
+    columns=['start_date', 'end_date'],
+).astype(datetime64)
+
+
+class BcolzDailyBarSpotReaderTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        all_trading_days = TradingEnvironment().trading_days
+        cls.trading_days = all_trading_days[
+            all_trading_days.get_loc(TEST_CALENDAR_START):
+            all_trading_days.get_loc(TEST_CALENDAR_STOP) + 1
+        ]
+
+    def setUp(self):
+
+        self.asset_info = EQUITY_INFO
+        self.writer = SyntheticDailyBarWriter(
+            self.asset_info,
+            self.trading_days,
+        )
+
+        self.dir_ = TempDirectory()
+        self.dir_.create()
+        self.dest = self.dir_.getpath('daily_equity_pricing.bcolz')
+
+        self.writer.write(self.dest, self.trading_days, self.assets)
+
+        self.daily_bar_spot_reader = BcolzDailyBarSpotReader(self.dest)
+
+    def tearDown(self):
+        self.dir_.cleanup()
+
+    @property
+    def assets(self):
+        return self.asset_info.index
+
+    def test_unadjusted_spot_price(self):
+        # At beginning
+        price = self.daily_bar_spot_reader.unadjusted_spot_price(
+            1, Timestamp('2015-06-01', tz='UTC'))
+        # Synthetic writes price for date.
+        self.assertEqual(135630.0, price)
+
+        # Middle
+        price = self.daily_bar_spot_reader.unadjusted_spot_price(
+            1, Timestamp('2015-06-02', tz='UTC'))
+        self.assertEqual(135631.0, price)
+
+        # End
+        price = self.daily_bar_spot_reader.unadjusted_spot_price(
+            1, Timestamp('2015-06-05', tz='UTC'))
+        self.assertEqual(135634.0, price)
+
+        # Another sid at beginning.
+        price = self.daily_bar_spot_reader.unadjusted_spot_price(
+            2, Timestamp('2015-06-22', tz='UTC'))
+        self.assertEqual(235651.0, price)
+
+    def test_unadjusted_spot_price_no_data(self):
+
+        # before
+        with self.assertRaises(NoDataOnDate):
+            self.daily_bar_spot_reader.unadjusted_spot_price(
+                1, Timestamp('2015-05-29', tz='UTC'))
+
+        # after
+        with self.assertRaises(NoDataOnDate):
+            self.daily_bar_spot_reader.unadjusted_spot_price(
+                1, Timestamp('2015-06-08', tz='UTC'))

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -35,6 +35,7 @@ from zipline.api import (
     pipeline_output,
     get_datetime,
 )
+from zipline.data.adjustments import SQLiteAdjustmentWriter
 from zipline.errors import (
     AttachPipelineAfterInitialize,
     PipelineOutputDuringInitialize,
@@ -49,7 +50,6 @@ from zipline.pipeline.loaders.equity_pricing_loader import (
     BcolzDailyBarReader,
     DailyBarWriterFromCSVs,
     SQLiteAdjustmentReader,
-    SQLiteAdjustmentWriter,
     USEquityPricingLoader,
 )
 from zipline.utils.test_utils import (

--- a/tests/pipeline/test_us_equity_pricing_loader.py
+++ b/tests/pipeline/test_us_equity_pricing_loader.py
@@ -39,6 +39,7 @@ from pandas import (
 from pandas.util.testing import assert_index_equal
 from testfixtures import TempDirectory
 
+from zipline.data.adjustments import SQLiteAdjustmentWriter
 from zipline.lib.adjustment import Float64Multiply
 from zipline.pipeline.loaders.synthetic import (
     NullAdjustmentReader,
@@ -47,7 +48,6 @@ from zipline.pipeline.loaders.synthetic import (
 from zipline.pipeline.loaders.equity_pricing_loader import (
     BcolzDailyBarReader,
     SQLiteAdjustmentReader,
-    SQLiteAdjustmentWriter,
     USEquityPricingLoader,
 )
 from zipline.errors import WindowLengthTooLong

--- a/tests/pipeline/test_us_equity_pricing_loader.py
+++ b/tests/pipeline/test_us_equity_pricing_loader.py
@@ -369,32 +369,95 @@ MERGERS = DataFrame(
 DIVIDENDS = DataFrame(
     [
         # Before query range, should be excluded.
+        {'declared_date': Timestamp('2015-05-01', tz='UTC').to_datetime64(),
+         'ex_date': Timestamp('2015-06-01', tz='UTC').to_datetime64(),
+         'record_date': Timestamp('2015-06-03', tz='UTC').to_datetime64(),
+         'pay_date': Timestamp('2015-06-05', tz='UTC').to_datetime64(),
+         'amount': 90.0,
+         'sid': 1},
+        # First day of query range, should be excluded.
+        {'declared_date': Timestamp('2015-06-01', tz='UTC').to_datetime64(),
+         'ex_date': Timestamp('2015-06-10', tz='UTC').to_datetime64(),
+         'record_date': Timestamp('2015-06-15', tz='UTC').to_datetime64(),
+         'pay_date': Timestamp('2015-06-17', tz='UTC').to_datetime64(),
+         'amount': 80.0,
+         'sid': 3},
+        # Third day of query range, should have last_row of 2
+        {'declared_date': Timestamp('2015-06-01', tz='UTC').to_datetime64(),
+         'ex_date': Timestamp('2015-06-12', tz='UTC').to_datetime64(),
+         'record_date': Timestamp('2015-06-15', tz='UTC').to_datetime64(),
+         'pay_date': Timestamp('2015-06-17', tz='UTC').to_datetime64(),
+         'amount': 70.0,
+         'sid': 3},
+        # After query range, should be excluded.
+        {'declared_date': Timestamp('2015-06-01', tz='UTC').to_datetime64(),
+         'ex_date': Timestamp('2015-06-25', tz='UTC').to_datetime64(),
+         'record_date': Timestamp('2015-06-28', tz='UTC').to_datetime64(),
+         'pay_date': Timestamp('2015-06-30', tz='UTC').to_datetime64(),
+         'amount': 60.0,
+         'sid': 6},
+        # Another action in query range, should have last_row of 3
+        {'declared_date': Timestamp('2015-06-01', tz='UTC').to_datetime64(),
+         'ex_date': Timestamp('2015-06-15', tz='UTC').to_datetime64(),
+         'record_date': Timestamp('2015-06-18', tz='UTC').to_datetime64(),
+         'pay_date': Timestamp('2015-06-20', tz='UTC').to_datetime64(),
+         'amount': 50.0,
+         'sid': 3},
+        # Last day of range.  Should have last_row of 7
+        {'declared_date': Timestamp('2015-06-01', tz='UTC').to_datetime64(),
+         'ex_date': Timestamp('2015-06-19', tz='UTC').to_datetime64(),
+         'record_date': Timestamp('2015-06-22', tz='UTC').to_datetime64(),
+         'pay_date': Timestamp('2015-06-30', tz='UTC').to_datetime64(),
+         'amount': 40.0,
+         'sid': 3},
+    ],
+    columns=['declared_date',
+             'ex_date',
+             'record_date',
+             'pay_date',
+             'amount',
+             'sid'],
+)
+
+
+DIVIDENDS_EXPECTED = DataFrame(
+    [
+        # Before query range, should be excluded.
         {'effective_date': str_to_seconds('2015-06-01'),
-         'ratio': 1.301,
+         'ratio': 0.1,
          'sid': 1},
         # First day of query range, should be excluded.
         {'effective_date': str_to_seconds('2015-06-10'),
-         'ratio': 3.310,
+         'ratio': 0.20,
          'sid': 3},
         # Third day of query range, should have last_row of 2
         {'effective_date': str_to_seconds('2015-06-12'),
-         'ratio': 3.312,
+         'ratio': 0.30,
          'sid': 3},
         # After query range, should be excluded.
         {'effective_date': str_to_seconds('2015-06-25'),
-         'ratio': 6.325,
+         'ratio': 0.40,
          'sid': 6},
         # Another action in query range, should have last_row of 3
         {'effective_date': str_to_seconds('2015-06-15'),
-         'ratio': 3.315,
+         'ratio': 0.50,
          'sid': 3},
         # Last day of range.  Should have last_row of 7
         {'effective_date': str_to_seconds('2015-06-19'),
-         'ratio': 3.319,
+         'ratio': 0.60,
          'sid': 3},
     ],
     columns=['effective_date', 'ratio', 'sid'],
 )
+
+
+class MockDailyBarSpotReader(object):
+
+    def __init__(self):
+        pass
+
+    def unadjusted_spot_price(self, sid, day, column):
+        return 100.0
 
 
 class USEquityPricingLoaderTestCase(TestCase):
@@ -403,11 +466,14 @@ class USEquityPricingLoaderTestCase(TestCase):
     def setUpClass(cls):
         cls.test_data_dir = TempDirectory()
         cls.db_path = cls.test_data_dir.getpath('adjustments.db')
-        writer = SQLiteAdjustmentWriter(cls.db_path)
+        daily_bar_spot_reader = MockDailyBarSpotReader()
+        all_days = TradingEnvironment().trading_days
+        writer = SQLiteAdjustmentWriter(cls.db_path,
+                                        all_days,
+                                        daily_bar_spot_reader)
         writer.write(SPLITS, MERGERS, DIVIDENDS)
 
         cls.assets = TEST_QUERY_ASSETS
-        all_days = TradingEnvironment().trading_days
         cls.calendar_days = all_days[
             all_days.slice_indexer(TEST_CALENDAR_START, TEST_CALENDAR_STOP)
         ]
@@ -427,7 +493,7 @@ class USEquityPricingLoaderTestCase(TestCase):
     def test_input_sanity(self):
         # Ensure that the input data doesn't contain adjustments during periods
         # where the corresponding asset didn't exist.
-        for table in SPLITS, MERGERS, DIVIDENDS:
+        for table in SPLITS, MERGERS, DIVIDENDS_EXPECTED:
             for eff_date_secs, _, sid in table.itertuples(index=False):
                 eff_date = Timestamp(eff_date_secs, unit='s')
                 asset_start, asset_end = EQUITY_INFO.ix[
@@ -451,7 +517,7 @@ class USEquityPricingLoaderTestCase(TestCase):
         query_days = self.calendar_days_between(start_date, end_date)
         start_loc = query_days.get_loc(start_date)
 
-        for table in SPLITS, MERGERS, DIVIDENDS:
+        for table in SPLITS, MERGERS, DIVIDENDS_EXPECTED:
             for eff_date_secs, ratio, sid in table.itertuples(index=False):
                 eff_date = Timestamp(eff_date_secs, unit='s', tz='UTC')
 
@@ -483,6 +549,7 @@ class USEquityPricingLoaderTestCase(TestCase):
                             value=1.0 / ratio,
                         )
                     )
+
         return price_adjustments, volume_adjustments
 
     def test_load_adjustments_from_sqlite(self):
@@ -504,8 +571,23 @@ class USEquityPricingLoaderTestCase(TestCase):
 
         expected_close_adjustments, expected_volume_adjustments = \
             self.expected_adjustments(TEST_QUERY_START, TEST_QUERY_STOP)
-        self.assertEqual(close_adjustments, expected_close_adjustments)
-        self.assertEqual(volume_adjustments, expected_volume_adjustments)
+        for key in expected_close_adjustments:
+            close_adjustment = close_adjustments[key]
+            for j, adj in enumerate(close_adjustment):
+                expected = expected_close_adjustments[key][j]
+                self.assertEqual(adj.first_row, expected.first_row)
+                self.assertEqual(adj.last_row, expected.last_row)
+                self.assertEqual(adj.col, expected.col)
+                assert_allclose(adj.value, expected.value)
+
+        for key in expected_volume_adjustments:
+            volume_adjustment = volume_adjustments[key]
+            for j, adj in enumerate(volume_adjustment):
+                expected = expected_volume_adjustments[key][j]
+                self.assertEqual(adj.first_row, expected.first_row)
+                self.assertEqual(adj.last_row, expected.last_row)
+                self.assertEqual(adj.col, expected.col)
+                assert_allclose(adj.value, expected.value)
 
     def test_read_no_adjustments(self):
         adjustment_reader = NullAdjustmentReader()
@@ -642,7 +724,8 @@ class USEquityPricingLoaderTestCase(TestCase):
                     self.assets,
                     baseline,
                     # Apply all adjustments.
-                    concat([SPLITS, MERGERS, DIVIDENDS], ignore_index=True),
+                    concat([SPLITS, MERGERS, DIVIDENDS_EXPECTED],
+                           ignore_index=True),
                 )
                 assert_allclose(expected_adjusted_highs, window)
 

--- a/zipline/data/adjustments.py
+++ b/zipline/data/adjustments.py
@@ -1,0 +1,173 @@
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from errno import ENOENT
+from os import remove
+from os.path import exists
+
+import sqlite3
+
+from numpy import (
+    floating,
+    integer,
+    issubdtype,
+)
+
+from six import iteritems
+
+
+SQLITE_ADJUSTMENT_COLUMNS = frozenset(['effective_date', 'ratio', 'sid'])
+SQLITE_ADJUSTMENT_COLUMN_DTYPES = {
+    'effective_date': integer,
+    'ratio': floating,
+    'sid': integer,
+}
+SQLITE_ADJUSTMENT_TABLENAMES = frozenset(['splits', 'dividends', 'mergers'])
+
+
+class SQLiteAdjustmentWriter(object):
+    """
+    Writer for data to be read by SQLiteAdjustmentWriter
+
+    Parameters
+    ----------
+    conn_or_path : str or sqlite3.Connection
+        A handle to the target sqlite database.
+    overwrite : bool, optional, default=False
+        If True and conn_or_path is a string, remove any existing files at the
+        given path before connecting.
+
+    See Also
+    --------
+    SQLiteAdjustmentReader
+    """
+
+    def __init__(self, conn_or_path, overwrite=False):
+        if isinstance(conn_or_path, sqlite3.Connection):
+            self.conn = conn_or_path
+        elif isinstance(conn_or_path, str):
+            if overwrite and exists(conn_or_path):
+                try:
+                    remove(conn_or_path)
+                except OSError as e:
+                    if e.errno != ENOENT:
+                        raise
+            self.conn = sqlite3.connect(conn_or_path)
+        else:
+            raise TypeError("Unknown connection type %s" % type(conn_or_path))
+
+    def write_frame(self, tablename, frame):
+        if frozenset(frame.columns) != SQLITE_ADJUSTMENT_COLUMNS:
+            raise ValueError(
+                "Unexpected frame columns:\n"
+                "Expected Columns: %s\n"
+                "Received Columns: %s" % (
+                    SQLITE_ADJUSTMENT_COLUMNS,
+                    frame.columns.tolist(),
+                )
+            )
+        elif tablename not in SQLITE_ADJUSTMENT_TABLENAMES:
+            raise ValueError(
+                "Adjustment table %s not in %s" % (
+                    tablename, SQLITE_ADJUSTMENT_TABLENAMES
+                )
+            )
+
+        expected_dtypes = SQLITE_ADJUSTMENT_COLUMN_DTYPES
+        actual_dtypes = frame.dtypes
+        for colname, expected in iteritems(expected_dtypes):
+            actual = actual_dtypes[colname]
+            if not issubdtype(actual, expected):
+                raise TypeError(
+                    "Expected data of type {expected} for column '{colname}', "
+                    "but got {actual}.".format(
+                        expected=expected,
+                        colname=colname,
+                        actual=actual,
+                    )
+                )
+        return frame.to_sql(tablename, self.conn)
+
+    def write(self, splits, mergers, dividends):
+        """
+        Writes data to a SQLite file to be read by SQLiteAdjustmentReader.
+
+        Parameters
+        ----------
+        splits : pandas.DataFrame
+            Dataframe containing split data.
+        mergers : pandas.DataFrame
+            DataFrame containing merger data.
+        dividends : pandas.DataFrame
+            DataFrame containing dividend data.
+
+        Notes
+        -----
+        DataFrame input (`splits`, `mergers`, and `dividends`) should all have
+        the following columns:
+
+        effective_date : int
+            The date, represented as seconds since Unix epoch, on which the
+            adjustment should be applied.
+        ratio : float
+            A value to apply to all data earlier than the effective date.
+        sid : int
+            The asset id associated with this adjustment.
+
+        The ratio column is interpreted as follows:
+        - For all adjustment types, multiply price fields ('open', 'high',
+          'low', and 'close') by the ratio.
+        - For **splits only**, **divide** volume by the adjustment ratio.
+
+        Dividend ratios should be calculated as
+        1.0 - (dividend_value / "close on day prior to dividend ex_date").
+
+        Returns
+        -------
+        None
+
+        See Also
+        --------
+        SQLiteAdjustmentReader : Consumer for the data written by this class
+        """
+        self.write_frame('splits', splits)
+        self.write_frame('mergers', mergers)
+        self.write_frame('dividends', dividends)
+        self.conn.execute(
+            "CREATE INDEX splits_sids "
+            "ON splits(sid)"
+        )
+        self.conn.execute(
+            "CREATE INDEX splits_effective_date "
+            "ON splits(effective_date)"
+        )
+        self.conn.execute(
+            "CREATE INDEX mergers_sids "
+            "ON mergers(sid)"
+        )
+        self.conn.execute(
+            "CREATE INDEX mergers_effective_date "
+            "ON mergers(effective_date)"
+        )
+        self.conn.execute(
+            "CREATE INDEX dividends_sid "
+            "ON dividends(sid)"
+        )
+        self.conn.execute(
+            "CREATE INDEX dividends_effective_date "
+            "ON dividends(effective_date)"
+        )
+
+    def close(self):
+        self.conn.close()

--- a/zipline/data/adjustments.py
+++ b/zipline/data/adjustments.py
@@ -18,13 +18,21 @@ from os.path import exists
 
 import sqlite3
 
+import pandas as pd
 from numpy import (
     floating,
     integer,
     issubdtype,
+    uint32
 )
+import logbook
+import numpy as np
 
 from six import iteritems
+
+from zipline.data.us_equity_pricing import NoDataOnDate
+
+logger = logbook.Logger('Adjustments')
 
 
 SQLITE_ADJUSTMENT_COLUMNS = frozenset(['effective_date', 'ratio', 'sid'])
@@ -34,6 +42,42 @@ SQLITE_ADJUSTMENT_COLUMN_DTYPES = {
     'sid': integer,
 }
 SQLITE_ADJUSTMENT_TABLENAMES = frozenset(['splits', 'dividends', 'mergers'])
+
+
+SQLITE_DIVIDEND_PAYOUT_COLUMNS = frozenset(
+    ['sid',
+     'ex_date',
+     'declared_date',
+     'pay_date',
+     'record_date',
+     'amount'])
+SQLITE_DIVIDEND_PAYOUT_COLUMN_DTYPES = {
+    'sid': integer,
+    'ex_date': integer,
+    'declared_date': integer,
+    'record_date': integer,
+    'pay_date': integer,
+    'amount': float,
+}
+
+
+SQLITE_STOCK_DIVIDEND_PAYOUT_COLUMNS = frozenset(
+    ['sid',
+     'ex_date',
+     'declared_date',
+     'record_date',
+     'pay_date',
+     'payment_sid',
+     'ratio'])
+SQLITE_STOCK_DIVIDEND_PAYOUT_COLUMN_DTYPES = {
+    'sid': integer,
+    'ex_date': integer,
+    'declared_date': integer,
+    'record_date': integer,
+    'pay_date': integer,
+    'payment_sid': integer,
+    'ratio': float,
+}
 
 
 class SQLiteAdjustmentWriter(object):
@@ -53,7 +97,8 @@ class SQLiteAdjustmentWriter(object):
     SQLiteAdjustmentReader
     """
 
-    def __init__(self, conn_or_path, overwrite=False):
+    def __init__(self, conn_or_path, trading_days,
+                 daily_bar_spot_reader, overwrite=False):
         if isinstance(conn_or_path, sqlite3.Connection):
             self.conn = conn_or_path
         elif isinstance(conn_or_path, str):
@@ -66,6 +111,9 @@ class SQLiteAdjustmentWriter(object):
             self.conn = sqlite3.connect(conn_or_path)
         else:
             raise TypeError("Unknown connection type %s" % type(conn_or_path))
+
+        self.trading_days = trading_days
+        self.daily_bar_spot_reader = daily_bar_spot_reader
 
     def write_frame(self, tablename, frame):
         if frozenset(frame.columns) != SQLITE_ADJUSTMENT_COLUMNS:
@@ -99,7 +147,167 @@ class SQLiteAdjustmentWriter(object):
                 )
         return frame.to_sql(tablename, self.conn)
 
-    def write(self, splits, mergers, dividends):
+    def write_dividend_payouts(self, frame):
+        """
+        Write dividend payout data to SQLite table `dividend_payouts`.
+        """
+        if frozenset(frame.columns) != SQLITE_DIVIDEND_PAYOUT_COLUMNS:
+            raise ValueError(
+                "Unexpected frame columns:\n"
+                "Expected Columns: %s\n"
+                "Received Columns: %s" % (
+                    sorted(SQLITE_DIVIDEND_PAYOUT_COLUMNS),
+                    sorted(frame.columns.tolist()),
+                )
+            )
+
+        expected_dtypes = SQLITE_DIVIDEND_PAYOUT_COLUMN_DTYPES
+        actual_dtypes = frame.dtypes
+        for colname, expected in iteritems(expected_dtypes):
+            actual = actual_dtypes[colname]
+            if not issubdtype(actual, expected):
+                raise TypeError(
+                    "Expected data of type {expected} for column '{colname}', "
+                    "but got {actual}.".format(
+                        expected=expected,
+                        colname=colname,
+                        actual=actual,
+                    )
+                )
+        return frame.to_sql('dividend_payouts', self.conn)
+
+    def write_stock_dividend_payouts(self, frame):
+        if frozenset(frame.columns) != SQLITE_STOCK_DIVIDEND_PAYOUT_COLUMNS:
+            raise ValueError(
+                "Unexpected frame columns:\n"
+                "Expected Columns: %s\n"
+                "Received Columns: %s" % (
+                    sorted(SQLITE_STOCK_DIVIDEND_PAYOUT_COLUMNS),
+                    sorted(frame.columns.tolist()),
+                )
+            )
+
+        expected_dtypes = SQLITE_STOCK_DIVIDEND_PAYOUT_COLUMN_DTYPES
+        actual_dtypes = frame.dtypes
+        for colname, expected in iteritems(expected_dtypes):
+            actual = actual_dtypes[colname]
+            if not issubdtype(actual, expected):
+                raise TypeError(
+                    "Expected data of type {expected} for column '{colname}', "
+                    "but got {actual}.".format(
+                        expected=expected,
+                        colname=colname,
+                        actual=actual,
+                    )
+                )
+        return frame.to_sql('stock_dividend_payouts', self.conn)
+
+    def calc_dividend_ratios(self, dividends):
+        """
+        Calculate the ratios to apply to equities when looking back at pricing
+        history so that the price is smoothed over the ex_date, when the market
+        adjusts to the change in equity value due to upcoming dividend.
+
+        Returns
+        -------
+        DataFrame
+            A frame in the same format as splits and mergers, with keys
+            - sid, the id of the equity
+            - effective_date, the date in seconds on which to apply the ratio.
+            - ratio, the ratio to apply to backwards looking pricing data.
+        """
+        ex_dates = dividends.ex_date.values
+
+        sids = dividends.sid.values
+        amounts = dividends.amount.values
+
+        ratios = np.full(len(amounts), np.nan)
+
+        spot_reader = self.daily_bar_spot_reader
+
+        trading_days = self.trading_days
+
+        for i, amount in enumerate(amounts):
+            sid = sids[i]
+            ex_date = ex_dates[i]
+            day_loc = trading_days.get_loc(ex_date)
+            div_adj_date = trading_days[day_loc - 1]
+            try:
+                prev_close = spot_reader.unadjusted_spot_price(
+                    sid, div_adj_date, 'close')
+                ratio = 1.0 - amount / (prev_close)
+                ratios[i] = ratio
+            except NoDataOnDate:
+                logger.warn("Couldn't compute ratio for dividend %s" % {
+                    'sid': sid,
+                    'ex_date': ex_date,
+                    'gross_amount': amount,
+                })
+                continue
+
+        effective_dates = ex_dates.astype('datetime64[s]').astype(uint32)
+
+        return pd.DataFrame({
+            'sid': sids,
+            'effective_date': effective_dates,
+            'ratio': ratios,
+        })
+
+    def write_dividend_data(self, dividends, stock_dividends=None):
+        """
+        Write both dividend payouts and the derived price adjustment ratios.
+        """
+
+        # First write the dividend payouts.
+        dividend_payouts = dividends.copy()
+        dividend_payouts['ex_date'] = dividend_payouts['ex_date'].values.\
+            astype('datetime64[s]').astype(integer)
+        dividend_payouts['record_date'] = \
+            dividend_payouts['record_date'].values.astype('datetime64[s]').\
+            astype(integer)
+        dividend_payouts['declared_date'] = \
+            dividend_payouts['declared_date'].values.astype('datetime64[s]').\
+            astype(integer)
+        dividend_payouts['pay_date'] = \
+            dividend_payouts['declared_date'].values.astype('datetime64[s]').\
+            astype(integer)
+
+        self.write_dividend_payouts(dividend_payouts)
+
+        if stock_dividends is not None:
+            stock_dividend_payouts = stock_dividends.copy()
+            stock_dividend_payouts['ex_date'] = \
+                stock_dividend_payouts['ex_date'].values.\
+                astype('datetime64[s]').astype(integer)
+            stock_dividend_payouts['record_date'] = \
+                stock_dividend_payouts['record_date'].values.\
+                astype('datetime64[s]').astype(integer)
+            stock_dividend_payouts['declared_date'] = \
+                stock_dividend_payouts['declared_date'].\
+                values.astype('datetime64[s]').astype(integer)
+            stock_dividend_payouts['pay_date'] = \
+                stock_dividend_payouts['declared_date'].\
+                values.astype('datetime64[s]').astype(integer)
+        else:
+            stock_dividend_payouts = pd.DataFrame({
+                'sid': np.array([], dtype=uint32),
+                'record_date': np.array([], dtype=uint32),
+                'ex_date': np.array([], dtype=uint32),
+                'declared_date': np.array([], dtype=uint32),
+                'pay_date': np.array([], dtype=uint32),
+                'payment_sid': np.array([], dtype=uint32),
+                'ratio': np.array([], dtype=float),
+            })
+
+        self.write_stock_dividend_payouts(stock_dividend_payouts)
+
+        # Second from the dividend payouts, calculate ratios.
+
+        dividend_ratios = self.calc_dividend_ratios(dividends)
+
+        self.write_frame('dividends', dividend_ratios)
+
+    def write(self, splits, mergers, dividends, stock_dividends=None):
         """
         Writes data to a SQLite file to be read by SQLiteAdjustmentReader.
 
@@ -114,8 +322,8 @@ class SQLiteAdjustmentWriter(object):
 
         Notes
         -----
-        DataFrame input (`splits`, `mergers`, and `dividends`) should all have
-        the following columns:
+        DataFrame input (`splits`, `mergers`) should all have the following
+        columns:
 
         effective_date : int
             The date, represented as seconds since Unix epoch, on which the
@@ -130,8 +338,49 @@ class SQLiteAdjustmentWriter(object):
           'low', and 'close') by the ratio.
         - For **splits only**, **divide** volume by the adjustment ratio.
 
+
+        DataFrame input, 'dividends' should have the following columns:
+
+        sid : int
+            The asset id associated with this adjustment.
+        ex_date : datetime64
+            The date on which an equity must be held to be eligible to receive
+            payment.
+        declared_date : datetime64
+            The date on which the dividend is announced to the public.
+        pay_date : datetime64
+            The date on which the dividend is distributed.
+        record_date : datetime64
+            The date on which the stock ownership is checked to determine
+            distribution of dividends.
+        amount : float
+            The cash amount paid for each share.
+
         Dividend ratios should be calculated as
         1.0 - (dividend_value / "close on day prior to dividend ex_date").
+
+
+        DataFrame input, 'stock_dividends' should have the following columns:
+
+        sid : int
+            The asset id associated with this adjustment.
+        ex_date : datetime64
+            The date on which an equity must be held to be eligible to receive
+            payment.
+        declared_date : datetime64
+            The date on which the dividend is announced to the public.
+        pay_date : datetime64
+            The date on which the dividend is distributed.
+        record_date : datetime64
+            The date on which the stock ownership is checked to determine
+            distribution of dividends.
+        payment_sid : int
+            The asset id of the shares that should be paid instead of cash.
+        ratio: float
+            The ration of currently held shares in the held sid that should
+            be paid with new shares of the payment_sid.
+
+        stock_dividends is optional.
 
         Returns
         -------
@@ -143,7 +392,7 @@ class SQLiteAdjustmentWriter(object):
         """
         self.write_frame('splits', splits)
         self.write_frame('mergers', mergers)
-        self.write_frame('dividends', dividends)
+        self.write_dividend_data(dividends, stock_dividends)
         self.conn.execute(
             "CREATE INDEX splits_sids "
             "ON splits(sid)"
@@ -167,6 +416,30 @@ class SQLiteAdjustmentWriter(object):
         self.conn.execute(
             "CREATE INDEX dividends_effective_date "
             "ON dividends(effective_date)"
+        )
+        self.conn.execute(
+            "CREATE INDEX dividend_payouts_sid "
+            "ON dividend_payouts(sid)"
+        )
+        self.conn.execute(
+            "CREATE INDEX dividend_payouts_ex_date "
+            "ON dividend_payouts(ex_date)"
+        )
+        self.conn.execute(
+            "CREATE INDEX dividend_payouts_record_date "
+            "ON dividend_payouts(record_date)"
+        )
+        self.conn.execute(
+            "CREATE INDEX stock_dividend_payouts_sid "
+            "ON stock_dividend_payouts(sid)"
+        )
+        self.conn.execute(
+            "CREATE INDEX stock_dividend_payouts_ex_date "
+            "ON stock_dividend_payouts(ex_date)"
+        )
+        self.conn.execute(
+            "CREATE INDEX stock_dividend_payouts_record_date "
+            "ON stock_dividend_payouts(record_date)"
         )
 
     def close(self):

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bcolz
+from bcolz import ctable
 import pandas as pd
+
+from sid import string_types
 
 
 class NoDataOnDate(Exception):
@@ -24,9 +26,18 @@ class NoDataOnDate(Exception):
 
 
 class BcolzDailyBarSpotReader(object):
+    """
+    Reads inividual price moments from the daily bcolz file format shared
+    with pipeline.loaders.equity_pricing_loader.BcolzOHLCVReader
 
-    def __init__(self, daily_bars_path):
-        self.daily_bar_table = bcolz.ctable(rootdir=daily_bars_path, mode='r')
+    This is distinct from the BcolzOHLCVReader since the queries are on moments
+    instead of windows.
+    """
+
+    def __init__(self, table):
+        if isinstance(table, string_types):
+            table = ctable(rootdir=table, mode='r')
+        self.daily_bar_table = table
         calendar = self.daily_bar_table.attrs['calendar']
         self.trading_days = pd.DatetimeIndex(calendar, tz='UTC')
 

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -1,0 +1,98 @@
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bcolz
+import pandas as pd
+
+
+class NoDataOnDate(Exception):
+    """
+    Raised when a spot price can be found for the sid and date.
+    """
+    pass
+
+
+class BcolzDailyBarSpotReader(object):
+
+    def __init__(self, daily_bars_path):
+        self.daily_bar_table = bcolz.ctable(rootdir=daily_bars_path, mode='r')
+        calendar = self.daily_bar_table.attrs['calendar']
+        self.trading_days = pd.DatetimeIndex(calendar, tz='UTC')
+
+        # For indexing into daily bars.
+        # We may be able to reuse code from DataPortal when that is ready.
+        self.first_rows = {
+            int(k): v for k, v
+            in self.daily_bar_table.attrs['first_row'].iteritems()}
+        self.last_rows = {
+            int(k): v for k, v
+            in self.daily_bar_table.attrs['last_row'].iteritems()}
+        self.calendar_offset = {
+            int(k): v for k, v
+            in self.daily_bar_table.attrs['calendar_offset'].iteritems()}
+
+        self._cols = {}
+
+    def daily_bar_col(self, colname):
+        """
+        Get the colname from daily_bar_table and read all of it into memory,
+        caching the result.
+
+        Parameters
+        ----------
+        colname : string
+            A name of a OHLCV carray in the daily_bar_table
+
+        Returns
+        -------
+        array (uint32)
+            Full read array of the carray in the daily_bar_table with the
+            given colname.
+        """
+        try:
+            col = self._cols[colname]
+        except KeyError:
+            col = self._cols[colname] = self.daily_bar_table[colname][:]
+        return col
+
+    def unadjusted_spot_price(self, sid, day, colname):
+        """
+        Parameters
+        ----------
+        sid : int
+            The asset identifier.
+        day : datetime64
+            Midnight of the day for which data is requested.
+        colname : string
+            The price field. e.g. ('open', 'high', 'low', 'close', 'volume')
+
+        Returns
+        -------
+        float
+            The spot price for colnmae of the given sid on the given day.
+            Raises a NoDataOnDate exception if there is no data available
+            for the given day and sid.
+        """
+        day_loc = self.trading_days.get_loc(day)
+        offset = day_loc - self.calendar_offset[sid]
+        if offset < 0:
+            raise NoDataOnDate(
+                "No data on or before day={0} for sid={1}".format(
+                    day, sid))
+        ix = self.first_rows[sid] + offset
+        if ix > self.last_rows[sid]:
+            raise NoDataOnDate(
+                "No data on or after day={0} for sid={1}".format(
+                    day, sid))
+        return self.daily_bar_col(colname)[ix] * 0.001

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -16,9 +16,6 @@ from abc import (
     abstractmethod,
 )
 from contextlib import contextmanager
-from errno import ENOENT
-from os import remove
-from os.path import exists
 import sqlite3
 
 from bcolz import (
@@ -33,7 +30,6 @@ from numpy import (
     full,
     iinfo,
     integer,
-    issubdtype,
     uint32,
 )
 from pandas import (
@@ -61,13 +57,6 @@ US_EQUITY_PRICING_BCOLZ_COLUMNS = [
     'open', 'high', 'low', 'close', 'volume', 'day', 'id'
 ]
 DAILY_US_EQUITY_PRICING_DEFAULT_FILENAME = 'daily_us_equity_pricing.bcolz'
-SQLITE_ADJUSTMENT_COLUMNS = frozenset(['effective_date', 'ratio', 'sid'])
-SQLITE_ADJUSTMENT_COLUMN_DTYPES = {
-    'effective_date': integer,
-    'ratio': floating,
-    'sid': integer,
-}
-SQLITE_ADJUSTMENT_TABLENAMES = frozenset(['splits', 'dividends', 'mergers'])
 
 UINT32_MAX = iinfo(uint32).max
 
@@ -406,143 +395,6 @@ class BcolzDailyBarReader(object):
             last_rows,
             offsets,
         )
-
-
-class SQLiteAdjustmentWriter(object):
-    """
-    Writer for data to be read by SQLiteAdjustmentWriter
-
-    Parameters
-    ----------
-    conn_or_path : str or sqlite3.Connection
-        A handle to the target sqlite database.
-    overwrite : bool, optional, default=False
-        If True and conn_or_path is a string, remove any existing files at the
-        given path before connecting.
-
-    See Also
-    --------
-    SQLiteAdjustmentReader
-    """
-
-    def __init__(self, conn_or_path, overwrite=False):
-        if isinstance(conn_or_path, sqlite3.Connection):
-            self.conn = conn_or_path
-        elif isinstance(conn_or_path, str):
-            if overwrite and exists(conn_or_path):
-                try:
-                    remove(conn_or_path)
-                except OSError as e:
-                    if e.errno != ENOENT:
-                        raise
-            self.conn = sqlite3.connect(conn_or_path)
-        else:
-            raise TypeError("Unknown connection type %s" % type(conn_or_path))
-
-    def write_frame(self, tablename, frame):
-        if frozenset(frame.columns) != SQLITE_ADJUSTMENT_COLUMNS:
-            raise ValueError(
-                "Unexpected frame columns:\n"
-                "Expected Columns: %s\n"
-                "Received Columns: %s" % (
-                    SQLITE_ADJUSTMENT_COLUMNS,
-                    frame.columns.tolist(),
-                )
-            )
-        elif tablename not in SQLITE_ADJUSTMENT_TABLENAMES:
-            raise ValueError(
-                "Adjustment table %s not in %s" % (
-                    tablename, SQLITE_ADJUSTMENT_TABLENAMES
-                )
-            )
-
-        expected_dtypes = SQLITE_ADJUSTMENT_COLUMN_DTYPES
-        actual_dtypes = frame.dtypes
-        for colname, expected in iteritems(expected_dtypes):
-            actual = actual_dtypes[colname]
-            if not issubdtype(actual, expected):
-                raise TypeError(
-                    "Expected data of type {expected} for column '{colname}', "
-                    "but got {actual}.".format(
-                        expected=expected,
-                        colname=colname,
-                        actual=actual,
-                    )
-                )
-        return frame.to_sql(tablename, self.conn)
-
-    def write(self, splits, mergers, dividends):
-        """
-        Writes data to a SQLite file to be read by SQLiteAdjustmentReader.
-
-        Parameters
-        ----------
-        splits : pandas.DataFrame
-            Dataframe containing split data.
-        mergers : pandas.DataFrame
-            DataFrame containing merger data.
-        dividends : pandas.DataFrame
-            DataFrame containing dividend data.
-
-        Notes
-        -----
-        DataFrame input (`splits`, `mergers`, and `dividends`) should all have
-        the following columns:
-
-        effective_date : int
-            The date, represented as seconds since Unix epoch, on which the
-            adjustment should be applied.
-        ratio : float
-            A value to apply to all data earlier than the effective date.
-        sid : int
-            The asset id associated with this adjustment.
-
-        The ratio column is interpreted as follows:
-        - For all adjustment types, multiply price fields ('open', 'high',
-          'low', and 'close') by the ratio.
-        - For **splits only**, **divide** volume by the adjustment ratio.
-
-        Dividend ratios should be calculated as
-        1.0 - (dividend_value / "close on day prior to dividend ex_date").
-
-        Returns
-        -------
-        None
-
-        See Also
-        --------
-        SQLiteAdjustmentReader : Consumer for the data written by this class
-        """
-        self.write_frame('splits', splits)
-        self.write_frame('mergers', mergers)
-        self.write_frame('dividends', dividends)
-        self.conn.execute(
-            "CREATE INDEX splits_sids "
-            "ON splits(sid)"
-        )
-        self.conn.execute(
-            "CREATE INDEX splits_effective_date "
-            "ON splits(effective_date)"
-        )
-        self.conn.execute(
-            "CREATE INDEX mergers_sids "
-            "ON mergers(sid)"
-        )
-        self.conn.execute(
-            "CREATE INDEX mergers_effective_date "
-            "ON mergers(effective_date)"
-        )
-        self.conn.execute(
-            "CREATE INDEX dividends_sid "
-            "ON dividends(sid)"
-        )
-        self.conn.execute(
-            "CREATE INDEX dividends_effective_date "
-            "ON dividends(effective_date)"
-        )
-
-    def close(self):
-        self.conn.close()
 
 
 class SQLiteAdjustmentReader(object):

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -26,10 +26,8 @@ from click import progressbar
 from numpy import (
     array,
     float64,
-    floating,
     full,
     iinfo,
-    integer,
     uint32,
 )
 from pandas import (

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -20,9 +20,10 @@ from .frame import DataFrameLoader
 from .equity_pricing_loader import (
     BcolzDailyBarWriter,
     SQLiteAdjustmentReader,
-    SQLiteAdjustmentWriter,
     US_EQUITY_PRICING_BCOLZ_COLUMNS,
 )
+
+from zipline.data.adjustments import SQLiteAdjustmentWriter
 
 
 UINT_32_MAX = iinfo(uint32).max

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -246,6 +246,14 @@ class SyntheticDailyBarWriter(BcolzDailyBarWriter):
     # END SUPERCLASS INTERFACE
 
 
+class DailyBarSpotReader(object):
+    def __init__(self):
+        pass
+
+    def spot_price(self, sid, day, column):
+        return 100.0
+
+
 class NullAdjustmentReader(SQLiteAdjustmentReader):
     """
     A SQLiteAdjustmentReader that stores no adjustments and uses in-memory
@@ -254,11 +262,21 @@ class NullAdjustmentReader(SQLiteAdjustmentReader):
 
     def __init__(self):
         conn = sqlite3_connect(':memory:')
-        writer = SQLiteAdjustmentWriter(conn)
+        daily_bar_spot_reader = DailyBarSpotReader()
+        writer = SQLiteAdjustmentWriter(conn, None, daily_bar_spot_reader)
         empty = DataFrame({
             'sid': array([], dtype=uint32),
             'effective_date': array([], dtype=uint32),
             'ratio': array([], dtype=float),
         })
-        writer.write(splits=empty, mergers=empty, dividends=empty)
+        empty_dividends = DataFrame({
+            'sid': array([], dtype=uint32),
+            'amount': array([], dtype=float64),
+            'record_date': array([], dtype='datetime64[ns]'),
+            'ex_date': array([], dtype='datetime64[ns]'),
+            'declared_date': array([], dtype='datetime64[ns]'),
+            'pay_date': array([], dtype='datetime64[ns]'),
+        })
+
+        writer.write(splits=empty, mergers=empty, dividends=empty_dividends)
         super(NullAdjustmentReader, self).__init__(conn)


### PR DESCRIPTION
To prepare for querying for payouts from SQLite, write the dividend
payouts to a new table `dividend_payouts`.

Change the expected columns of the passed dividend frame to contain the
payout data, and use that data to calculate the ratios (this moves
internal code that was calcualting the ratios into Zipline.)

The end result is that instead of just a `dividends` table with the
backward looking adjustment ratios, also write a `dividend_payouts`
table and a `stock_dividend_payout` table.