### PR TITLE
BUG: Fixes handling of Futures without start_dates in future_chain

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -670,6 +670,14 @@ class AssetFinderTestCase(TestCase):
                 'expiration_date': pd.Timestamp('2016-11-16', tz='UTC'),
                 'start_date': pd.Timestamp('2015-08-01', tz='UTC')
             },
+            # No start date, shouldn't be in any chains
+            5: {
+                'symbol': 'ADZ25',
+                'root_symbol': 'AD',
+                'asset_type': 'future',
+                'notice_date': pd.Timestamp('2020-11-25', tz='UTC'),
+                'expiration_date': pd.Timestamp('2020-11-16', tz='UTC')
+            },
         }
         self.env.write_data(futures_data=metadata)
         finder = AssetFinder(self.env.engine)

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -385,6 +385,7 @@ class AssetFinder(object):
             sids = list(map(
                 itemgetter('sid'),
                 sa.select((fc_cols.sid,)).where(
+                    (fc_cols.start_date > 0) &
                     (fc_cols.root_symbol == root_symbol),
                 ).order_by(
                     fc_cols.notice_date.asc(),
@@ -402,6 +403,7 @@ class AssetFinder(object):
                 sa.select((fc_cols.sid,)).where(
                     (fc_cols.root_symbol == root_symbol) &
                     (fc_cols.start_date <= knowledge_date) &
+                    (fc_cols.start_date > 0) &
 
                     # Filter to contracts that are still valid. If both
                     # exist, use the one that comes first in time (i.e.


### PR DESCRIPTION
Adds a check that the start_date is > 0 to prevent returning Futures that do not have a start date.

Adds a test for this behavior to prevent regression.