### PR TITLE
restore benchmark functionality

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,212 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from unittest import TestCase
+from datetime import timedelta
+import numpy as np
+import pandas as pd
+from testfixtures import TempDirectory
+from zipline.data.us_equity_pricing import SQLiteAdjustmentWriter, \
+    SQLiteAdjustmentReader
+from zipline.errors import (
+    BenchmarkAssetNotAvailableTooEarly,
+    BenchmarkAssetNotAvailableTooLate,
+    InvalidBenchmarkAsset)
+
+from zipline.finance.trading import TradingEnvironment
+from zipline.gens.tradesimulation import AlgorithmSimulator
+from zipline.utils import factory
+from zipline.utils.test_utils import create_data_portal, write_minute_data
+from .test_perf_tracking import MockDailyBarSpotReader
+
+
+class TestBenchmark(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        cls.tempdir = TempDirectory()
+
+        cls.sim_params = factory.create_simulation_parameters()
+
+        cls.env.write_data(equities_data={
+            1: {
+                "start_date": cls.sim_params.trading_days[0],
+                "end_date": cls.sim_params.trading_days[-1] + timedelta(days=1)
+            },
+            2: {
+                "start_date": cls.sim_params.trading_days[0],
+                "end_date": cls.sim_params.trading_days[-1] + timedelta(days=1)
+            },
+            3: {
+                "start_date": cls.sim_params.trading_days[100],
+                "end_date": cls.sim_params.trading_days[-100]
+            },
+            4: {
+                "start_date": cls.sim_params.trading_days[0],
+                "end_date": cls.sim_params.trading_days[-1] + timedelta(days=1)
+            }
+
+        })
+
+        dbpath = os.path.join(cls.tempdir.path, "adjustments.db")
+
+        writer = SQLiteAdjustmentWriter(dbpath, cls.env.trading_days,
+                                        MockDailyBarSpotReader())
+        splits = mergers = pd.DataFrame(
+            {
+                # Hackery to make the dtypes correct on an empty frame.
+                'effective_date': np.array([], dtype=int),
+                'ratio': np.array([], dtype=float),
+                'sid': np.array([], dtype=int),
+            },
+            index=pd.DatetimeIndex([], tz='UTC'),
+            columns=['effective_date', 'ratio', 'sid'],
+        )
+        dividends = pd.DataFrame({
+            'sid': np.array([], dtype=np.uint32),
+            'amount': np.array([], dtype=np.float64),
+            'declared_date': np.array([], dtype='datetime64[ns]'),
+            'ex_date': np.array([], dtype='datetime64[ns]'),
+            'pay_date': np.array([], dtype='datetime64[ns]'),
+            'record_date': np.array([], dtype='datetime64[ns]'),
+        })
+        declared_date = cls.sim_params.trading_days[45]
+        ex_date = cls.sim_params.trading_days[50]
+        record_date = pay_date = cls.sim_params.trading_days[55]
+
+        stock_dividends = pd.DataFrame({
+            'sid': np.array([4], dtype=np.uint32),
+            'payment_sid': np.array([5], dtype=np.uint32),
+            'ratio': np.array([2], dtype=np.float64),
+            'declared_date': np.array([declared_date], dtype='datetime64[ns]'),
+            'ex_date': np.array([ex_date], dtype='datetime64[ns]'),
+            'record_date': np.array([record_date], dtype='datetime64[ns]'),
+            'pay_date': np.array([pay_date], dtype='datetime64[ns]'),
+        })
+        writer.write(splits, mergers, dividends,
+                     stock_dividends=stock_dividends)
+
+        cls.data_portal = create_data_portal(
+            cls.env,
+            cls.tempdir,
+            cls.sim_params,
+            [1, 2, 3, 4],
+            adjustment_reader= SQLiteAdjustmentReader(dbpath)
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.env
+        cls.tempdir.cleanup()
+
+    def test_normal(self):
+        days_to_use = self.sim_params.trading_days[1:]
+
+        series = AlgorithmSimulator._prepare_benchmark_series(
+            1, self.env, days_to_use, self.data_portal
+        )
+
+        self.assertEqual(len(days_to_use), len(series))
+
+        # should be the equivalent of getting the price history, then doing
+        # a pct_change on it
+        manually_calculated = self.data_portal.get_history_window(
+            [1], days_to_use[-1], len(days_to_use), "1d", "close_price"
+        )[1].pct_change()
+
+        # compare all the fields except the first one, for which we don't have
+        # data in manually_calculated
+        np.testing.assert_array_equal(series[1:], manually_calculated[1:])
+
+        self.assertAlmostEqual(0.1, series[0])
+
+    def test_asset_not_trading(self):
+        with self.assertRaises(BenchmarkAssetNotAvailableTooEarly) as exc:
+            AlgorithmSimulator._prepare_benchmark_series(
+                3,
+                self.env,
+                self.sim_params.trading_days[1:],
+                self.data_portal
+            )
+
+        self.assertEqual(
+            '3 does not exist on 2006-01-04 00:00:00+00:00. '
+            'It started trading on 2006-05-26 00:00:00+00:00.',
+            exc.exception.message
+        )
+
+        with self.assertRaises(BenchmarkAssetNotAvailableTooLate) as exc2:
+            AlgorithmSimulator._prepare_benchmark_series(
+                3,
+                self.env,
+                self.sim_params.trading_days[120:],
+                self.data_portal
+            )
+
+        self.assertEqual(
+            '3 does not exist on 2006-06-26 00:00:00+00:00. '
+            'It stopped trading on 2006-08-09 00:00:00+00:00.',
+            exc2.exception.message
+        )
+
+    def test_asset_IPOed_same_day(self):
+        # gotta get some minute data up in here.
+        # add sid 4 for a couple of days
+        minutes = self.env.minutes_for_days_in_range(
+            self.sim_params.trading_days[0],
+            self.sim_params.trading_days[5]
+        )
+
+        path = write_minute_data(
+            self.tempdir,
+            minutes,
+            [2]
+        )
+
+        self.data_portal.minutes_equities_path = path
+
+        series = AlgorithmSimulator._prepare_benchmark_series(
+            2,
+            self.env,
+            self.sim_params.trading_days,
+            self.data_portal
+        )
+
+        # first value should be 0.10, coming from daily data
+        self.assertAlmostEquals(0.10, series[0])
+
+        days_to_use = self.sim_params.trading_days
+
+        manually_calculated = self.data_portal.get_history_window(
+            [2], days_to_use[-1], len(days_to_use), "1d", "close_price"
+        )[2].pct_change()
+
+        np.testing.assert_array_equal(series[1:], manually_calculated[1:])
+
+    def test_no_stock_dividends_allowed(self):
+        # try to use sid(4) as benchmark, should blow up due to the presence
+        # of a stock dividend
+
+        with self.assertRaises(InvalidBenchmarkAsset) as exc:
+            AlgorithmSimulator._prepare_benchmark_series(
+                4, self.env, self.sim_params.trading_days, self.data_portal
+            )
+
+        self.assertEqual("""
+4 cannot be used as the benchmark because it has a stock dividend on \
+2006-03-16 00:00:00.  Choose another asset to use as the benchmark.""".strip(),
+            exc.exception.message
+        )
+

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -2220,8 +2220,6 @@ class TestPerformanceTracker(unittest.TestCase):
                     perf_tracker.process_trade(event)
                 elif event.type == zp.DATASOURCE_TYPE.ORDER:
                     perf_tracker.process_order(event)
-                elif event.type == zp.DATASOURCE_TYPE.BENCHMARK:
-                    perf_tracker.process_benchmark(event)
                 elif event.type == zp.DATASOURCE_TYPE.TRANSACTION:
                     perf_tracker.process_transaction(event)
             msg = perf_tracker.handle_market_close_daily()

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -28,7 +28,6 @@ from six import (
     itervalues,
     string_types,
 )
-from zipline.data.data_portal import DataPortal
 
 from zipline.errors import (
     AttachPipelineAfterInitialize,
@@ -39,6 +38,7 @@ from zipline.errors import (
     PipelineOutputDuringInitialize,
     RegisterAccountControlPostInit,
     RegisterTradingControlPostInit,
+    SetBenchmarkOutsideInitialize,
     UnsupportedCommissionModel,
     UnsupportedDatetimeFormat,
     UnsupportedOrderParameters,
@@ -297,6 +297,8 @@ class TradingAlgorithm(object):
         self.initialized = False
         self.initialize_args = args
         self.initialize_kwargs = kwargs
+
+        self.benchmark_sid = kwargs.pop('benchmark_sid', None)
 
     def init_engine(self, get_loader):
         """
@@ -565,6 +567,13 @@ class TradingAlgorithm(object):
         positionals = zip(*args)
         for name, value in chain(positionals, iteritems(kwargs)):
             self._recorded_vars[name] = value
+
+    @api_method
+    def set_benchmark(self, benchmark_sid):
+        if self.initialized:
+            raise SetBenchmarkOutsideInitialize()
+
+        self.benchmark_sid = benchmark_sid
 
     @api_method
     @preprocess(symbol_str=ensure_upper_case)

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,21 @@ class NoTradeDataAvailableTooEarly(NoTradeDataAvailable):
 
 class NoTradeDataAvailableTooLate(NoTradeDataAvailable):
     msg = "{sid} does not exist on {dt}. It stopped trading on {end_dt}."
+
+
+class BenchmarkAssetNotAvailableTooEarly(NoTradeDataAvailableTooEarly):
+    pass
+
+
+class BenchmarkAssetNotAvailableTooLate(NoTradeDataAvailableTooLate):
+    pass
+
+
+class InvalidBenchmarkAsset(ZiplineError):
+    msg = """
+{sid} cannot be used as the benchmark because it has a stock \
+dividend on {dt}.  Choose another asset to use as the benchmark.
+""".strip()
 
 
 class WrongDataForTransform(ZiplineError):

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -173,6 +173,13 @@ class OrderDuringInitialize(ZiplineError):
     msg = "{msg}"
 
 
+class SetBenchmarkOutsideInitialize(ZiplineError):
+    """
+    Raised if set_benchmark is called outside initialize()
+    """
+    msg = "'set_benchmark' can only be called within initialize function."
+
+
 class AccountControlViolation(ZiplineError):
     """
     Raised if the account violates a constraint set by a AccountControl.

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -292,27 +292,6 @@ class PerformanceTracker(object):
         self.cumulative_performance.handle_commission(event)
         self.todays_performance.handle_commission(event)
 
-    def process_benchmark(self, event):
-        if self.sim_params.data_frequency == 'minute' and \
-           self.sim_params.emission_rate == 'daily':
-            # Minute data benchmarks should have a timestamp of market
-            # close, so that calculations are triggered at the right time.
-            # However, risk module uses midnight as the 'day'
-            # marker for returns, so adjust back to midnight.
-            midnight = pd.tseries.tools.normalize_date(event.dt)
-        else:
-            midnight = event.dt
-
-        if midnight not in self.all_benchmark_returns.index:
-            raise AssertionError(
-                ("Date %s not allocated in all_benchmark_returns. "
-                 "Calendar seems to mismatch with benchmark. "
-                 "Benchmark container is=%s" %
-                 (midnight,
-                  self.all_benchmark_returns.index)))
-
-        self.all_benchmark_returns[midnight] = event.returns
-
     def process_close_position(self, event):
         txn = self.position_tracker.\
             maybe_create_close_position_transaction(event)

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -90,9 +90,7 @@ class RiskMetricsCumulative(object):
         'information',
     )
 
-    def __init__(self, sim_params, env,
-                 create_first_day_stats=False,
-                 account=None):
+    def __init__(self, sim_params, env, create_first_day_stats=False):
         self.treasury_curves = env.treasury_curves
         self.start_date = sim_params.period_start.replace(
             hour=0, minute=0, second=0, microsecond=0

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -17,6 +17,10 @@ import pandas as pd
 
 from logbook import Logger, Processor
 from pandas.tslib import normalize_date
+from zipline.errors import (
+    BenchmarkAssetNotAvailableTooEarly,
+    BenchmarkAssetNotAvailableTooLate,
+    InvalidBenchmarkAsset)
 
 from zipline.protocol import BarData
 
@@ -109,24 +113,9 @@ class AlgorithmSimulator(object):
             '2002-01-02')]
         first_trading_day_idx = all_trading_days.searchsorted(trading_days[0])
 
-        if algo.benchmark_sid is None:
-            # get benchmark info from tradingenvironment
-            benchmark_series = env.benchmark_returns[
-                trading_days[0]:trading_days[-1]]
-        else:
-            # calculate benchmark. start one day before the first trading day,
-            # so we can get a return value for the first day.
-            benchmark_sid = algo.benchmark_sid
-            benchmark_series = data_portal.get_history_window(
-                [benchmark_sid],
-                trading_days[-1],
-                bar_count=len(trading_days) + 1,
-                frequency="1d",
-                field="close"
-            )[benchmark_sid].pct_change()
-
-            if np.isnan(benchmark_series[0]):
-                benchmark_series[0] = 0
+        benchmark_series = self._prepare_benchmark_series(
+            algo.benchmark_sid, env, trading_days, data_portal
+        )
 
         def inner_loop(dt_to_use):
             # called every tick (minute or day).
@@ -165,8 +154,7 @@ class AlgorithmSimulator(object):
             # call before trading start
             algo.before_trading_start(current_data)
 
-            # handle any splits or dividends that impact any positions or
-            # any open orders.
+            # handle any splits that impact any positions or any open orders.
             sids_we_care_about = \
                 list(set(perf_tracker.position_tracker.positions.keys() +
                          blotter.open_orders.keys()))
@@ -188,7 +176,7 @@ class AlgorithmSimulator(object):
                     perf_tracker_benchmark_returns[trading_day] = \
                         benchmark_series.loc[trading_day]
 
-                    yield self.get_message(trading_day)
+                    yield self.get_message(trading_day, algo, perf_tracker)
             else:
                 for day_idx, trading_day in enumerate(trading_days):
                     once_a_day(trading_day)
@@ -205,50 +193,132 @@ class AlgorithmSimulator(object):
                     perf_tracker_benchmark_returns[trading_day] = \
                         benchmark_series.loc[trading_day]
 
-                    yield self.get_message(minute)
+                    yield self.get_message(minute, algo, perf_tracker)
 
-        risk_message = self.algo.perf_tracker.handle_simulation_end()
+        risk_message = perf_tracker.handle_simulation_end()
         yield risk_message
 
-    def get_message(self, dt):
+    def get_message(self, dt, algo, perf_tracker):
         """
         Get a perf message for the given datetime.
         """
-        rvars = self.algo.recorded_vars
-        if self.algo.perf_tracker.emission_rate == 'daily':
+        rvars = algo.recorded_vars
+        if perf_tracker.emission_rate == 'daily':
             perf_message = \
-                self.algo.perf_tracker.handle_market_close_daily()
+                perf_tracker.handle_market_close_daily()
             perf_message['daily_perf']['recorded_vars'] = rvars
             return perf_message
 
-        elif self.algo.perf_tracker.emission_rate == 'minute':
-            self.algo.perf_tracker.handle_minute_close(dt)
-            perf_message = self.algo.perf_tracker.to_dict()
+        elif perf_tracker.emission_rate == 'minute':
+            perf_tracker.handle_minute_close(dt)
+            perf_message = perf_tracker.to_dict()
             perf_message['minute_perf']['recorded_vars'] = rvars
             return perf_message
 
-    def generate_messages(self, dt):
+    @staticmethod
+    def _prepare_benchmark_series(sid, env, trading_days, data_portal):
         """
-        Generator that yields perf messages for the given datetime.
+        Internal method that precalculates the benchmark return series for
+        use in the simulation.
+
+        Parameters
+        ----------
+        algo: TradingAlgorithm
+
+        env: TradingEnvironment
+
+        trading_days: pd.DateTimeIndex
+
+        data_portal: DataPortal
+
+        Notes
+        -----
+        If the benchmark asset started trading after the simulation start,
+        or finished trading before the simulation end, exceptions are raised.
+
+        If the benchmark asset started trading the same day as the simulation
+        start, the first available minute price on that day is used instead
+        of the previous close.
+
+        We use history to get an adjusted price history for each day's close,
+        as of the look-back date (the last day of the simulation).  Prices are
+        fully adjusted for dividends, splits, and mergers.
+
+        Returns
+        -------
+        A pd.Series, indexed by trading day, whose values represent the %
+        change from close to close.
         """
-        rvars = self.algo.recorded_vars
-        if self.algo.perf_tracker.emission_rate == 'daily':
-            perf_message = \
-                self.algo.perf_tracker.handle_market_close_daily()
-            perf_message['daily_perf']['recorded_vars'] = rvars
-            yield perf_message
+        if sid is None:
+            # get benchmark info from trading environment
+            benchmark_series = \
+                env.benchmark_returns[trading_days[0]:trading_days[-1]]
+        else:
+            # check if this security has a stock dividend.  if so, raise an
+            # error suggesting that the user pick a different asset to use
+            # as benchmark.
+            stock_dividends = \
+                data_portal.get_stock_dividends(sid, trading_days)
 
-        elif self.algo.perf_tracker.emission_rate == 'minute':
-            # close the minute in the tracker, and collect the daily message if
-            # the minute is the close of the trading day
-            minute_message, daily_message = \
-                self.algo.perf_tracker.handle_minute_close(dt)
+            if len(stock_dividends) > 0:
+                raise InvalidBenchmarkAsset(
+                    sid=str(sid),
+                    dt=stock_dividends[0]["ex_date"]
+                )
 
-            # collect and yield the minute's perf message
-            minute_message['minute_perf']['recorded_vars'] = rvars
-            yield minute_message
+            benchmark_asset = env.asset_finder.retrieve_asset(sid)
+            if benchmark_asset.start_date > trading_days[0]:
+                # the asset started trading after the first simulation day
+                raise BenchmarkAssetNotAvailableTooEarly(
+                    sid=str(sid),
+                    dt=trading_days[0],
+                    start_dt=benchmark_asset.start_date
+                )
 
-            # if there was a daily perf message, collect and yield it
-            if daily_message:
-                daily_message['daily_perf']['recorded_vars'] = rvars
-                yield daily_message
+            if benchmark_asset.end_date < trading_days[-1]:
+                # the asset stopped trading before the last simulation day
+                raise BenchmarkAssetNotAvailableTooLate(
+                    sid=str(sid),
+                    dt=trading_days[0],
+                    end_dt=benchmark_asset.end_date
+                )
+
+            # get the window of close prices for benchmark_sid from the last
+            # trading day of the simulation, going up to one day before the
+            # simulation start day.
+            benchmark_series = data_portal.get_history_window(
+                [sid],
+                trading_days[-1],
+                bar_count=len(trading_days) + 1,
+                frequency="1d",
+                field="close"
+            )[sid]
+
+            # now, we need to check if we can safely go use the
+            # one-day-before-sim-start value, by seeing if the asset was
+            # trading that day.
+            trading_day_before_sim_start = \
+                env.previous_trading_day(trading_days[0])
+
+            if benchmark_asset.start_date > trading_day_before_sim_start:
+                # we can't go back one day before sim start, because the asset
+                # didn't start trading until the same day as the sim start.
+                # instead, we'll use the first available minute value of the
+                # first sim day.
+                minutes_in_first_day = \
+                    env.market_minutes_for_day(trading_days[0])
+
+                # get a minute history window of the first day
+                minute_window = data_portal.get_history_window(
+                    [sid],
+                    minutes_in_first_day[-1],
+                    bar_count=len(minutes_in_first_day),
+                    frequency="1m",
+                    field="close_price"
+                )[sid]
+
+                # find the first non-zero value
+                value_to_use = minute_window[minute_window != 0][0]
+                benchmark_series[0] = value_to_use
+
+        return benchmark_series.pct_change()[1:]


### PR DESCRIPTION
1) moved set_benchmark to Zipline
2) tradesim now pre-calculates the benchmark for the entire simulation,
either via downloaded market data, or via the specified sid
3) when possible, dataportal now uses only daily bars for history