### PR TITLE
ENH: Allow pipelines to run with matching start/end dates

### DIFF
--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -153,9 +153,9 @@ class SimplePipelineEngine(object):
         --------
         PipelineEngine.run_pipeline
         """
-        if end_date <= start_date:
+        if end_date < start_date:
             raise ValueError(
-                "start_date must be before end_date \n"
+                "start_date must be before or equal to end_date \n"
                 "start_date=%s, end_date=%s" % (start_date, end_date)
             )
 


### PR DESCRIPTION
I think restricting this was just paranoia.  This is required for use in live trading (where the start and end dates are the same on day 1).

(Opening PR to get travis to run)