### PR TITLE
ENH: vectorize mean algorithm returns calculation

### DIFF
--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -100,12 +100,9 @@ class RiskMetricsPeriod(object):
         self.num_trading_days = len(self.benchmark_returns)
         self.trading_day_counts = pd.stats.moments.rolling_count(
             self.algorithm_returns, self.num_trading_days)
-        self.mean_algorithm_returns = pd.Series(
-            index=self.algorithm_returns.index)
-        for dt, ret in self.algorithm_returns.iteritems():
-            self.mean_algorithm_returns[dt] = (
-                self.algorithm_returns[:dt].sum() /
-                self.trading_day_counts[dt])
+
+        self.mean_algorithm_returns = \
+            self.algorithm_returns.cumsum() / self.trading_day_counts
 
         self.benchmark_volatility = self.calculate_volatility(
             self.benchmark_returns)


### PR DESCRIPTION
In a sample backtest on my machine, this takes the final risk
calculations down from ~10 seconds to ~0.8 seconds.