### PR TITLE
Make clocks contsants importable from sim_engine.

### DIFF
--- a/zipline/gens/sim_engine.pyx
+++ b/zipline/gens/sim_engine.pyx
@@ -5,12 +5,10 @@ cimport cython
 
 cdef np.int64_t minute_in_nano = 60000000000
 
-# TODO: Should this be a struct?
-
-cdef np.int64_t DATA_AVAILABLE = 0
-cdef np.int64_t ONCE_A_DAY = 1
-cdef np.int64_t UPDATE_BENCHMARK = 2
-cdef np.int64_t CALC_PERFORMANCE = 3
+DATA_AVAILABLE = 0
+ONCE_A_DAY = 1
+UPDATE_BENCHMARK = 2
+CALC_PERFORMANCE = 3
 
 
 cdef class MinuteSimulationClock:

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -21,11 +21,12 @@ from zipline.errors import (
 from zipline.protocol import BarData
 from zipline.utils.api_support import ZiplineAPI
 
-# FIXME how to import this from sim_engine?
-DATA_AVAILABLE = 0
-ONCE_A_DAY = 1
-UPDATE_BENCHMARK = 2
-CALC_PERFORMANCE = 3
+from zipline.gens.sim_engine import (
+    DATA_AVAILABLE,
+    ONCE_A_DAY,
+    UPDATE_BENCHMARK,
+    CALC_PERFORMANCE,
+)
 
 
 log = Logger('Trade Simulation')


### PR DESCRIPTION
Removing the explicit typing allows the constants to be imported.