### PR TITLE
BUG: Issue #801 Initializing TradingAlgorithm Object Does Not Set

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1842,3 +1842,36 @@ class TestClosePosAlgo(TestCase):
                 actual_position, expected_positions[i],
                 "position for day={0} not equal, actual={1}, expected={2}".
                 format(i, actual_position, expected_positions[i]))
+
+
+class TestTradingAlgorithm(TestCase):
+    def setUp(self):
+        self.env = TradingEnvironment()
+        self.days = self.env.trading_days[:4]
+        self.panel = pd.Panel({1: pd.DataFrame({
+            'price': [1, 1, 2, 4], 'volume': [1e9, 1e9, 1e9, 0],
+            'type': [DATASOURCE_TYPE.TRADE,
+                     DATASOURCE_TYPE.TRADE,
+                     DATASOURCE_TYPE.TRADE,
+                     DATASOURCE_TYPE.CLOSE_POSITION]},
+            index=self.days)
+        })
+
+    def test_analyze_called(self):
+        results_ref = None
+
+        def initialize(self, context):
+            pass
+
+        def handel_data(self, context, data):
+            pass
+
+        def analyze(self, perf):
+            self.perf_ref = perf
+
+        algo = TradingAlgorithm(initialize = initialize, handle_data=handel_data,
+                                analyze = analyze)
+
+        data = DataPanelSource(self.panel)
+        results = algo.run(data)
+        self.assertEqual(results, results_ref)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -266,6 +266,7 @@ class TradingAlgorithm(object):
         self.algoscript = kwargs.pop('script', None)
 
         self._initialize = None
+        self._analyze = kwargs.pop('analyze', None)
         self._before_trading_start = None
         self._analyze = None
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -264,9 +264,7 @@ class TradingAlgorithm(object):
         # If string is passed in, execute and get reference to
         # functions.
         self.algoscript = kwargs.pop('script', None)
-
         self._initialize = None
-        self._analyze = kwargs.pop('analyze', None)
         self._before_trading_start = None
         self._analyze = None
 
@@ -297,6 +295,7 @@ class TradingAlgorithm(object):
             self._handle_data = kwargs.pop('handle_data')
             self._before_trading_start = kwargs.pop('before_trading_start',
                                                     None)
+            self._analyze = kwargs.pop('analyze', None)
 
         self.event_manager.add_event(
             zipline.utils.events.Event(


### PR DESCRIPTION
_analyze Method in algorithm.py

Added one line to check for the keyword argument 'analyze' and set the
the _analyze method when a TradingAlgorithm object is initialized
within a script.