### PR TITLE
MAINT: Removes unused allow_sid_assignment arg

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -75,9 +75,7 @@ class AssetFinder(object):
     # reference to an AssetFinder
     PERSISTENT_TOKEN = "<AssetFinder>"
 
-    def __init__(self, engine, allow_sid_assignment=True):
-
-        self.allow_sid_assignment = allow_sid_assignment
+    def __init__(self, engine):
 
         self.engine = engine
         metadata = sa.MetaData(bind=engine)


### PR DESCRIPTION
Removes an unused arg from AssetFinder __init__