### PR TITLE
Speedup retrieve all

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ verbosity=2
 detailed-errors=1
 with-ignore-docstrings=1
 with-timer=1
-timer-top-n=15
+timer-filter=warning
 
 [metadata]
 description-file = README.rst

--- a/tests/pipeline/base.py
+++ b/tests/pipeline/base.py
@@ -12,7 +12,7 @@ from zipline.finance.trading import TradingEnvironment
 from zipline.pipeline.engine import SimplePipelineEngine
 from zipline.pipeline.term import AssetExists
 from zipline.utils.pandas_utils import explode
-from zipline.utils.test_utils import make_simple_asset_info, ExplodingObject
+from zipline.utils.test_utils import make_simple_equity_info, ExplodingObject
 from zipline.utils.tradingcalendar import trading_day
 
 
@@ -52,7 +52,7 @@ class BasePipelineTestCase(TestCase):
         # Set up env for test
         env = TradingEnvironment()
         env.write_data(
-            equities_df=make_simple_asset_info(
+            equities_df=make_simple_equity_info(
                 assets,
                 self.__calendar[0],
                 self.__calendar[-1],

--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -29,18 +29,18 @@ from zipline.pipeline.loaders.blaze import (
     NonPipelineField,
 )
 from zipline.utils.numpy_utils import repeat_last_axis
-from zipline.utils.test_utils import tmp_asset_finder, make_simple_asset_info
+from zipline.utils.test_utils import tmp_asset_finder, make_simple_equity_info
 
 
 nameof = op.attrgetter('name')
 dtypeof = op.attrgetter('dtype')
 asset_infos = (
-    (make_simple_asset_info(
+    (make_simple_equity_info(
         tuple(map(ord, 'ABC')),
         pd.Timestamp(0),
         pd.Timestamp('2015'),
     ),),
-    (make_simple_asset_info(
+    (make_simple_equity_info(
         tuple(map(ord, 'ABCD')),
         pd.Timestamp(0),
         pd.Timestamp('2015'),

--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -333,7 +333,7 @@ class BlazeToPipelineTestCase(TestCase):
         dates = self.dates
 
         asset_info = asset_infos[0][0]
-        with tmp_asset_finder(asset_info) as finder:
+        with tmp_asset_finder(equities=asset_info) as finder:
             result = SimplePipelineEngine(
                 loader,
                 dates,
@@ -422,7 +422,7 @@ class BlazeToPipelineTestCase(TestCase):
                 expected_views,
             )
 
-        with tmp_asset_finder(asset_info) as finder:
+        with tmp_asset_finder(equities=asset_info) as finder:
             expected_output = pd.DataFrame(
                 list(concatv([12] * nassets, [13] * nassets, [14] * nassets)),
                 index=pd.MultiIndex.from_product((
@@ -466,7 +466,7 @@ class BlazeToPipelineTestCase(TestCase):
             '2014-01-03': repeat_last_axis(np.array([11.0, 2.0]), nassets),
         })
 
-        with tmp_asset_finder(asset_info) as finder:
+        with tmp_asset_finder(equities=asset_info) as finder:
             expected_output = pd.DataFrame(
                 list(concatv([10] * nassets, [11] * nassets)),
                 index=pd.MultiIndex.from_product((
@@ -534,7 +534,7 @@ class BlazeToPipelineTestCase(TestCase):
             pd.Timestamp('2014-01-06'),
         ])
 
-        with tmp_asset_finder(asset_info) as finder:
+        with tmp_asset_finder(equities=asset_info) as finder:
             expected_output = pd.DataFrame(
                 expected_output_buffer,
                 index=pd.MultiIndex.from_product((
@@ -594,7 +594,7 @@ class BlazeToPipelineTestCase(TestCase):
             # omitting the 4th and 5th to simulate a weekend
             pd.Timestamp('2014-01-06'),
         ])
-        with tmp_asset_finder(asset_info) as finder:
+        with tmp_asset_finder(equities=asset_info) as finder:
             expected_output = pd.DataFrame(
                 list(concatv([10] * nassets, [11] * nassets)),
                 index=pd.MultiIndex.from_product((

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -51,7 +51,7 @@ from zipline.pipeline.factors import (
 from zipline.utils.memoize import lazyval
 from zipline.utils.test_utils import (
     make_rotating_asset_info,
-    make_simple_asset_info,
+    make_simple_equity_info,
     product_upper_triangle,
     check_arrays,
 )
@@ -151,7 +151,7 @@ class ConstantInputTestCase(TestCase):
             assets=self.assets,
         )
 
-        self.asset_info = make_simple_asset_info(
+        self.asset_info = make_simple_equity_info(
             self.assets,
             start_date=self.dates[0],
             end_date=self.dates[-1],
@@ -498,7 +498,7 @@ class FrameInputTestCase(TestCase):
             tz='UTC',
         )
 
-        asset_info = make_simple_asset_info(
+        asset_info = make_simple_equity_info(
             cls.assets,
             start_date=cls.dates[0],
             end_date=cls.dates[-1],

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -50,7 +50,7 @@ from zipline.pipeline.factors import (
 )
 from zipline.utils.memoize import lazyval
 from zipline.utils.test_utils import (
-    make_rotating_asset_info,
+    make_rotating_equity_info,
     make_simple_equity_info,
     product_upper_triangle,
     check_arrays,
@@ -608,7 +608,7 @@ class SyntheticBcolzTestCase(TestCase):
         cls.trading_day = day = cls.env.trading_day
         cls.calendar = date_range('2015', '2015-08', tz='UTC', freq=day)
 
-        cls.asset_info = make_rotating_asset_info(
+        cls.asset_info = make_rotating_equity_info(
             num_assets=6,
             first_start=cls.first_asset_start,
             frequency=day,

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -57,7 +57,7 @@ from zipline.pipeline.loaders.equity_pricing_loader import (
     USEquityPricingLoader,
 )
 from zipline.utils.test_utils import (
-    make_simple_asset_info,
+    make_simple_equity_info,
     str_to_seconds,
 )
 from zipline.utils.tradingcalendar import (
@@ -332,7 +332,7 @@ class PipelineAlgorithmTestCase(TestCase):
         cls.MSFT = 2
         cls.BRK_A = 3
         cls.assets = [cls.AAPL, cls.MSFT, cls.BRK_A]
-        asset_info = make_simple_asset_info(
+        asset_info = make_simple_equity_info(
             cls.assets,
             Timestamp('2014'),
             Timestamp('2015'),

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -59,8 +59,8 @@ from zipline.errors import (
 from zipline.finance.trading import TradingEnvironment, noop_load
 from zipline.utils.test_utils import (
     all_subindices,
-    make_rotating_asset_info,
-    tmp_assets_db
+    tmp_assets_db,
+    make_rotating_equity_info,
 )
 
 
@@ -105,7 +105,7 @@ def build_lookup_generic_cases(asset_finder_type):
             },
         ],
         index='sid')
-    with tmp_assets_db(frame) as assets_db:
+    with tmp_assets_db(equities=frame) as assets_db:
         finder = asset_finder_type(assets_db)
         dupe_0, dupe_1, unique = assets = [
             finder.retrieve_asset(i)
@@ -774,7 +774,7 @@ class AssetFinderTestCase(TestCase):
         trading_day = self.env.trading_day
         first_start = pd.Timestamp('2015-04-01', tz='UTC')
 
-        frame = make_rotating_asset_info(
+        frame = make_rotating_equity_info(
             num_assets=num_assets,
             first_start=first_start,
             frequency=self.env.trading_day,

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -97,7 +97,6 @@ from zipline.utils.events import (
     TimeRuleFactory,
 )
 from zipline.utils.factory import create_simulation_parameters
-from zipline.utils.functional import is_a
 from zipline.utils.math_utils import tolerant_equals
 from zipline.utils.preprocess import preprocess
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -21,8 +21,10 @@ from pandas.tseries.tools import normalize_date
 import numpy as np
 
 from datetime import datetime
-
 from itertools import groupby, chain, repeat
+from numbers import Integral
+from operator import attrgetter
+
 from six.moves import filter
 from six import (
     exec_,
@@ -30,7 +32,6 @@ from six import (
     itervalues,
     string_types,
 )
-from operator import attrgetter
 
 
 from zipline.errors import (
@@ -96,6 +97,7 @@ from zipline.utils.events import (
     TimeRuleFactory,
 )
 from zipline.utils.factory import create_simulation_parameters
+from zipline.utils.functional import is_a
 from zipline.utils.math_utils import tolerant_equals
 from zipline.utils.preprocess import preprocess
 
@@ -608,8 +610,7 @@ class TradingAlgorithm(object):
             if isinstance(identifier, Asset):
                 asset = self.asset_finder.retrieve_asset(sid=identifier.sid,
                                                          default_none=True)
-
-            elif hasattr(identifier, '__int__'):
+            elif isinstance(identifier, Integral):
                 asset = self.asset_finder.retrieve_asset(sid=identifier,
                                                          default_none=True)
             if asset is None:
@@ -617,6 +618,12 @@ class TradingAlgorithm(object):
 
         self.trading_environment.write_data(
             equities_identifiers=identifiers_to_build)
+
+        # We need to clear out any cache misses that were stored while trying
+        # to do lookups.  The real fix for this problem is to not construct an
+        # AssetFinder until we `run()` when we actually have all the data we
+        # need to so.
+        self.asset_finder._reset_caches()
 
         return self.asset_finder.map_identifier_index_to_sids(
             identifiers, as_of_date,

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -256,9 +256,6 @@ class AssetFinder(object):
         """
         return self._retrieve_assets(sids, self.futures_contracts, Future)
 
-    def _retrieve_futures_contract(self, sid):
-        return self._retrieve_futures_contracts((sid,))[sid]
-
     @staticmethod
     def _select_assets_by_sid(asset_tbl, sids):
         return sa.select([asset_tbl]).where(

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -166,7 +166,7 @@ class AssetFinder(object):
 
         Returns
         -------
-        types : defaultdict[str or None -> list[int]]
+        types : dict[str or None -> list[int]]
             A dict mapping unique asset types to lists of sids drawn from sids.
             If we fail to look up an asset, we assign it a key of None.
         """

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -99,11 +99,22 @@ class AssetFinder(object):
         #
         # The caches are read through, i.e. accessing an asset through
         # retrieve_asset will populate the cache on first retrieval.
-        self._asset_cache = {}
-        self._asset_type_cache = {}
+        self._caches = (self._asset_cache, self._asset_type_cache) = {}, {}
 
         # Populated on first call to `lifetimes`.
         self._asset_lifetimes = None
+
+    def _reset_caches(self):
+        """
+        Reset our asset caches.
+
+        You probably shouldn't call this method.
+        """
+        # This method exists as a workaround for the in-place mutating behavior
+        # of `TradingAlgorithm._write_and_map_id_index_to_sids`.  No one else
+        # should be calling this.
+        for cache in self._caches:
+            cache.clear()
 
     def lookup_asset_types(self, sids):
         """

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -20,7 +20,6 @@ from logbook import Logger
 import numpy as np
 import pandas as pd
 from pandas import isnull
-from pandas.tseries.tools import normalize_date
 from six import with_metaclass, string_types, viewkeys
 from six.moves import map as imap
 import sqlalchemy as sa
@@ -442,7 +441,7 @@ class AssetFinder(object):
             split_delimited_symbol(symbol)
         if as_of_date:
             # Format inputs
-            as_of_date = pd.Timestamp(normalize_date(as_of_date))
+            as_of_date = pd.Timestamp(as_of_date).normalize()
             ad_value = as_of_date.value
 
             if fuzzy:

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -26,11 +26,13 @@ from six.moves import map as imap
 import sqlalchemy as sa
 
 from zipline.errors import (
+    EquitiesNotFound,
+    FutureContractsNotFound,
+    MapAssetIdentifierIndexError,
     MultipleSymbolsFound,
     RootSymbolNotFound,
     SidsNotFound,
     SymbolNotFound,
-    MapAssetIdentifierIndexError,
 )
 from zipline.assets import (
     Asset, Equity, Future,
@@ -227,10 +229,10 @@ class AssetFinder(object):
             raise SidsNotFound(sids=list(failures))
 
         # We don't update the asset cache here because it should already be
-        # updated by `self._retrieve_equities`.
-        update_hits(self._retrieve_equities(type_to_assets.pop('equity', ())))
+        # updated by `self.retrieve_equities`.
+        update_hits(self.retrieve_equities(type_to_assets.pop('equity', ())))
         update_hits(
-            self._retrieve_futures_contracts(type_to_assets.pop('future', ()))
+            self.retrieve_futures_contracts(type_to_assets.pop('future', ()))
         )
 
         # We shouldn't know about any other asset types.
@@ -241,18 +243,52 @@ class AssetFinder(object):
 
         return [hits[sid] for sid in sids]
 
-    def _retrieve_equities(self, sids):
+    def retrieve_equities(self, sids):
         """
-        Retrieve the Equity object of a given sid.
+        Retrieve Equity objects for a list of sids.
+
+        Users generally shouldn't need to this method (instead, they should
+        prefer the more general/friendly `retrieve_assets`), but it has a
+        documented interface and tests because it's used upstream.
+
+        Parameters
+        ----------
+        sids : iterable[int]
+
+        Returns
+        -------
+        equities : dict[int -> Equity]
+
+        Raises
+        ------
+        EquitiesNotFound
+            When any requested asset isn't found.
         """
         return self._retrieve_assets(sids, self.equities, Equity)
 
     def _retrieve_equity(self, sid):
-        return self._retrieve_equities((sid,))[sid]
+        return self.retrieve_equities((sid,))[sid]
 
-    def _retrieve_futures_contracts(self, sids):
+    def retrieve_futures_contracts(self, sids):
         """
-        Retrieve the Future object of a given sid.
+        Retrieve Future objects for an iterable of sids.
+
+        Users generally shouldn't need to this method (instead, they should
+        prefer the more general/friendly `retrieve_assets`), but it has a
+        documented interface and tests because it's used upstream.
+
+        Parameters
+        ----------
+        sids : iterable[int]
+
+        Returns
+        -------
+        equities : dict[int -> Equity]
+
+        Raises
+        ------
+        EquitiesNotFound
+            When any requested asset isn't found.
         """
         return self._retrieve_assets(sids, self.futures_contracts, Future)
 
@@ -307,12 +343,10 @@ class AssetFinder(object):
         # an error in our code, not a user-input error.
         misses = tuple(set(sids) - viewkeys(hits))
         if misses:
-            raise AssertionError(
-                "Couldn't resolve sids {sids} as instances of {type}.".format(
-                    sids=misses,
-                    type=asset_type,
-                )
-            )
+            if asset_type == Equity:
+                raise EquitiesNotFound(sids=misses)
+            else:
+                raise FutureContractsNotFound(sids=misses)
         return hits
 
     def _get_fuzzy_candidates(self, fuzzy_symbol):
@@ -589,7 +623,7 @@ class AssetFinder(object):
             if count == 0:
                 raise RootSymbolNotFound(root_symbol=root_symbol)
 
-        contracts = self._retrieve_futures_contracts(sids)
+        contracts = self.retrieve_futures_contracts(sids)
         return [contracts[sid] for sid in sids]
 
     @property

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -146,12 +146,9 @@ class AssetFinder(object):
             if asset is not None:
                 self._asset_cache[sid] = asset
 
-        if asset is not None:
+        if (asset is not None) or default_none:
             return asset
-        elif default_none:
-            return None
-        else:
-            raise SidNotFound(sid=sid)
+        raise SidNotFound(sid=sid)
 
     def retrieve_all(self, sids, default_none=False):
         return [self.retrieve_asset(sid, default_none) for sid in sids]

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -906,9 +906,7 @@ class AssetFinderCachedEquities(AssetFinder):
         return Equity(**_convert_asset_timestamp_fields(dict(row)))
 
     def _get_fuzzy_candidates(self, fuzzy_symbol):
-        if fuzzy_symbol in self.fuzzy_symbol_hashed_equities:
-            return self.fuzzy_symbol_hashed_equities[fuzzy_symbol]
-        return []
+        return self.fuzzy_symbol_hashed_equities.get(fuzzy_symbol, ())
 
     def _get_fuzzy_candidates_in_range(self, fuzzy_symbol, ad_value):
         equities = self._get_fuzzy_candidates(fuzzy_symbol)
@@ -921,11 +919,10 @@ class AssetFinderCachedEquities(AssetFinder):
         return fuzzy_candidates
 
     def _get_split_candidates(self, company_symbol, share_class_symbol):
-        if (company_symbol, share_class_symbol) in \
-                self.company_share_class_hashed_equities:
-            return self.company_share_class_hashed_equities[(
-                company_symbol, share_class_symbol)]
-        return []
+        return self.company_share_class_hashed_equities.get(
+            (company_symbol, share_class_symbol),
+            (),
+        )
 
     def _get_split_candidates_in_range(self,
                                        company_symbol,

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -152,10 +152,6 @@ class AssetFinder(object):
 
         return found
 
-    def lookup_single_asset_type(self, sid):
-        """Retrieve the asset type for a single asset."""
-        return self.lookup_asset_types([sid])[sid]
-
     def group_by_type(self, sids):
         """
         Group a list of sids by asset type.

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -270,8 +270,8 @@ class AssetFinder(object):
         """
         Internal function for loading assets from a table.
 
-        This function does not do any caching.  It is assumed that this will be
-        called at most once with any given sid.
+        This should be the only method of `AssetFinder` that writes Assets into
+        self._asset_cache.
 
         Parameters
         ---------

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -15,7 +15,6 @@
 from abc import ABCMeta
 from numbers import Integral
 from operator import itemgetter
-import warnings
 
 from logbook import Logger
 import numpy as np
@@ -720,9 +719,8 @@ class AssetFinder(object):
             self._lookup_generic_scalar(identifier, as_of_date,
                                         matches, missing)
 
-        # Handle missing assets
-        if len(missing) > 0:
-            warnings.warn("Missing assets for identifiers: %s" % missing)
+        if missing:
+            raise ValueError("Missing assets for identifiers: %s" % missing)
 
         # Return a list of the sids of the found assets
         return [asset.sid for asset in matches]

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -900,14 +900,11 @@ class AssetFinderCachedEquities(AssetFinder):
                 fuzzy_symbol, []
             ).append(asset)
 
-    def _convert_row_to_equity(self, equity):
+    def _convert_row_to_equity(self, row):
         """
         Converts a SQLAlchemy equity row to an Equity object.
         """
-        data = dict(equity.items())
-        _convert_asset_timestamp_fields(data)
-        asset = Equity(**data)
-        return asset
+        return Equity(**_convert_asset_timestamp_fields(dict(row)))
 
     def _get_fuzzy_candidates(self, fuzzy_symbol):
         if fuzzy_symbol in self.fuzzy_symbol_hashed_equities:

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -238,11 +238,40 @@ class SidsNotFound(ZiplineError):
     non-existent sid.
     """
     @lazyval
+    def plural(self):
+        return len(self.sids) > 1
+
+    @lazyval
+    def sids(self):
+        return self.kwargs['sids']
+
+    @lazyval
     def msg(self):
-        sids = self.kwargs['sids']
-        if len(sids) == 1:
-            return "No asset found for sid: {sids[0]}."
-        return "No assets found for sids: {sids}."
+        if self.plural:
+            return "No assets found for sids: {sids}."
+        return "No asset found for sid: {sids[0]}."
+
+
+class EquitiesNotFound(SidsNotFound):
+    """
+    Raised when a call to `retrieve_equities` fails to find an asset.
+    """
+    @lazyval
+    def msg(self):
+        if self.plural:
+            return "No equities found for sids: {sids}."
+        return "No equity found for sid: {sids[0]}."
+
+
+class FutureContractsNotFound(SidsNotFound):
+    """
+    Raised when a call to `retrieve_futures_contracts` fails to find an asset.
+    """
+    @lazyval
+    def msg(self):
+        if self.plural:
+            return "No future contracts found for sids: {sids}."
+        return "No future contract found for sid: {sids[0]}."
 
 
 class ConsumeAssetMetaDataError(ZiplineError):

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from zipline.utils.memoize import lazyval
+
 
 class ZiplineError(Exception):
     msg = None
 
-    def __init__(self, *args, **kwargs):
-        self.args = args
+    def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.message = str(self)
 
@@ -231,13 +232,17 @@ Root symbol '{root_symbol}' was not found.
 """.strip()
 
 
-class SidNotFound(ZiplineError):
+class SidsNotFound(ZiplineError):
     """
-    Raised when a retrieve_asset() call contains a non-existent sid.
+    Raised when a retrieve_asset() or retrieve_all() call contains a
+    non-existent sid.
     """
-    msg = """
-Asset with sid '{sid}' was not found.
-""".strip()
+    @lazyval
+    def msg(self):
+        sids = self.kwargs['sids']
+        if len(sids) == 1:
+            return "No asset found for sid: {sids[0]}."
+        return "No assets found for sids: {sids}."
 
 
 class ConsumeAssetMetaDataError(ZiplineError):

--- a/zipline/utils/control_flow.py
+++ b/zipline/utils/control_flow.py
@@ -59,15 +59,15 @@ def ignore_nanwarnings():
 
 def invert(d):
     """
-    Invert a dictionary into a dictionary of lists.
+    Invert a dictionary into a dictionary of sets.
 
     >>> invert({'a': 1, 'b': 2, 'c': 1})
-    {1: ['a', 'c'], 2: ['b']}
+    {1: {'a', 'c'}, 2: {'b'}}
     """
     out = {}
     for k, v in iteritems(d):
         try:
-            out[v].append(k)
+            out[v].add(k)
         except KeyError:
-            out[v] = [k]
+            out[v] = {k}
     return out

--- a/zipline/utils/control_flow.py
+++ b/zipline/utils/control_flow.py
@@ -1,6 +1,7 @@
 """
 Control flow utilities.
 """
+from six import iteritems
 from warnings import (
     catch_warnings,
     filterwarnings,
@@ -54,3 +55,19 @@ def ignore_nanwarnings():
             {'category': RuntimeWarning, 'module': 'numpy.lib.nanfunctions'},
         )
     )
+
+
+def invert(d):
+    """
+    Invert a dictionary into a dictionary of lists.
+
+    >>> invert({'a': 1, 'b': 2, 'c': 1})
+    {1: ['a', 'c'], 2: ['b']}
+    """
+    out = {}
+    for k, v in iteritems(d):
+        try:
+            out[v].append(k)
+        except KeyError:
+            out[v] = [k]
+    return out

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -281,7 +281,7 @@ def make_rotating_asset_info(num_assets,
     )
 
 
-def make_simple_asset_info(assets, start_date, end_date, symbols=None):
+def make_simple_equity_info(assets, start_date, end_date, symbols=None):
     """
     Create a DataFrame representing assets that exist for the full duration
     between `start_date` and `end_date`.
@@ -375,7 +375,7 @@ class tmp_assets_db(object):
     def __init__(self, data=None):
         self._eng = None
         self._data = AssetDBWriterFromDataFrame(
-            data if data is not None else make_simple_asset_info(
+            data if data is not None else make_simple_equity_info(
                 list(map(ord, 'ABC')),
                 pd.Timestamp(0),
                 pd.Timestamp('2015'),

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -233,11 +233,11 @@ def all_subindices(index):
     )
 
 
-def make_rotating_asset_info(num_assets,
-                             first_start,
-                             frequency,
-                             periods_between_starts,
-                             asset_lifetime):
+def make_rotating_equity_info(num_assets,
+                              first_start,
+                              frequency,
+                              periods_between_starts,
+                              asset_lifetime):
     """
     Create a DataFrame representing lifetimes of assets that are constantly
     rotating in and out of existence.

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -514,8 +514,12 @@ class tmp_asset_finder(tmp_assets_db):
     data : dict, optional
         The data to feed to the writer
     """
+    def __init__(self, finder_cls=AssetFinder, **frames):
+        self._finder_cls = finder_cls
+        super(tmp_asset_finder, self).__init__(**frames)
+
     def __enter__(self):
-        return AssetFinder(super(tmp_asset_finder, self).__enter__())
+        return self._finder_cls(super(tmp_asset_finder, self).__enter__())
 
 
 class SubTestFailures(AssertionError):


### PR DESCRIPTION
Speed up `AssetFinder.retrieve_all` by doing one query instead of N.

- Removes the separate caches for equities and futures in favor of a single asset cache.
- We now cache the results of failed lookups.  This required unfortunate hacks in the `TradingAlgorithm` code that resolves assets from DataFrames.
- Reimplements single-asset lookups as a special case of multiple-asset lookups.