### PR TITLE
ENH: Truncate negative dividend adjustment ratios to 0.05

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -687,7 +687,19 @@ class SQLiteAdjustmentWriter(object):
                     sid, prev_close_date, 'close')
                 if prev_close != 0.0:
                     ratio = 1.0 - amount / prev_close
-                    ratios[i] = ratio
+                    # Occasionally assets pay dividends greater than the last
+                    # traded value of the asset. Instead of allowing the
+                    # adjustment ratio to be negative, set a low adjustment
+                    # ratio. Example: http://finance.yahoo.com/q?s=VXUP
+                    if ratio < 0:
+                        logger.warn("Dividend adjustment ratio for sid {0} is "
+                                    "<0: amount={1}, prev_close={2}; "
+                                    "updating to 0.05".format(sid, amount,
+                                                              prev_close)
+                                    )
+                        ratios[i] = 0.05
+                    else:
+                        ratios[i] = ratio
                     # only assign effective_date when data is found
                     effective_dates[i] = ex_date
             except NoDataOnDate:


### PR DESCRIPTION
Occasionally assets pay dividends greater than the last traded
value of the asset. This can occur when investors are uncertain
about the nature of the dividend payments, which means they are
not able to correctly price the asset in advance of the dividend.
After these payments the assets fall dramatically in value. Use
a 5% adjustment factor as it is consistent with the case of VXUP
and VXDN: http://finance.yahoo.com/q?s=VXUP.