### PR TITLE
BLD: Don't pin install requirements to exact versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ install:
   - source activate testenv
   - conda install --yes -c https://conda.binstar.org/Quantopian numpy=$NUMPY_VERSION pandas=$PANDAS_VERSION scipy==$SCIPY_VERSION matplotlib Cython patsy statsmodels tornado pyparsing xlrd mock pytz requests six dateutil ta-lib logbook
   - pip install --upgrade pip coverage
-  - pip install -e .[dev]
+  - pip install -r etc/requirements.txt
+  - pip install -r etc/requirements_dev.txt
   - pip install -r etc/requirements_blaze.txt
+  - python setup.py build_ext --inplace
 before_script:
   - pip freeze | sort
   - "flake8 zipline tests"

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -43,7 +43,7 @@ None
 Build
 ~~~~~
 
-None
+* Makes zipline install requirements more flexible (:issue:`825`).
 
 Documentation
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -118,13 +118,20 @@ def _filter_requirements(lines_iter):
             yield requirement
 
 
-def read_requirements(path):
+def read_requirements(path, convert_eq_to_lte=True):
     """
     Read a requirements.txt file, expressed as a path relative to Zipline root.
+
+    Returns requirements with the pinned versions as lower bounds.
     """
     real_path = join(dirname(abspath(__file__)), path)
     with open(real_path) as f:
-        return list(_filter_requirements(f.readlines()))
+        reqs = _filter_requirements(f.readlines())
+
+        if not convert_eq_to_lte:
+            return list(reqs)
+        else:
+            return [req.replace('==', '>=') for req in reqs]
 
 
 def install_requires():

--- a/setup.py
+++ b/setup.py
@@ -118,17 +118,18 @@ def _filter_requirements(lines_iter):
             yield requirement
 
 
-def read_requirements(path, convert_eq_to_lte=True):
+def read_requirements(path, strict_bounds=False):
     """
     Read a requirements.txt file, expressed as a path relative to Zipline root.
 
-    Returns requirements with the pinned versions as lower bounds.
+    Returns requirements with the pinned versions as lower bounds
+    if `strict_bounds` is falsey.
     """
     real_path = join(dirname(abspath(__file__)), path)
     with open(real_path) as f:
         reqs = _filter_requirements(f.readlines())
 
-        if not convert_eq_to_lte:
+        if strict_bounds:
             return list(reqs)
         else:
             return [req.replace('==', '>=') for req in reqs]
@@ -139,7 +140,8 @@ def install_requires():
 
 
 def extras_requires():
-    dev_reqs = read_requirements('etc/requirements_dev.txt')
+    dev_reqs = read_requirements('etc/requirements_dev.txt',
+                                 strict_bounds=True)
     talib_reqs = ['TA-Lib==0.4.9']
     return {
         'dev': dev_reqs,


### PR DESCRIPTION
Instead, use those versions as lower bounds, so zipline
will work with packages that require other versions.