### PR TITLE
Siddata caching affects len

### DIFF
--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from copy import copy
 
 from six import iteritems, iterkeys
@@ -377,7 +376,7 @@ class SIDData(object):
         else:
             return buffer_[self._sid][-bars:]
 
-    def _get_bars(self, days):
+    def _cache_daily_minutely(self, days, fn):
         """
         Gets the number of bars needed for the current number of days.
 
@@ -439,8 +438,20 @@ class SIDData(object):
             self._get_bars = minute_get_bars
             self._get_max_bars = minute_get_max_bars
 
+        # NOTE: This silently adds these two entries to the `__dict__`
+        # without affecting the `__len__` of the object. This is important
+        # because we use the `len` of the `SIDData` object to see if we have
+        # data for this asset.
+        self._initial_len += 2
+
         # Not actually recursive because we have already cached the new method.
-        return self._get_bars(days)
+        return getattr(self, fn)(days)
+
+    def _get_bars(self, bars):
+        return self._cache_daily_minutely(bars, fn='_get_bars')
+
+    def _get_max_bars(self, bars):
+        return self._cache_daily_minutely(bars, fn='_get_max_bars')
 
     def mavg(self, days):
         bars = self._get_bars(days)

--- a/zipline/sources/test_source.py
+++ b/zipline/sources/test_source.py
@@ -126,9 +126,9 @@ class SpecificEquityTrades(object):
             self.count = kwargs.get('count', len(self.event_list))
             self.start = kwargs.get('start', self.event_list[0].dt)
             self.end = kwargs.get('end', self.event_list[-1].dt)
-            self.delta = kwargs.get(
-                'delta',
-                self.event_list[1].dt - self.event_list[0].dt)
+            self.delta = delta = kwargs.get('delta')
+            if delta is None:
+                self.delta = self.event_list[1].dt - self.event_list[0].dt
             self.concurrent = kwargs.get('concurrent', False)
 
             self.identifiers = kwargs.get(


### PR DESCRIPTION
When we cache the two methods on the instance, we need to update the initial_len to account for these untracked attributes in the dict.

Long term goal of removing `__len__` and `__contains__` from this object, it is not a container.