### PR TITLE
TST: Limit the timer report to just the 15 longest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_script:
   - pip freeze | sort
   - "flake8 zipline tests"
 script:
-  - nosetests --with-timer --exclude=^test_examples --with-coverage --cover-package=zipline
+  - nosetests --with-timer --exclude=^test_examples --with-coverage --cover-package=zipline --timer-top-n=15
 after_success:
   - coveralls

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -67,3 +67,4 @@ Miscellaneous
 * Adds :func:`~zipline.utils.test_utils.subtest` decorator for creating subtests
   without ``nose_parameterized.expand`` which bloats the test output
   (:issue:`833`).
+* Limits timer report in test output to 15 longest tests (:issue:`838`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ verbosity=2
 detailed-errors=1
 with-ignore-docstrings=1
 with-timer=1
+timer-top-n=15
 
 [metadata]
 description-file = README.rst


### PR DESCRIPTION
The default of all the tests is pretty spammy.