### PR TITLE
TST: tests removing of expired data and removes ffill in DataPanelSource

### DIFF
--- a/tests/test_events_through_risk.py
+++ b/tests/test_events_through_risk.py
@@ -15,6 +15,7 @@
 
 import unittest
 import datetime
+import pandas as pd
 import pytz
 
 import numpy as np
@@ -77,9 +78,9 @@ class TestEventsThroughRisk(unittest.TestCase):
 
         algo = BuyAndHoldAlgorithm(sim_params=sim_params, env=self.env)
 
-        first_date = datetime.datetime(2006, 1, 3, tzinfo=pytz.utc)
-        second_date = datetime.datetime(2006, 1, 4, tzinfo=pytz.utc)
-        third_date = datetime.datetime(2006, 1, 5, tzinfo=pytz.utc)
+        first_date = pd.Timestamp('2006-01-03', tz='UTC')
+        second_date = pd.Timestamp('2006-01-04', tz='UTC')
+        third_date = pd.Timestamp('2006-01-05', tz='UTC')
 
         trade_bar_data = [
             Event({

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -123,12 +123,7 @@ class TestDataFrameSource(TestCase):
         self.assertEqual(5, event.sid)
         event = next(source)
         self.assertEqual(4, event.sid)
-        try:
-            x = False
-            event = next(source)
-        except StopIteration:
-            x = True
-        self.assertTrue(x)
+        self.assertRaises(StopIteration, next, source)
 
 
 class TestRandomWalkSource(TestCase):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -123,9 +123,12 @@ class TestDataFrameSource(TestCase):
         self.assertEqual(5, event.sid)
         event = next(source)
         self.assertEqual(4, event.sid)
-        event = next(source)
-        self.assertEqual(5, event.sid)
-        self.assertFalse(np.isnan(event.price))
+        try:
+            x = False
+            event = next(source)
+        except StopIteration:
+            x = True
+        self.assertTrue(x)
 
 
 class TestRandomWalkSource(TestCase):

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -266,9 +266,9 @@ class AssetFinder(object):
                 self.equities.c.share_class_symbol ==
                 share_class_symbol,
                 self.equities.c.start_date <= ad_value),
-            ).order_by(
-                self.equities.c.end_date.desc(),
-            ).execute().fetchall()
+        ).order_by(
+            self.equities.c.end_date.desc(),
+        ).execute().fetchall()
         return candidates
 
     def _get_best_candidate(self, candidates):
@@ -491,6 +491,26 @@ class AssetFinder(object):
                 raise RootSymbolNotFound(root_symbol=root_symbol)
 
         return list(map(self._retrieve_futures_contract, sids))
+
+    def lookup_expired_futures(self, start, end):
+        start = start.value
+        end = end.value
+
+        fc_cols = self.futures_contracts.c
+
+        nd = sa.func.nullif(fc_cols.notice_date, pd.tslib.iNaT)
+        ed = sa.func.nullif(fc_cols.expiration_date, pd.tslib.iNaT)
+        date = sa.func.coalesce(sa.func.min(nd, ed), ed, nd)
+
+        sids = list(map(
+            itemgetter('sid'),
+            sa.select((fc_cols.sid,)).where(
+                (date >= start) & (date < end)).order_by(
+                sa.func.coalesce(ed, nd).asc()
+            ).execute().fetchall()
+        ))
+
+        return sids
 
     @property
     def sids(self):
@@ -741,6 +761,7 @@ class AssetFinderCachedEquities(AssetFinder):
     into memory and overrides the methods that lookup_symbol uses to look up
     those equities.
     """
+
     def __init__(self, engine):
         super(AssetFinderCachedEquities, self).__init__(engine)
         self.fuzzy_symbol_hashed_equities = {}

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -26,6 +26,7 @@ from zipline.protocol import (
     SIDData,
     DATASOURCE_TYPE
 )
+from zipline.errors import SidNotFound
 
 log = Logger('Trade Simulation')
 
@@ -99,6 +100,16 @@ class AlgorithmSimulator(object):
 
                 self.simulation_dt = date
                 self.on_dt_changed(date)
+
+                # removing expired futures
+                for sid in self.current_data.keys():
+                    try:
+                        if self.env.asset_finder.retrieve_asset(sid).end_date \
+                                < self.simulation_dt:
+                            del self.current_data[sid]
+                    except (AttributeError, TypeError, ValueError,
+                            SidNotFound):
+                        continue
 
                 # If we're still in the warmup period.  Use the event to
                 # update our universe, but don't yield any perf messages,

--- a/zipline/sources/data_frame_source.py
+++ b/zipline/sources/data_frame_source.py
@@ -114,7 +114,6 @@ class DataPanelSource(DataSource):
         # TODO is ffilling correct/necessary?
         # forward fill with volumes of 0
         self.data = data.fillna(value={'volume': 0})
-        self.data = self.data.fillna(method='ffill')
         # Unpack config dictionary with default values.
         self.start = kwargs.get('start', self.data.major_axis[0])
         self.end = kwargs.get('end', self.data.major_axis[-1])
@@ -153,8 +152,7 @@ class DataPanelSource(DataSource):
             df = self.data.major_xs(dt)
             for sid, series in df.iteritems():
                 # Skip SIDs that can not be forward filled
-                if np.isnan(series['price']) and \
-                   sid not in self.started_sids:
+                if np.isnan(series['price']):
                     continue
                 self.started_sids.add(sid)
 

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -937,6 +937,16 @@ class InvalidOrderAlgorithm(TradingAlgorithm):
                                      style=style)
 
 
+class TestRemoveDataAlgo(TradingAlgorithm):
+    def initialize(self, *args, **kwargs):
+        self.data = np.zeros(6)
+        self.i = 0
+
+    def handle_data(self, data):
+        self.data[self.i] = len(data)
+        self.i += 1
+
+
 ##############################
 # Quantopian style algorithms
 

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -939,7 +939,7 @@ class InvalidOrderAlgorithm(TradingAlgorithm):
 
 class TestRemoveDataAlgo(TradingAlgorithm):
     def initialize(self, *args, **kwargs):
-        self.data = np.zeros(6)
+        self.data = np.zeros(7)
         self.i = 0
 
     def handle_data(self, data):


### PR DESCRIPTION
Currently it seems as though the data for expired futures is not removed from the info that gets sent to ```handle_data```. Over longer backtests this can result in the ```data``` variable becoming quite large and gives in a large reduction in performance esp when ```history``` is used.
cc @jfkirk @dhexus