### PR TITLE
MAINT: Fix type coercion warnings with numpy 1.10.

### DIFF
--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -21,6 +21,7 @@ from unittest import TestCase
 
 from nose_parameterized import parameterized
 import numpy as np
+import pandas as pd
 from six import iteritems
 from six.moves import range, map
 
@@ -254,8 +255,8 @@ class TestStatelessRules(RuleTestCase):
         cls.class_ = StatelessRule
 
         cls.sept_days = cls.env.days_in_range(
-            np.datetime64(datetime.date(year=2014, month=9, day=1)),
-            np.datetime64(datetime.date(year=2014, month=9, day=30)),
+            pd.Timestamp('2014-09-01'),
+            pd.Timestamp('2014-09-30'),
         )
 
         cls.sept_week = cls.env.minutes_for_days_in_range(

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -20,7 +20,6 @@ import random
 from unittest import TestCase
 
 from nose_parameterized import parameterized
-import numpy as np
 import pandas as pd
 from six import iteritems
 from six.moves import range, map

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -149,10 +149,10 @@ class SyntheticDailyBarWriter(BcolzDailyBarWriter):
         )
 
         # Add 10,000 * column-index to OHLCV columns
-        data[:, :5] += arange(5) * (10 * 1000)
+        data[:, :5] += arange(5, dtype=uint32) * (10 * 1000)
 
         # Add days since Jan 1 2001 for OHLCV columns.
-        data[:, :5] += (dates - self.PSEUDO_EPOCH).days[:, None]
+        data[:, :5] += (dates - self.PSEUDO_EPOCH).days[:, None].astype(uint32)
 
         frame = DataFrame(
             data,


### PR DESCRIPTION
Numpy warns about adding Python integers to uint32s and converting date
objects to datetime64.