### PR TITLE
Docs improvements

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -5,7 +5,7 @@ Algorithm API
 ~~~~~~~~~~~~~
 
 The following methods are available for use in the ``initialize``,
-``handle_data`` and ``before_trading_start`` API functions.
+``handle_data``, and ``before_trading_start`` API functions.
 
 In all listed functions, the ``self`` argument is implicitly the
 currently-executing :class:`~zipline.algorithm.TradingAlgorithm` instance.

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -1,8 +1,62 @@
-Zipline API
------------
+API Reference
+-------------
 
-For each of these api functions, the ``self`` argument is implicitly the current
-:class:`~zipline.algorithm.TradingAlgorithm`
+Algorithm API
+~~~~~~~~~~~~~
+
+The following methods are available for use in the ``initialize``,
+``handle_data`` and ``before_trading_start`` API functions.
+
+In all listed functions, the ``self`` argument is implicitly the
+currently-executing :class:`~zipline.algorithm.TradingAlgorithm` instance.
 
 .. automodule:: zipline.api
+   :members:
+
+.. autoclass:: zipline.algorithm.TradingAlgorithm
+
+Pipeline API
+~~~~~~~~~~~~
+
+.. autoclass:: zipline.pipeline.Pipeline
+   :members:
+   :member-order: groupwise
+
+.. autoclass:: zipline.pipeline.CustomFactor
+   :members:
+   :member-order: groupwise
+
+.. autoclass:: zipline.pipeline.factors.Factor
+   :members: top, bottom, rank, percentile_between, isnan, notnan, isfinite,
+             eq, __add__, __sub__, __mul__, __div__, __mod__, __pow__, __lt__,
+             __le__, __ne__, __ge__, __gt__
+   :exclude-members: dtype
+   :member-order: bysource
+
+.. autoclass:: zipline.pipeline.filters.Filter
+   :members: __and__, __or__
+   :exclude-members: dtype
+
+Asset Metadata
+~~~~~~~~~~~~~~
+
+.. autoclass:: zipline.assets.assets.Asset
+   :members:
+
+.. autoclass:: zipline.assets.assets.Equity
+   :members:
+
+.. autoclass:: zipline.assets.assets.Future
+   :members:
+
+.. autoclass:: zipline.assets.assets.AssetFinder
+   :members:
+
+.. autoclass:: zipline.assets.assets.AssetFinderCachedEquities
+   :members:
+
+.. autoclass:: zipline.assets.asset_writer.AssetDBWriter
+   :members:
+
+.. autoclass:: zipline.assets.assets.AssetConvertible
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
     'sphinx.ext.autosummary',
+    'sphinx.ext.viewcode',
 ]
 
 

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -2,6 +2,8 @@
 Release Notes
 =============
 
+.. include:: whatsnew/0.8.4.txt
+
 .. include:: whatsnew/0.8.3.txt
 
 .. include:: whatsnew/0.8.0.txt

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -19,7 +19,10 @@ Enhancements
   passed to :class:`~zipline.algorithm.TradingAlgorithm` by the keyword argument
   ``create_event_context`` (:issue:`828`).
 
-* Added `isnan`, `notnan`, and `isfinite` methods to `Factor` (:issue:`861`).
+.. py:currentmodule:: zipline.pipeline.factors
+
+* Added :meth:`~Factor.isnan`, :meth:`~Factor.notnan` and
+  :meth:`~Factor.isfinite` methods to :class:`Factor` (:issue:`861`).
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
@@ -40,10 +43,12 @@ Bug Fixes
 Performance
 ~~~~~~~~~~~
 
-* Speeds up `AssetFinder.lookup_symbol` by adding an extension, 
-`AssetFinderCachedEquities`, that loads equities into dictionaries and
-then directs `lookup_symbol` to these dictionaries to find matching equities
- (:issue:`830`).
+.. py:currentmodule:: zipline.assets.assets
+
+* Speeds up :meth:`AssetFinder.lookup_symbol` by adding an extension,
+  :class:`AssetFinderCachedEquities`, that loads equities into dictionaries and
+  then directs :meth:`AssetFinder.lookup_symbol` to these dictionaries to find
+  matching equities (:issue:`830`).
 
 Maintenance and Refactorings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -16,7 +16,7 @@ None
 Enhancements
 ~~~~~~~~~~~~
 
-* Adds a way for users to specify context manager to use when executing the
+* Adds a way for users to provide a context manager to use when executing the
   scheduled functions (including ``handle_data``). This context manager will be
   passed the :class:`~zipline.protocol.BarData` object for the bar and will
   be used for the duration of all of the functions scheduled to run. This can be

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -1,8 +1,12 @@
-Release 0.8.4
--------------
+Development
+-----------
 
 :Release: 0.8.4
 :Date: TBD
+
+.. warning::
+   This release is still under active development.  All changes listed are
+   subject to change at any time.
 
 Highlights
 ~~~~~~~~~~

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -19,6 +19,8 @@ Enhancements
   passed to :class:`~zipline.algorithm.TradingAlgorithm` by the keyword argument
   ``create_event_context`` (:issue:`828`).
 
+* Added `isnan`, `notnan`, and `isfinite` methods to `Factor` (:issue:`861`).
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -23,10 +23,10 @@ Enhancements
   passed to :class:`~zipline.algorithm.TradingAlgorithm` by the keyword argument
   ``create_event_context`` (:issue:`828`).
 
-.. py:currentmodule:: zipline.pipeline.factors
-
-* Added :meth:`~Factor.isnan`, :meth:`~Factor.notnan` and
-  :meth:`~Factor.isfinite` methods to :class:`Factor` (:issue:`861`).
+* Added :meth:`~zipline.pipeline.factors.Factor.isnan`,
+  :meth:`~zipline.pipeline.factors.Factor.notnan` and
+  :meth:`~zipline.pipeline.factors.Factor.isfinite` methods to
+  :class:`zipline.pipeline.factors.Factor` (:issue:`861`).
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
@@ -47,12 +47,11 @@ Bug Fixes
 Performance
 ~~~~~~~~~~~
 
-.. py:currentmodule:: zipline.assets.assets
-
-* Speeds up :meth:`AssetFinder.lookup_symbol` by adding an extension,
-  :class:`AssetFinderCachedEquities`, that loads equities into dictionaries and
-  then directs :meth:`AssetFinder.lookup_symbol` to these dictionaries to find
-  matching equities (:issue:`830`).
+* Speeds up :meth:`~zipline.assets.assets.AssetFinder.lookup_symbol` by adding
+  an extension, :class:`~zipline.assets.assets.AssetFinderCachedEquities`, that
+  loads equities into dictionaries and then directs
+  :meth:`~zipline.assets.assets.AssetFinder.lookup_symbol` to these dictionaries
+  to find matching equities (:issue:`830`).
 
 Maintenance and Refactorings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -73,6 +73,8 @@ Documentation
 * Document the release process for developers (:issue:`835`).
 * Added reference docs for the Pipeline API. (:issue:`864`).
 * Added reference docs for Asset Metadata APIs. (:issue:`864`).
+* Generated documentation now includes links to source code for many classes
+  and functions. (:issue:`864`).
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -68,6 +68,8 @@ Documentation
 ~~~~~~~~~~~~~
 
 * Document the release process for developers (:issue:`835`).
+* Added reference docs for the Pipeline API. (:issue:`864`).
+* Added reference docs for Asset Metadata APIs. (:issue:`864`).
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/zipline/assets/_assets.pyx
+++ b/zipline/assets/_assets.pyx
@@ -1,3 +1,4 @@
+# cython: embedsignature=True
 #
 # Copyright 2015 Quantopian, Inc.
 #

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -76,9 +76,25 @@ def _convert_asset_timestamp_fields(dict_):
 
 
 class AssetFinder(object):
+    """
+    An AssetFinder is an interface to a database of Asset metadata written by
+    an ``AssetDBWriter``.
 
+    This class provides methods for looking up assets by unique integer id or
+    by symbol.  For historical reasons, we refer to these unique ids as 'sids'.
+
+    Parameters
+    ----------
+    engine : str or SQLAlchemy.engine
+        An engine with a connection to the asset database to use, or a string
+        that can be parsed by SQLAlchemy as a URI.
+
+    See Also
+    --------
+    :class:`zipline.assets.asset_writer.AssetDBWriter`
+    """
     # Token used as a substitute for pickling objects that contain a
-    # reference to an AssetFinder
+    # reference to an AssetFinder.
     PERSISTENT_TOKEN = "<AssetFinder>"
 
     def __init__(self, engine):

--- a/zipline/pipeline/pipeline.py
+++ b/zipline/pipeline/pipeline.py
@@ -17,7 +17,7 @@ class Pipeline(object):
     To compute a pipeline in the context of a TradingAlgorithm, users must call
     ``attach_pipeline`` in their ``initialize`` function to register that the
     pipeline should be computed each trading day.  The outputs of a pipeline on
-    a given day can be accessed by calling ``pipeline_outputs`` in
+    a given day can be accessed by calling ``pipeline_output`` in
     ``handle_data`` or ``before_trading_start``.
 
     Parameters


### PR DESCRIPTION
- Generate links to sourcecode via the Sphinx `viewcode` extension.
- Generate reference docs for Asset/Equity/Future, AssetFinder, and
  AssetDBWriter.
- Generate reference docs for Pipeline API classes.
- Fix broken links and formatting issues in the 0.8.4 whatsnew.
- Use embedsignature in _assets.pyx so that the signatures of Asset
  subclasses are inspectable.