### PR TITLE
BLD: Replace `pre_setup` with a lazy cmdclass.

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -41,7 +41,7 @@ networkx==1.9.1
 numexpr==2.4.3
 
 # On disk storage format for pipeline data.
-bcolz==0.10.0
+bcolz==0.12.1
 
 # Command line interface helper
 click==4.0.0


### PR DESCRIPTION
Replaces `LazyCythonizingList` and our janky `pre_setup` function that
shells out to `pip` with a custom `build_ext` class that lazily accesses
`numpy` and `Cython`.  This means that we no longer depend on Cython and
numpy until after those modules have been installed by setuptools
because they're specified as part of `setup_requires`.

This currently still fails because `bcolz` imports numpy at module scope
in their `setup.py`.