### PR TITLE
REF: Use daily bar reader spot price in portal

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -486,7 +486,11 @@ class BcolzDailyBarReader(object):
             Raises a NoDataOnDate exception if the given day and sid is before
             or after the date range of the equity.
         """
-        day_loc = self._calendar.get_loc(day)
+        try:
+            day_loc = self._calendar.get_loc(day)
+        except:
+            raise NoDataOnDate("day={0} is outside of calendar={1}".format(
+                day, self._calendar))
         offset = day_loc - self._calendar_offsets[sid]
         if offset < 0:
             raise NoDataOnDate(


### PR DESCRIPTION
On the path of removing the need to hardcode/or pass around a 'first
trading day' value, use the calendar alreday embedded in the bcolz file
by the daily bar writer by using the daily bar reader's spot_price
method.

Removes one, but not all of the uses of the `FIRST_TRADING_DAY` value.