### PR TITLE
ENH: Remove hard coding of first day in portal

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -186,8 +186,8 @@ class TestBenchmark(TestCase):
 
         days_to_use = self.sim_params.trading_days
 
-        # first value should be 0.10, coming from daily data
-        self.assertAlmostEquals(0.10, source.get_value(days_to_use[0]))
+        # first value should be 0.0, coming from daily data
+        self.assertAlmostEquals(0.0, source.get_value(days_to_use[0]))
 
         manually_calculated = self.data_portal.get_history_window(
             [2], days_to_use[-1], len(days_to_use), "1d", "close_price"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -884,12 +884,12 @@ class HistoryTestCase(TestCase):
                 for i in range(0, 6):
                     self.assertEqual(len(window.iloc[i]), 0)
 
-    def test_daily_window_starts_before_1_2_2002(self):
+    def test_daily_window_starts_before_minute_data(self):
 
         env = TradingEnvironment()
         asset_info = make_simple_asset_info(
             [self.GS],
-            Timestamp('1999-05-04'),
+            Timestamp('1999-04-05'),
             Timestamp('2004-08-30'),
             ['GS']
         )
@@ -898,7 +898,8 @@ class HistoryTestCase(TestCase):
 
         window = portal.get_history_window(
             [self.GS],
-            pd.Timestamp("2002-01-04 14:35:00", tz='UTC'),
+            # 3rd day of daily data for GS, minute data starts in 2002.
+            pd.Timestamp("1999-04-07 14:35:00", tz='UTC'),
             10,
             "1d",
             "low"

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -806,6 +806,11 @@ class DataPortal(object):
         end_idx = self._find_position_of_minute(minutes_for_window[-1]) + 1
 
         return_data = np.zeros(len(minutes_for_window), dtype=np.float64)
+
+        if end_idx == 0:
+            # No data to return for minute window.
+            return return_data
+
         data_to_copy = raw_data[start_idx:end_idx]
 
         num_minutes = len(minutes_for_window)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -26,6 +26,7 @@ from zipline.data.us_equity_pricing import (
     BcolzDailyBarReader,
     NoDataOnDate
 )
+from zipline.pipeline.data.equity_pricing import USEquityPricing
 
 from zipline.utils import tradingcalendar
 from zipline.errors import (
@@ -33,8 +34,6 @@ from zipline.errors import (
     NoTradeDataAvailableTooLate
 )
 
-# FIXME anything to do with 2002-01-02 probably belongs in qexec, right/
-FIRST_TRADING_DAY = pd.Timestamp("2002-01-02 00:00:00", tz='UTC')
 FIRST_TRADING_MINUTE = pd.Timestamp("2002-01-02 14:31:00", tz='UTC')
 
 # FIXME should this be passed in (is this qexec specific?)?
@@ -53,6 +52,18 @@ BASE_FIELDS = {
     'close_price': 'close',
     'volume': 'volume',
     'price': 'close'
+}
+
+
+US_EQUITY_COLUMNS = {
+    'open': USEquityPricing.open,
+    'open_price': USEquityPricing.open,
+    'high': USEquityPricing.high,
+    'low': USEquityPricing.low,
+    'close': USEquityPricing.close,
+    'close_price': USEquityPricing.close,
+    'volume': USEquityPricing.volume,
+    'price': USEquityPricing.close,
 }
 
 
@@ -132,7 +143,6 @@ class DataPortal(object):
         self._equity_sid_path_func = equity_sid_path_func
         self._futures_sid_path_func = futures_sid_path_func
 
-        self.DAILY_PRICE_ADJUSTMENT_FACTOR = 0.001
         self.MINUTE_PRICE_ADJUSTMENT_FACTOR = 0.001
 
         if daily_equities_path is not None:
@@ -214,13 +224,6 @@ class DataPortal(object):
                     self._augmented_sources_map[col_name] = {}
 
                 self._augmented_sources_map[col_name][identifier] = df
-
-    def _open_daily_file(self):
-        if self._daily_equities_data is None:
-            self._daily_equities_data = bcolz.open(self._daily_equities_path)
-            self.daily_equities_attrs = self._daily_equities_data.attrs
-
-        return self._daily_equities_data, self.daily_equities_attrs
 
     def _open_minute_file(self, field, asset):
         sid_str = str(int(asset))
@@ -954,6 +957,8 @@ class DataPortal(object):
         day = minute_dt.date()
         day_idx = tradingcalendar.trading_days.searchsorted(day) -\
             INDEX_OF_FIRST_TRADING_DAY
+        if day_idx < 0:
+            return -1
 
         day_open = pd.Timestamp(
             datetime(
@@ -1001,12 +1006,11 @@ class DataPortal(object):
         nan.
 
         """
-        daily_data, daily_attrs = self._open_daily_file()
-
-        # the daily file stores each sid's daily OHLCV in a contiguous block.
-        # the first row per sid is either 1/2/2002, or the sid's start_date if
-        # it started after 1/2/2002.  once a sid stops trading, there are no
-        # rows for it.
+        column = US_EQUITY_COLUMNS[field]
+        data = self._daily_bar_reader.load_raw_arrays([column],
+                                                      days_in_window[0],
+                                                      days_in_window[-1],
+                                                      [asset])
 
         bar_count = len(days_in_window)
 
@@ -1019,59 +1023,13 @@ class DataPortal(object):
         return_array[:] = np.NAN
         sid = int(asset)
 
-        # find the start index in the daily file for this asset
-        asset_file_index = daily_attrs['first_row'][str(sid)]
-
-        trading_days = tradingcalendar.trading_days
-
-        # Calculate the starting day to use (either the asset's first trading
-        # day, or 1/1/2002 (which is the 3028th day in the trading calendar).
-        first_trading_day_to_use = max(trading_days.searchsorted(
-            self._asset_start_dates[asset]), INDEX_OF_FIRST_TRADING_DAY)
-
-        # find the # of trading days between max(asset's first trade date,
-        # 2002-01-02) and start_dt
-        window_offset = (trading_days.searchsorted(days_in_window[0]) -
-                         first_trading_day_to_use)
-
-        start_index = max(asset_file_index, asset_file_index + window_offset)
-
-        if window_offset < 0 and (abs(window_offset) > bar_count):
-            # consumer is requesting a history window that starts AND ends
-            # before this equity started trading, so gtfo
-            return return_array
-
-        # find the end index in the daily file. make sure it doesn't extend
-        # past the end of this asset's data in the daily file.
-        if window_offset < 0:
-            # if the window_offset is negative, we need to decrease the
-            # end_index accordingly.
-            end_index = min(start_index + window_offset + bar_count,
-                            daily_attrs['last_row'][str(sid)] + 1)
-
-            # get data from bcolz file
-            data = daily_data[field][start_index:end_index]
-
-            # have to leave a bunch of empty slots at the beginning of
-            # return_array, since they represent days before this asset
-            # started trading.
-            return_array[abs(window_offset):bar_count] = data
-        else:
-            end_index = min(start_index + bar_count,
-                            daily_attrs['last_row'][str(sid)])
-            data = daily_data[field][start_index:(end_index + 1)]
-
-            if len(data) > len(return_array):
-                return_array[:] = data[0:len(return_array)]
-            else:
-                return_array[0:len(data)] = data
+        return_array[0:bar_count] = data[0].T[0]
 
         self._apply_all_adjustments(
             return_array,
             sid,
             days_in_window,
             field,
-            self.DAILY_PRICE_ADJUSTMENT_FACTOR
         )
 
         return return_array

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -432,7 +432,11 @@ class BcolzDailyBarReader(object):
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
         # Assumes that the given dates are actually in calendar.
-        start_idx = self._calendar.get_loc(start_date)
+        try:
+            start_idx = self._calendar.get_loc(start_date)
+        except KeyError:
+            raise NoDataOnDate("day={0} is before calendar={1}".format(
+                start_date, self._calendar))
         end_idx = self._calendar.get_loc(end_date)
         first_rows, last_rows, offsets = self._compute_slices(
             start_idx,


### PR DESCRIPTION
Use daily bar reader for daily history values in data portal, which
removes the need maintaining the first trading day in the data portal
class. The daily bar reader reads the calendar and asset starts from the
data written to the daily bar file. Using that data removes the need to
hard code the values in the data portal module, without having to pass
the values down to the data portal as parameters.

Removes daily pricing adjustment from data portal since that value is
handled by the daily bar reader.

Also, update how daily benchmarks (which uses the data_portal) handles
the case where the daily bar reader does not have data for the day
before the start of the backtest. (Since the reader throws an exception
when data is accessed before the calendar start.)