### PR TITLE
Fix sharpe3

### DIFF
--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -41,7 +41,7 @@ from zipline.utils.serialization_utils import (
 log = logbook.Logger('Risk Cumulative')
 
 
-choose_treasury = functools.partial(choose_treasury, lambda *args: '10year',
+choose_treasury = functools.partial(choose_treasury, lambda *args: '3month',
                                     compound=False)
 
 
@@ -390,10 +390,8 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         """
         http://en.wikipedia.org/wiki/Sharpe_ratio
         """
-        return sharpe_ratio(
-            self.algorithm_volatility[self.latest_dt_loc],
-            self.annualized_mean_returns_cont[self.latest_dt_loc],
-            self.daily_treasury[self.latest_dt.date()])
+        return sharpe_ratio(self.algorithm_returns,
+                            self.daily_treasury[:self.latest_dt.date()])
 
     def calculate_sortino(self):
         """

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -218,8 +218,7 @@ class RiskMetricsPeriod(object):
         """
         http://en.wikipedia.org/wiki/Sharpe_ratio
         """
-        return sharpe_ratio(self.algorithm_volatility,
-                            self.algorithm_period_returns,
+        return sharpe_ratio(self.algorithm_returns,
                             self.treasury_period_return)
 
     def calculate_sortino(self):

--- a/zipline/finance/risk/risk.py
+++ b/zipline/finance/risk/risk.py
@@ -88,22 +88,29 @@ def check_entry(key, value):
 ############################
 
 
-def sharpe_ratio(algorithm_volatility, algorithm_return, treasury_return):
+def sharpe_ratio(algorithm_return, treasury_return):
     """
     http://en.wikipedia.org/wiki/Sharpe_ratio
 
     Args:
-        algorithm_volatility (float): Algorithm volatility.
-        algorithm_return (float): Algorithm return percentage.
-        treasury_return (float): Treasury return percentage.
+        algorithm_return (float): Daily algorithm return percentage.
+        treasury_return (float): Annual treasury return percentage.
 
     Returns:
         float. The Sharpe ratio.
     """
-    if zp_math.tolerant_equals(algorithm_volatility, 0):
+    if len(algorithm_return) < 2:
         return np.nan
 
-    return (algorithm_return - treasury_return) / algorithm_volatility
+    # compute daily returns from provided annual treasury yields
+    if treasury_return != 0:
+        treasury_return_daily = (1 + treasury_return)**(1/252) - 1
+
+    return_risk_adj = algorithm_return - treasury_return_daily
+
+    return np.mean(return_risk_adj) / \
+        np.std(return_risk_adj) * \
+        np.sqrt(252)
 
 
 def downside_risk(algorithm_returns, mean_returns, normalization_factor):

--- a/zipline/finance/risk/risk.py
+++ b/zipline/finance/risk/risk.py
@@ -93,8 +93,8 @@ def sharpe_ratio(algorithm_return, treasury_return):
     http://en.wikipedia.org/wiki/Sharpe_ratio
 
     Args:
-        algorithm_return (float): Daily algorithm return percentage.
-        treasury_return (float): Annual treasury return percentage.
+        algorithm_return (array-like): Daily algorithm return percentage.
+        treasury_return (array-like): Daily treasury return percentage.
 
     Returns:
         float. The Sharpe ratio.
@@ -102,15 +102,14 @@ def sharpe_ratio(algorithm_return, treasury_return):
     if len(algorithm_return) < 2:
         return np.nan
 
+    if len(algorithm_return) != len(treasury_return):
+        raise ValueError("the length of algorithm_return must be the same as treasury_return's")
     # compute daily returns from provided annual treasury yields
-    if treasury_return != 0:
-        treasury_return_daily = (1 + treasury_return)**(1/252) - 1
 
-    return_risk_adj = algorithm_return - treasury_return_daily
+    return_risk_adj = algorithm_return - treasury_return
 
     return np.mean(return_risk_adj) / \
-        np.std(return_risk_adj) * \
-        np.sqrt(252)
+        np.std(return_risk_adj)
 
 
 def downside_risk(algorithm_returns, mean_returns, normalization_factor):


### PR DESCRIPTION
sharpe ratio should accept 2 array-like params and return a float sharpe ratio

maybe calculate_sharpe in cumulative.py should not be called every bar arrive. it's better to be called when the backtest finishes.