### PR TITLE
REF: Remove data offset calc from clock.

### DIFF
--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -55,7 +55,8 @@ class TestDataPortal(TestCase):
             sim_params = SimulationParameters(
                 period_start=minutes[0],
                 period_end=minutes[-1],
-                data_frequency="minute"
+                data_frequency="minute",
+                env=env,
             )
 
             dp = DataPortal(
@@ -184,7 +185,8 @@ class TestDataPortal(TestCase):
             sim_params = SimulationParameters(
                 period_start=minutes[0],
                 period_end=minutes[-1],
-                data_frequency="minute"
+                data_frequency="minute",
+                env=env
             )
 
             # create a split for 6/24

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -396,14 +396,17 @@ class TradingAlgorithm(object):
 
             minutely_emission = self.sim_params.emission_rate == "minute"
 
-            return MinuteSimulationClock(
+            clock = MinuteSimulationClock(
                 self.sim_params.trading_days,
                 market_opens,
                 market_closes,
-                self.data_portal,
                 env.trading_days,
                 minutely_emission
             )
+            self.data_portal.setup_offset_cache(
+                clock.minutes_by_day,
+                clock.minutes_to_day)
+            return clock
         else:
             return DailySimulationClock(self.sim_params.trading_days)
 

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -740,6 +740,9 @@ class FakeDataPortal(object):
     def __init__(self):
         self._adjustment_reader = None
 
+    def setup_offset_cache(self, minutes_by_day, minutes_to_day):
+        pass
+
 
 class FetcherDataPortal(DataPortal):
     """


### PR DESCRIPTION
Remove the responsibility of calculating the minute dataset index from
the clock, i.e. the offset that is used for the 'fast' lookup path in
the bcolz data. Instead, the clock calculates all the minutes that the
clock will run through and provides a map of days to the minutes for
each day, and a map of minutes to which day the minute occurs on.

Those two maps are then used by the data_portal to do on demand
calculations of the dataset offset, instead of the clock calculating
the value every minute.

This is on the path to removing all hardcodings of the minute offsets,
by removing the hardcoding from the clock, with the data_portal taking
responsibility for the offsets (work that follows this will remove the
hardcoding from the data_portal.)

### Other Notes

We may want to move the `minutes_by_day` and `minutes_to_day` to the simulation parameters or somewhere higher level.

