### PR TITLE
Allow different data set starts for minute data portal

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -73,7 +73,9 @@ class SlippageTestCase(TestCase):
             })
         }
 
-        MinuteBarWriterFromDataFrames().write(cls.tempdir.path, assets)
+        MinuteBarWriterFromDataFrames(
+            pd.Timestamp('2002-01-02', tz='UTC')
+        ).write(cls.tempdir.path, assets)
 
         cls.env.write_data(equities_data={
             133: {
@@ -108,7 +110,9 @@ class SlippageTestCase(TestCase):
                 })
             }
 
-            MinuteBarWriterFromDataFrames().write(tempdir.path, assets)
+            MinuteBarWriterFromDataFrames(
+                pd.Timestamp('2002-01-02', tz='UTC')
+            ).write(tempdir.path, assets)
 
             data_portal = DataPortal(
                 self.env,
@@ -448,7 +452,9 @@ class SlippageTestCase(TestCase):
                 })
             }
 
-            MinuteBarWriterFromDataFrames().write(tempdir.path, assets)
+            MinuteBarWriterFromDataFrames(
+                pd.Timestamp('2002-01-02', tz='UTC')
+            ).write(tempdir.path, assets)
 
             data_portal = DataPortal(
                 self.env,

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -50,7 +50,9 @@ class TestDataPortal(TestCase):
                 "minute": minutes
             })
 
-            MinuteBarWriterFromDataFrames().write(tempdir.path, {0: df})
+            MinuteBarWriterFromDataFrames(
+                pd.Timestamp('2002-01-02', tz='UTC')).write(
+                    tempdir.path, {0: df})
 
             sim_params = SimulationParameters(
                 period_start=minutes[0],
@@ -180,7 +182,9 @@ class TestDataPortal(TestCase):
                 "minute": minutes
             })
 
-            MinuteBarWriterFromDataFrames().write(tempdir.path, {0: df})
+            MinuteBarWriterFromDataFrames(
+                pd.Timestamp('2002-01-02', tz='UTC')).write(
+                    tempdir.path, {0: df})
 
             sim_params = SimulationParameters(
                 period_start=minutes[0],

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -315,7 +315,7 @@ class TestDataPortal(TestCase):
 
             dp = DataPortal(
                 env,
-                minutes_equities_path=tempdir.path
+                minutes_futures_path=tempdir.path
             )
 
             future123 = env.asset_finder.retrieve_asset(123)

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -218,7 +218,9 @@ class FinanceTestCase(TestCase):
                     }, index=minutes)
                 }
 
-                MinuteBarWriterFromDataFrames().write(tempdir.path, assets)
+                MinuteBarWriterFromDataFrames(
+                    pd.Timestamp('2002-01-02', tz='UTC')
+                ).write(tempdir.path, assets)
 
                 data_portal = DataPortal(
                     env,

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -245,12 +245,12 @@ class HistoryTestCase(TestCase):
                                    "DIVIDEND_minute.csv.gz"),
         }
 
-        path = os.path.join(tempdir.path, 'equity', 'minutes')
-        os.makedirs(path)
+        equities_tempdir = os.path.join(tempdir.path, 'equity', 'minutes')
+        os.makedirs(equities_tempdir)
 
         MinuteBarWriterFromCSVs(resources,
                                 pd.Timestamp('2002-01-02', tz='UTC')).write(
-                                    path, cls.assets)
+                                    equities_tempdir, cls.assets)
 
     @classmethod
     def create_fake_daily_data(cls, tempdir):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,6 +2,7 @@ from os.path import dirname, join, realpath
 from textwrap import dedent
 from unittest import TestCase
 import bcolz
+import os
 from datetime import timedelta
 from nose_parameterized import parameterized
 from pandas.tslib import normalize_date
@@ -106,8 +107,11 @@ class HistoryTestCase(TestCase):
                 cls.FUTURE_ASSET2: pd.Timestamp("2014-03-19 13:31", tz='UTC')
             }
 
+            futures_tempdir = os.path.join(cls.tempdir.path,
+                                           'futures', 'minutes')
+            os.makedirs(futures_tempdir)
             cls.create_fake_futures_minute_data(
-                cls.tempdir,
+                futures_tempdir,
                 cls.env.asset_finder.retrieve_asset(cls.FUTURE_ASSET),
                 cls.futures_start_dates[cls.FUTURE_ASSET],
                 cls.futures_start_dates[cls.FUTURE_ASSET] +
@@ -117,7 +121,7 @@ class HistoryTestCase(TestCase):
             # build data for FUTURE_ASSET2 from 2014-03-19 13:31 to
             # 2014-03-21 20:00
             cls.create_fake_futures_minute_data(
-                cls.tempdir,
+                futures_tempdir,
                 cls.env.asset_finder.retrieve_asset(cls.FUTURE_ASSET2),
                 cls.futures_start_dates[cls.FUTURE_ASSET2],
                 cls.futures_start_dates[cls.FUTURE_ASSET2] +
@@ -219,7 +223,7 @@ class HistoryTestCase(TestCase):
                                list(range(40000, 40000 + num_minutes)))
         })
 
-        path = join(tempdir.path, "{0}.bcolz".format(asset.sid))
+        path = join(tempdir, "{0}.bcolz".format(asset.sid))
         ctable = bcolz.ctable.fromdataframe(future_df, rootdir=path)
 
         ctable.attrs["start_dt"] = start_dt.value / 1e9
@@ -241,7 +245,10 @@ class HistoryTestCase(TestCase):
                                    "DIVIDEND_minute.csv.gz"),
         }
 
-        MinuteBarWriterFromCSVs(resources).write(tempdir.path, cls.assets)
+        path = os.path.join(tempdir.path, 'equity', 'minutes')
+        os.makedirs(path)
+
+        MinuteBarWriterFromCSVs(resources).write(path, cls.assets)
 
     @classmethod
     def create_fake_daily_data(cls, tempdir):
@@ -327,12 +334,16 @@ class HistoryTestCase(TestCase):
 
         temp_path = self.tempdir.path
 
+        minutes_path = os.path.join(temp_path, 'equity', 'minutes')
+        futures_path = os.path.join(temp_path, 'futures', 'minutes')
+
         adjustment_reader = SQLiteAdjustmentReader(
             join(temp_path, adjustments_filename))
 
         return DataPortal(
             env,
-            minutes_equities_path=temp_path,
+            minutes_equities_path=minutes_path,
+            minutes_futures_path=futures_path,
             daily_equities_path=join(temp_path, daily_equities_filename),
             adjustment_reader=adjustment_reader
         )

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -248,7 +248,9 @@ class HistoryTestCase(TestCase):
         path = os.path.join(tempdir.path, 'equity', 'minutes')
         os.makedirs(path)
 
-        MinuteBarWriterFromCSVs(resources).write(path, cls.assets)
+        MinuteBarWriterFromCSVs(resources,
+                                pd.Timestamp('2002-01-02', tz='UTC')).write(
+                                    path, cls.assets)
 
     @classmethod
     def create_fake_daily_data(cls, tempdir):

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -27,6 +27,7 @@ from zipline.data.us_equity_pricing import (
     BcolzDailyBarReader,
     NoDataOnDate
 )
+from zipline.data.us_equity_minutes import BcolzMinuteBarReader
 from zipline.pipeline.data.equity_pricing import USEquityPricing
 
 from zipline.utils import tradingcalendar
@@ -34,11 +35,6 @@ from zipline.errors import (
     NoTradeDataAvailableTooEarly,
     NoTradeDataAvailableTooLate
 )
-
-FIRST_TRADING_MINUTE = pd.Timestamp("2002-01-02 14:31:00", tz='UTC')
-
-# FIXME should this be passed in (is this qexec specific?)?
-INDEX_OF_FIRST_TRADING_DAY = 3028
 
 log = Logger('DataPortal')
 
@@ -147,6 +143,8 @@ class DataPortal(object):
         else:
             self._daily_bar_reader = None
 
+        self._minute_bar_reader = None
+
         # The following values are used by _minute_offset to calculate the
         # index into the minute bcolz date.
 
@@ -159,6 +157,13 @@ class DataPortal(object):
         # A dict of day to the offset into the minute bcolz on which that
         # days data starts.
         self._day_offsets = None
+
+    @property
+    def minute_bar_reader(self):
+        if self._minute_bar_reader is None:
+            self._minute_bar_reader = BcolzMinuteBarReader(
+                self._minutes_equities_path)
+        return self._minute_bar_reader
 
     def handle_extra_source(self, source_df):
         """
@@ -414,14 +419,12 @@ class DataPortal(object):
         # trading. This lets us avoid doing an offset calculation related
         # to the asset start date.  Hard-coding 390 minutes per day lets us
         # ignore half days.
-        td = tradingcalendar.trading_days
-
         self._minutes_to_day = minutes_to_day
         self._minutes_by_day = minutes_by_day
         if self._sim_params is not None:
             start = self._sim_params.trading_days[0]
-            first_trading_day_idx = td.searchsorted(start) - \
-                INDEX_OF_FIRST_TRADING_DAY
+            first_trading_day_idx = self.minute_bar_reader.trading_days.\
+                searchsorted(start)
             self._day_offsets = {
                 day: (i + first_trading_day_idx) * 390
                 for i, day in enumerate(
@@ -444,8 +447,8 @@ class DataPortal(object):
 
         if minute_offset_to_use is None:
             given_day = pd.Timestamp(dt.date(), tz='utc')
-            day_index = tradingcalendar.trading_days.searchsorted(
-                given_day) - INDEX_OF_FIRST_TRADING_DAY
+            day_index = self.minute_bar_reader.trading_days.searchsorted(
+                given_day)
 
             # if dt is before the first market minute, minute_index
             # will be 0.  if it's after the last market minute, it'll
@@ -465,8 +468,8 @@ class DataPortal(object):
 
             # get this asset's start date, so that we don't look before it.
             start_date = self._get_asset_start_date(asset)
-            start_date_idx = tradingcalendar.trading_days.searchsorted(
-                start_date) - INDEX_OF_FIRST_TRADING_DAY
+            start_date_idx = self.minute_bar_reader.trading_days.searchsorted(
+                start_date)
             start_day_offset = start_date_idx * 390
 
             original_start = minute_offset_to_use
@@ -677,10 +680,12 @@ class DataPortal(object):
         minutes_for_window = self.env.market_minute_window(
             end_dt, bar_count, step=-1)[::-1]
 
+        first_trading_day = self.minute_bar_reader.first_trading_day
+
         # but then cut it down to only the minutes after
-        # FIRST_TRADING_MINUTE
+        # the first trading day.
         modified_minutes_for_window = minutes_for_window[
-            minutes_for_window.slice_indexer(FIRST_TRADING_MINUTE)]
+            minutes_for_window.slice_indexer(first_trading_day)]
 
         modified_minutes_length = len(modified_minutes_for_window)
 
@@ -692,12 +697,13 @@ class DataPortal(object):
         bars_to_prepend = 0
         nans_to_prepend = None
 
-        if modified_minutes_length < bar_count and \
-           (modified_minutes_for_window[0] == FIRST_TRADING_MINUTE):
-            # the beginning of the window goes before our global trading
-            # start date
-            bars_to_prepend = bar_count - modified_minutes_length
-            nans_to_prepend = np.repeat(np.nan, bars_to_prepend)
+        if modified_minutes_length < bar_count:
+            first_trading_date = first_trading_day.date()
+            if modified_minutes_for_window[0].date() == first_trading_date:
+                # the beginning of the window goes before our global trading
+                # start date
+                bars_to_prepend = bar_count - modified_minutes_length
+                nans_to_prepend = np.repeat(np.nan, bars_to_prepend)
 
         if len(assets) == 0:
             return pd.DataFrame(
@@ -976,8 +982,7 @@ class DataPortal(object):
 
         np.around(data, 3, out=data)
 
-    @staticmethod
-    def _find_position_of_minute(minute_dt):
+    def _find_position_of_minute(self, minute_dt):
         """
         Internal method that returns the position of the given minute in the
         list of every trading minute since market open on 1/2/2002.
@@ -999,8 +1004,7 @@ class DataPortal(object):
         since market open on 1/2/2002.
         """
         day = minute_dt.date()
-        day_idx = tradingcalendar.trading_days.searchsorted(day) -\
-            INDEX_OF_FIRST_TRADING_DAY
+        day_idx = self.minute_bar_reader.trading_days.searchsorted(day)
         if day_idx < 0:
             return -1
 

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -73,6 +73,7 @@ class DataPortal(object):
                  env,
                  sim_params=None,
                  minutes_equities_path=None,
+                 minutes_futures_path=None,
                  daily_equities_path=None,
                  adjustment_reader=None,
                  equity_sid_path_func=None,
@@ -98,8 +99,10 @@ class DataPortal(object):
 
         self.views = {}
 
-        self._minutes_equities_path = minutes_equities_path
         self._daily_equities_path = daily_equities_path
+        self._minutes_equities_path = minutes_equities_path
+        self._minutes_futures_path = minutes_futures_path
+
         self._asset_finder = env.asset_finder
 
         self._carrays = {
@@ -246,16 +249,21 @@ class DataPortal(object):
     def _get_ctable(self, asset):
         sid = int(asset)
 
-        if isinstance(asset, Future) and \
-                self._futures_sid_path_func is not None:
-            path = self._futures_sid_path_func(
-                self._minutes_equities_path, sid
-            )
-        elif isinstance(asset, Equity) and \
-                self._equity_sid_path_func is not None:
-            path = self._equity_sid_path_func(
-                self._minutes_equities_path, sid
-            )
+        if isinstance(asset, Future):
+            if self._futures_sid_path_func is not None:
+                path = self._futures_sid_path_func(
+                    self._minutes_futures_path, sid
+                )
+            else:
+                path = "{0}/{1}.bcolz".format(self._minutes_futures_path, sid)
+        elif isinstance(asset, Equity):
+            if self._equity_sid_path_func is not None:
+                path = self._equity_sid_path_func(
+                    self._minutes_equities_path, sid
+                )
+            else:
+                path = "{0}/{1}.bcolz".format(self._minutes_equities_path, sid)
+
         else:
             path = "{0}/{1}.bcolz".format(self._minutes_equities_path, sid)
 

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -23,6 +23,17 @@ _writer_env = TradingEnvironment()
 METADATA_FILENAME = 'metadata.json'
 
 
+def write_metadata(directory, first_trading_day):
+    metadata_path = os.path.join(directory, METADATA_FILENAME)
+
+    metadata = {
+        'first_trading_day': str(first_trading_day.date())
+    }
+
+    with open(metadata_path, 'w') as fp:
+        json.dump(metadata, fp)
+
+
 class BcolzMinuteBarWriter(with_metaclass(ABCMeta)):
     """
     Class capable of writing minute OHLCV data to disk into bcolz format.
@@ -75,14 +86,7 @@ class BcolzMinuteBarWriter(with_metaclass(ABCMeta)):
     def _write_internal(self, directory, iterator, sid_path_func=None):
         first_trading_day = self.first_trading_day
 
-        metadata_path = os.path.join(directory, METADATA_FILENAME)
-
-        metadata = {
-            'first_trading_day': str(first_trading_day.date())
-        }
-
-        with open(metadata_path, 'w') as fp:
-            json.dump(metadata, fp)
+        write_metadata(directory, first_trading_day)
 
         first_open = pd.Timestamp(
             datetime(

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -596,8 +596,8 @@ def write_minute_data(tempdir, minutes, sids, sid_path_func=None):
             "minute": minutes
         }, index=minutes)
 
-    MinuteBarWriterFromDataFrames().write(tempdir.path, assets,
-                                          sid_path_func=sid_path_func)
+    MinuteBarWriterFromDataFrames(pd.Timestamp('2002-01-02', tz='UTC')).write(
+        tempdir.path, assets, sid_path_func=sid_path_func)
 
     return tempdir.path
 
@@ -726,7 +726,8 @@ def create_data_portal_from_trade_history(env, tempdir, sim_params,
                 "minute": minutes
             }, index=minutes)
 
-        MinuteBarWriterFromDataFrames().write(tempdir.path, assets)
+        MinuteBarWriterFromDataFrames(pd.Timestamp('2002-01-02', tz='UTC')).\
+            write(tempdir.path, assets)
 
         return DataPortal(
             env,
@@ -763,6 +764,9 @@ class FetcherDataPortal(DataPortal):
 
         # otherwise just return a fixed value
         return int(asset)
+
+    def setup_offset_cache(self, minutes_by_day, minutes_to_day):
+        pass
 
     def _get_daily_window_for_sid(self, asset, field, days_in_window,
                                   extra_slot=True):


### PR DESCRIPTION
Instead of using a hardcoded start date for the calculations of the
index into the equity minute data, use a metadata file written by the
equity minute writer to set the first trading day of the equity minute
set.

To allow the data portal to be used with datasets with
different ranges. (i.e. not just the start date of 2002-01-02)

Also includes a change that requires both a futures and a equities path to the data portal, since the dataset start is equities specific.