### PR TITLE
DEV: Change some default values in the slippage and commission models.

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -142,10 +142,10 @@ class SlippageTestCase(TestCase):
             _, txn = orders_txns[0]
 
             expected_txn = {
-                'price': float(3.01875),
+                'price': float(3.0001875),
                 'dt': datetime.datetime(
                     2006, 1, 5, 14, 31, tzinfo=pytz.utc),
-                'amount': int(50),
+                'amount': int(5),
                 'sid': int(133),
                 'commission': None,
                 'type': DATASOURCE_TYPE.TRANSACTION,
@@ -222,10 +222,12 @@ class SlippageTestCase(TestCase):
         txn = orders_txns[0][1]
 
         expected_txn = {
-            'price': float(3.500875),
+            'price': float(3.50021875),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 34, tzinfo=pytz.utc),
-            'amount': int(100),
+            # we ordered 100 shares, but default volume slippage only allows
+            # for 2.5% of the volume.  2.5% * 2000 = 50 shares
+            'amount': int(50),
             'sid': int(133),
             'order_id': open_orders[0].id
         }
@@ -294,10 +296,10 @@ class SlippageTestCase(TestCase):
         _, txn = orders_txns[0]
 
         expected_txn = {
-            'price': float(3.499125),
+            'price': float(3.49978125),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 32, tzinfo=pytz.utc),
-            'amount': int(-100),
+            'amount': int(-50),
             'sid': int(133)
         }
 
@@ -352,9 +354,9 @@ class SlippageTestCase(TestCase):
             },
             'expected': {
                 'transaction': {
-                    'price': 4.001,
+                    'price': 4.00025,
                     'dt': pd.Timestamp('2006-01-05 14:31', tz='UTC'),
-                    'amount': 100,
+                    'amount': 50,
                     'sid': 133,
                 }
             }
@@ -423,9 +425,9 @@ class SlippageTestCase(TestCase):
             },
             'expected': {
                 'transaction': {
-                    'price': 2.99925,
+                    'price': 2.9998125,
                     'dt': pd.Timestamp('2006-01-05 14:31', tz='UTC'),
-                    'amount': -100,
+                    'amount': -50,
                     'sid': 133,
                 }
             }
@@ -578,10 +580,10 @@ class SlippageTestCase(TestCase):
         _, txn = orders_txns[0]
 
         expected_txn = {
-            'price': float(3.500875),
+            'price': float(3.50021875),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 34, tzinfo=pytz.utc),
-            'amount': int(100),
+            'amount': int(50),
             'sid': int(133)
         }
 
@@ -678,10 +680,10 @@ class SlippageTestCase(TestCase):
         _, txn = orders_txns[0]
 
         expected_txn = {
-            'price': float(3.499125),
+            'price': float(3.49978125),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 32, tzinfo=pytz.utc),
-            'amount': int(-100),
+            'amount': int(-50),
             'sid': int(133)
         }
 

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -35,6 +35,8 @@ from zipline.utils.test_utils import(
     setup_logger,
     teardown_logger,
 )
+from zipline.finance.slippage import DEFAULT_VOLUME_SLIPPAGE_BAR_LIMIT, \
+    FixedSlippage
 from .utils.daily_bar_writer import DailyBarWriterFromDataFrames
 from zipline.data.data_portal import DataPortal
 
@@ -107,6 +109,7 @@ class BlotterTestCase(TestCase):
 
     def test_order_rejection(self):
         blotter = Blotter()
+
         # Reject a nonexistent order -> no order appears in new_order,
         # no exceptions raised out
         blotter.reject(56)
@@ -151,6 +154,7 @@ class BlotterTestCase(TestCase):
 
         # You can't reject a filled order.
         blotter = Blotter()   # Reset for paranoia
+        blotter.slippage_func = FixedSlippage()
         filled_id = blotter.order(24, 100, MarketOrder())
         filled_order = None
         blotter.current_dt = self.sim_params.trading_days[-1]
@@ -203,7 +207,8 @@ class BlotterTestCase(TestCase):
             dt = data[1]
 
             order_size = 100
-            expected_filled = trade_amt * 0.25
+            expected_filled = int(trade_amt *
+                                  DEFAULT_VOLUME_SLIPPAGE_BAR_LIMIT)
             expected_open = order_size - expected_filled
             expected_status = ORDER_STATUS.OPEN if expected_open else \
                 ORDER_STATUS.FILLED

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -209,7 +209,7 @@ def minutes_for_days():
     """
     env = TradingEnvironment()
     random.seed('deterministic')
-    return ((env.market_minutes_for_day(random.choice(env.trading_days)),)
+    return ((env.market_minutes_for_day(random.choice(env.trading_days[:-1])),)
             for _ in range(500))
 
 
@@ -287,6 +287,7 @@ class TestStatelessRules(RuleTestCase):
             # at 13:30 UTC, meaning the first minute of data has an
             # offset of 1.
             self.assertFalse(should_trigger(m))
+
         for m in islice(ms, 64, None):
             # Check the rest of the day.
             self.assertTrue(should_trigger(m))

--- a/zipline/finance/commission.py
+++ b/zipline/finance/commission.py
@@ -19,6 +19,9 @@ from zipline.utils.serialization_utils import (
     VERSION_LABEL
 )
 
+DEFAULT_PER_SHARE_COST = 0.0075         # 0.75 cents per share
+DEFAULT_MINIMUM_COST_PER_TRADE = 1.0    # $1 per trade
+
 
 class PerShare(object):
     """
@@ -26,7 +29,9 @@ class PerShare(object):
     share cost with an optional minimum cost per trade.
     """
 
-    def __init__(self, cost=0.03, min_trade_cost=None):
+    def __init__(self,
+                 cost=DEFAULT_PER_SHARE_COST,
+                 min_trade_cost=DEFAULT_MINIMUM_COST_PER_TRADE):
         """
         Cost parameter is the cost of a trade per-share. $0.03
         means three cents per share, which is a very conservative
@@ -84,7 +89,7 @@ class PerTrade(object):
     trade cost.
     """
 
-    def __init__(self, cost=5.0):
+    def __init__(self, cost=DEFAULT_MINIMUM_COST_PER_TRADE):
         """
         Cost parameter is the cost of a trade, regardless of
         share count. $5.00 per trade is fairly typical of

--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -28,6 +28,9 @@ class LiquidityExceeded(Exception):
     pass
 
 
+DEFAULT_VOLUME_SLIPPAGE_BAR_LIMIT = 0.025
+
+
 class SlippageModel(with_metaclass(abc.ABCMeta)):
     def __init__(self):
         self._volume_for_bar = 0
@@ -66,9 +69,12 @@ class SlippageModel(with_metaclass(abc.ABCMeta)):
 
 class VolumeShareSlippage(SlippageModel):
 
-    def __init__(self, volume_limit=0.25, price_impact=0.1):
+    def __init__(self, volume_limit=DEFAULT_VOLUME_SLIPPAGE_BAR_LIMIT,
+                 price_impact=0.1):
         self.volume_limit = volume_limit
         self.price_impact = price_impact
+
+        super(VolumeShareSlippage, self).__init__()
 
     def __repr__(self):
         return """

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -344,6 +344,7 @@ class TestOrderValueAlgorithm(TradingAlgorithm):
 
 class TestTargetAlgorithm(TradingAlgorithm):
     def initialize(self):
+        self.set_slippage(FixedSlippage())
         self.target_shares = 0
         self.sale_price = None
 
@@ -361,6 +362,7 @@ class TestTargetAlgorithm(TradingAlgorithm):
 
 class TestOrderPercentAlgorithm(TradingAlgorithm):
     def initialize(self):
+        self.set_slippage(FixedSlippage())
         self.target_shares = 0
         self.sale_price = None
 
@@ -396,8 +398,8 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
         self.sale_price = None
 
         # this makes the math easier to check
-        self.commission = PerShare(0)
-        self.slippage = FixedSlippage(spread=0.0)
+        self.set_slippage(FixedSlippage())
+        self.set_commission(PerShare(0))
 
     def handle_data(self, data):
         if not self.ordered:
@@ -424,6 +426,7 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
 
 class TestTargetValueAlgorithm(TradingAlgorithm):
     def initialize(self):
+        self.set_slippage(FixedSlippage())
         self.target_shares = 0
         self.sale_price = None
 
@@ -476,6 +479,7 @@ class SetMaxLeverageAlgorithm(TradingAlgorithm):
 
 class SetMaxPositionSizeAlgorithm(TradingAlgorithm):
     def initialize(self, sid=None, max_shares=None, max_notional=None):
+        self.set_slippage(FixedSlippage())
         self.order_count = 0
         self.set_max_position_size(sid=sid,
                                    max_shares=max_shares,


### PR DESCRIPTION
VolumeShareSlippage, by default, now lets you take out 2.5% of the bar's volume
(instead of 25%).

PerShare and PerTrade commission models now default to $1 minimum cost per trade.

PerShare defaults to 0.75 cents per share (previously 3 cents).