### PR TITLE
REF: Pass minute reader instead of path to portal

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -35,6 +35,7 @@ from zipline.protocol import DATASOURCE_TYPE
 from zipline.finance.blotter import Order
 
 from zipline.data.us_equity_minutes import MinuteBarWriterFromDataFrames
+from zipline.data.us_equity_minutes import BcolzMinuteBarReader
 from zipline.data.data_portal import DataPortal
 
 
@@ -86,7 +87,7 @@ class SlippageTestCase(TestCase):
 
         cls.data_portal = DataPortal(
             cls.env,
-            minutes_equities_path=cls.tempdir.path,
+            equity_minute_reader=BcolzMinuteBarReader(cls.tempdir.path),
             sim_params=cls.sim_params
         )
 
@@ -114,9 +115,11 @@ class SlippageTestCase(TestCase):
                 pd.Timestamp('2002-01-02', tz='UTC')
             ).write(tempdir.path, assets)
 
+            equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
             data_portal = DataPortal(
                 self.env,
-                minutes_equities_path=tempdir.path,
+                equity_minute_reader=equity_minute_reader,
                 sim_params=self.sim_params
             )
 
@@ -456,9 +459,11 @@ class SlippageTestCase(TestCase):
                 pd.Timestamp('2002-01-02', tz='UTC')
             ).write(tempdir.path, assets)
 
+            equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
             data_portal = DataPortal(
                 self.env,
-                minutes_equities_path=tempdir.path,
+                equity_minute_reader=equity_minute_reader,
                 sim_params=self.sim_params
             )
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -81,13 +81,7 @@ from zipline.test_algorithms import (
 )
 from zipline.utils.context_tricks import CallbackManager
 import zipline.utils.events
-from zipline.assets import Equity
-from zipline.utils.test_utils import (
-    assert_single_position,
-    drain_zipline,
-    to_utc,
-)
-
+from zipline.utils.test_utils import to_utc
 
 from zipline.finance.execution import LimitOrder
 from zipline.finance.trading import SimulationParameters

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -11,7 +11,10 @@ from zipline.data.data_portal import DataPortal
 from zipline.data.us_equity_pricing import SQLiteAdjustmentWriter, \
     SQLiteAdjustmentReader
 from zipline.finance.trading import TradingEnvironment, SimulationParameters
-from zipline.data.us_equity_minutes import MinuteBarWriterFromDataFrames
+from zipline.data.us_equity_minutes import (
+    MinuteBarWriterFromDataFrames,
+    BcolzMinuteBarReader
+)
 from .utils.daily_bar_writer import DailyBarWriterFromDataFrames
 
 
@@ -61,9 +64,11 @@ class TestDataPortal(TestCase):
                 env=env,
             )
 
+            equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
             dp = DataPortal(
                 env,
-                minutes_equities_path=tempdir.path,
+                equity_minute_reader=equity_minute_reader,
                 sim_params=sim_params
             )
 
@@ -239,9 +244,11 @@ class TestDataPortal(TestCase):
 
             writer.write(splits, mergers, dividends)
 
+            equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
             dp = DataPortal(
                 env,
-                minutes_equities_path=tempdir.path,
+                equity_minute_reader=equity_minute_reader,
                 sim_params=sim_params,
                 adjustment_reader=SQLiteAdjustmentReader(adjustments_path)
             )

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -42,7 +42,10 @@ from zipline.utils.test_utils import(
     setup_logger,
     teardown_logger
 )
-from zipline.data.us_equity_minutes import MinuteBarWriterFromDataFrames
+from zipline.data.us_equity_minutes import (
+    MinuteBarWriterFromDataFrames,
+    BcolzMinuteBarReader
+)
 from zipline.data.data_portal import DataPortal
 from zipline.finance.slippage import FixedSlippage
 
@@ -222,9 +225,11 @@ class FinanceTestCase(TestCase):
                     pd.Timestamp('2002-01-02', tz='UTC')
                 ).write(tempdir.path, assets)
 
+                equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
                 data_portal = DataPortal(
                     env,
-                    minutes_equities_path=tempdir.path,
+                    equity_minute_reader=equity_minute_reader,
                     sim_params=sim_params
                 )
             else:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -30,7 +30,10 @@ from zipline.utils.test_utils import (
     str_to_seconds,
     MockDailyBarReader
 )
-from zipline.data.us_equity_minutes import MinuteBarWriterFromCSVs
+from zipline.data.us_equity_minutes import (
+    MinuteBarWriterFromCSVs,
+    BcolzMinuteBarReader
+)
 from zipline.utils.tradingcalendar import trading_days
 from zipline.finance.trading import (
     TradingEnvironment,
@@ -342,9 +345,11 @@ class HistoryTestCase(TestCase):
         adjustment_reader = SQLiteAdjustmentReader(
             join(temp_path, adjustments_filename))
 
+        equity_minute_reader = BcolzMinuteBarReader(minutes_path)
+
         return DataPortal(
             env,
-            minutes_equities_path=minutes_path,
+            equity_minute_reader=equity_minute_reader,
             minutes_futures_path=futures_path,
             daily_equities_path=join(temp_path, daily_equities_filename),
             adjustment_reader=adjustment_reader

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -214,7 +214,7 @@ class MinuteBarWriterFromCSVs(BcolzMinuteBarWriter):
 
 class BcolzMinuteBarReader(object):
 
-    def __init__(self, rootdir):
+    def __init__(self, rootdir, sid_path_func=None):
         self.rootdir = rootdir
 
         metadata = self._get_metadata()
@@ -224,6 +224,7 @@ class BcolzMinuteBarReader(object):
         mask = tradingcalendar.trading_days.slice_indexer(
             self.first_trading_day)
         self.trading_days = tradingcalendar.trading_days[mask]
+        self.sid_path_func = sid_path_func
 
     def _get_metadata(self):
         with open(os.path.join(self.rootdir, METADATA_FILENAME)) as fp:

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -24,7 +24,10 @@ from zipline.assets import AssetFinder
 from zipline.assets.asset_writer import AssetDBWriterFromDataFrame
 from zipline.assets.futures import CME_CODE_TO_MONTH
 from zipline.data.data_portal import DataPortal
-from zipline.data.us_equity_minutes import MinuteBarWriterFromDataFrames
+from zipline.data.us_equity_minutes import (
+    MinuteBarWriterFromDataFrames,
+    BcolzMinuteBarReader
+)
 from zipline.data.us_equity_pricing import SQLiteAdjustmentWriter, OHLC, \
     UINT32_MAX, BcolzDailyBarWriter
 from zipline.finance.order import ORDER_STATUS
@@ -645,9 +648,11 @@ def create_data_portal(env, tempdir, sim_params, sids, sid_path_func=None,
         minute_path = write_minute_data(tempdir, minutes, sids,
                                         sid_path_func)
 
+        equity_minute_reader = BcolzMinuteBarReader(minute_path)
+
         return DataPortal(
             env,
-            minutes_equities_path=minute_path,
+            equity_minute_reader=equity_minute_reader,
             sim_params=sim_params,
             adjustment_reader=adjustment_reader
         )
@@ -729,9 +734,11 @@ def create_data_portal_from_trade_history(env, tempdir, sim_params,
         MinuteBarWriterFromDataFrames(pd.Timestamp('2002-01-02', tz='UTC')).\
             write(tempdir.path, assets)
 
+        equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
         return DataPortal(
             env,
-            minutes_equities_path=tempdir.path,
+            equity_minute_reader=equity_minute_reader,
             sim_params=sim_params
         )
 


### PR DESCRIPTION
Start down path of abstracting out the reader, so that other readers,
e.g. a DataFrame can be implemented. (Those implementations would
require more of the read logic to be moved from the DataPortal to the
reader.)

This is also required for an internal override of the start date on the
bcolz reader, which is why this change is so minimal.