### PR TITLE
REF: Remove unused trading env member.

### DIFF
--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -96,7 +96,6 @@ class TradingEnvironment(object):
         self.open_and_closes = env_trading_calendar.open_and_closes.loc[
             self.trading_days]
 
-        self.prev_environment = self
         self.bm_symbol = bm_symbol
         if not load:
             load = load_market_data


### PR DESCRIPTION
Usage of `prev_environment` was removed by a previous commit,
dc964a7e7da7e975b22fabfe962d2210704c1d6b