### PR TITLE
Lazy daily fix

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -471,7 +471,7 @@ class BcolzDailyBarReader(object):
         try:
             col = self._spot_cols[colname]
         except KeyError:
-            col = self._spot_cols[colname] = self._table[colname][:]
+            col = self._spot_cols[colname] = self._table[colname]
         return col
 
     def sid_day_index(self, sid, day):

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -388,6 +388,8 @@ class BcolzDailyBarReader(object):
         # process first.
         self._spot_cols = {}
 
+        self.PRICE_ADJUSTMENT_FACTOR = 0.001
+
     def _compute_slices(self, start_idx, end_idx, assets):
         """
         Compute the raw row indices to load for each asset on a query for the
@@ -432,11 +434,7 @@ class BcolzDailyBarReader(object):
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
         # Assumes that the given dates are actually in calendar.
-        try:
-            start_idx = self._calendar.get_loc(start_date)
-        except KeyError:
-            raise NoDataOnDate("day={0} is before calendar={1}".format(
-                start_date, self._calendar))
+        start_idx = self._calendar.get_loc(start_date)
         end_idx = self._calendar.get_loc(end_date)
         first_rows, last_rows, offsets = self._compute_slices(
             start_idx,
@@ -451,6 +449,15 @@ class BcolzDailyBarReader(object):
             last_rows,
             offsets,
         )
+
+    def history_window(self, column, start_date, end_date, asset):
+        start_idx = self.sid_day_index(asset, start_date)
+        end_idx = self.sid_day_index(asset, end_date) + 1
+        col = self._spot_col(column)
+        window = col[start_idx:end_idx]
+        if column != 'volume':
+            window = window.astype(float64) * self.PRICE_ADJUSTMENT_FACTOR
+        return window
 
     def _spot_col(self, colname):
         """

--- a/zipline/sources/benchmark_source.py
+++ b/zipline/sources/benchmark_source.py
@@ -18,7 +18,6 @@ from zipline.errors import (
     BenchmarkAssetNotAvailableTooEarly,
     BenchmarkAssetNotAvailableTooLate
 )
-from zipline.data.us_equity_pricing import NoDataOnDate
 
 
 class BenchmarkSource(object):
@@ -147,7 +146,8 @@ class BenchmarkSource(object):
 
             return benchmark_series.pct_change()[1:]
         else:
-            try:
+            start_date = env.asset_finder.retrieve_asset(sid).start_date
+            if start_date < trading_days[0]:
                 # get the window of close prices for benchmark_sid from the
                 # last trading day of the simulation, going up to one day
                 # before the simulation start day (so that we can get the %
@@ -161,7 +161,7 @@ class BenchmarkSource(object):
                     ffill=True
                 )[sid]
                 return benchmark_series.pct_change()[1:]
-            except NoDataOnDate:
+            elif start_date == trading_days[0]:
                 # Attempt to handle case where stock data starts on first
                 # day, in this case use the open to close return.
                 benchmark_series = data_portal.get_history_window(


### PR DESCRIPTION
The main fix included fixes a regression on algorithms that only use a few equities:

PERF: Fix runtime regression on daily windows.

Re-using the pipeline infrastructure resulting in a bottleneck when
using a small number of stocks, where the read of the entire numpy
vector when only one stock was used was prohibitive.

Instead, base a solution off of @jbredeche's original solution, but
place the logic (at least the indexing logic into the DailyBcolzReader.)

We have an eye on making this eventually share code with pipeline, but
using the simpler non-shared solution for now.
Also, includes a small fix to a possible memory consumption issue when using spot_value discovered when investigating whether or not a cache of the numpy vector could be used in the bcolz daily bar reader.