### PR TITLE
Initial data portal commit.

### DIFF
--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -28,6 +28,7 @@ from zipline.data.us_equity_pricing import (
     BcolzDailyBarReader
 )
 from zipline.finance.trading import TradingEnvironment, SimulationParameters
+from zipline.data.future_pricing import FutureMinuteReader
 from zipline.data.us_equity_minutes import (
     MinuteBarWriterFromDataFrames,
     BcolzMinuteBarReader
@@ -343,9 +344,11 @@ class TestDataPortal(TestCase):
                 }
             })
 
+            future_minute_reader = FutureMinuteReader(tempdir.path)
+
             dp = DataPortal(
                 env,
-                minutes_futures_path=tempdir.path
+                future_minute_reader=future_minute_reader
             )
 
             future123 = env.asset_finder.retrieve_asset(123)

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -22,8 +22,11 @@ from unittest import TestCase
 from pandas.tslib import normalize_date
 from testfixtures import TempDirectory
 from zipline.data.data_portal import DataPortal
-from zipline.data.us_equity_pricing import SQLiteAdjustmentWriter, \
-    SQLiteAdjustmentReader
+from zipline.data.us_equity_pricing import (
+    SQLiteAdjustmentWriter,
+    SQLiteAdjustmentReader,
+    BcolzDailyBarReader
+)
 from zipline.finance.trading import TradingEnvironment, SimulationParameters
 from zipline.data.us_equity_minutes import (
     MinuteBarWriterFromDataFrames,
@@ -145,9 +148,11 @@ class TestDataPortal(TestCase):
                 data_frequency="daily"
             )
 
+            equity_daily_reader = BcolzDailyBarReader(path)
+
             dp = DataPortal(
                 env,
-                daily_equities_path=path,
+                equity_daily_reader=equity_daily_reader,
                 sim_params=sim_params
             )
 

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -1,0 +1,363 @@
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from datetime import timedelta
+import bcolz
+import numpy as np
+import pandas as pd
+
+from unittest import TestCase
+from pandas.tslib import normalize_date
+from testfixtures import TempDirectory
+from zipline.data.data_portal import DataPortal
+from zipline.data.us_equity_pricing import SQLiteAdjustmentWriter, \
+    SQLiteAdjustmentReader
+from zipline.finance.trading import TradingEnvironment, SimulationParameters
+from zipline.data.us_equity_minutes import (
+    MinuteBarWriterFromDataFrames,
+    BcolzMinuteBarReader
+)
+from .utils.daily_bar_writer import DailyBarWriterFromDataFrames
+
+
+class TestDataPortal(TestCase):
+    def test_forward_fill_minute(self):
+        tempdir = TempDirectory()
+        try:
+            env = TradingEnvironment()
+            env.write_data(
+                equities_data={
+                    0: {
+                        'start_date': pd.Timestamp("2015-09-28", tz='UTC'),
+                        'end_date': pd.Timestamp("2015-09-29", tz='UTC')
+                        + timedelta(days=1)
+                    }
+                }
+            )
+
+            minutes = env.minutes_for_days_in_range(
+                start=pd.Timestamp("2015-09-28", tz='UTC'),
+                end=pd.Timestamp("2015-09-29", tz='UTC')
+            )
+
+            df = pd.DataFrame({
+                # one missing bar, then 200 bars of real data,
+                # then 1.5 days of missing data
+                "open": np.array([0] + list(range(0, 200)) + [0] * 579)
+                * 1000,
+                "high": np.array([0] + list(range(1000, 1200)) + [0] * 579)
+                * 1000,
+                "low": np.array([0] + list(range(2000, 2200)) + [0] * 579)
+                * 1000,
+                "close": np.array([0] + list(range(3000, 3200)) + [0] * 579)
+                * 1000,
+                "volume": [0] + list(range(4000, 4200)) + [0] * 579,
+                "minute": minutes
+            })
+
+            MinuteBarWriterFromDataFrames(
+                pd.Timestamp('2002-01-02', tz='UTC')).write(
+                    tempdir.path, {0: df})
+
+            sim_params = SimulationParameters(
+                period_start=minutes[0],
+                period_end=minutes[-1],
+                data_frequency="minute",
+                env=env,
+            )
+
+            equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
+            dp = DataPortal(
+                env,
+                equity_minute_reader=equity_minute_reader,
+                sim_params=sim_params
+            )
+
+            for minute_idx, minute in enumerate(minutes):
+                for field_idx, field in enumerate(
+                        ["open", "high", "low", "close", "volume"]):
+                    val = dp.get_spot_value(0, field, dt=minute)
+                    if minute_idx == 0:
+                        self.assertEqual(0, val)
+                    elif minute_idx < 200:
+                        self.assertEqual((minute_idx - 1) +
+                                         (field_idx * 1000), val)
+                    else:
+                        self.assertEqual(199 + (field_idx * 1000), val)
+        finally:
+            tempdir.cleanup()
+
+    def test_forward_fill_daily(self):
+        tempdir = TempDirectory()
+        try:
+            # 17 trading days
+            start_day = pd.Timestamp("2015-09-07", tz='UTC')
+            end_day = pd.Timestamp("2015-09-30", tz='UTC')
+
+            env = TradingEnvironment()
+            env.write_data(
+                equities_data={
+                    0: {
+                        'start_date': start_day,
+                        'end_date': end_day
+                    }
+                }
+            )
+
+            days = env.days_in_range(start_day, end_day)
+
+            # first bar is missing.  then 8 real bars.  then 8 more missing
+            # bars.
+            df = pd.DataFrame({
+                "open": [0] + list(range(0, 8)) + [0] * 8,
+                "high": [0] + list(range(10, 18)) + [0] * 8,
+                "low": [0] + list(range(20, 28)) + [0] * 8,
+                "close": [0] + list(range(30, 38)) + [0] * 8,
+                "volume": [0] + list(range(40, 48)) + [0] * 8,
+                "day": [day.value for day in days]
+            }, index=days)
+
+            assets = {0: df}
+            path = os.path.join(tempdir.path, "testdaily.bcolz")
+
+            DailyBarWriterFromDataFrames(assets).write(
+                path,
+                days,
+                assets
+            )
+
+            sim_params = SimulationParameters(
+                period_start=days[0],
+                period_end=days[-1],
+                data_frequency="daily"
+            )
+
+            dp = DataPortal(
+                env,
+                daily_equities_path=path,
+                sim_params=sim_params
+            )
+
+            for day_idx, day in enumerate(days):
+                for field_idx, field in enumerate(
+                        ["open", "high", "low", "close", "volume"]):
+                    val = dp.get_spot_value(0, field, dt=day)
+                    if day_idx == 0:
+                        self.assertEqual(0, val)
+                    elif day_idx < 9:
+                        self.assertEqual((day_idx - 1) + (field_idx * 10), val)
+                    else:
+                        self.assertEqual(7 + (field_idx * 10), val)
+        finally:
+            tempdir.cleanup()
+
+    def test_adjust_forward_fill_minute(self):
+        tempdir = TempDirectory()
+        try:
+            start_day = pd.Timestamp("2013-06-21", tz='UTC')
+            end_day = pd.Timestamp("2013-06-24", tz='UTC')
+
+            env = TradingEnvironment()
+            env.write_data(
+                equities_data={
+                    0: {
+                        'start_date': start_day,
+                        'end_date': env.next_trading_day(end_day)
+                    }
+                }
+            )
+
+            minutes = env.minutes_for_days_in_range(
+                start=start_day,
+                end=end_day
+            )
+
+            df = pd.DataFrame({
+                # 390 bars of real data, then 100 missing bars, then 290
+                # bars of data again
+                "open": np.array(list(range(0, 390)) + [0] * 100 +
+                                 list(range(390, 680))) * 1000,
+                "high": np.array(list(range(1000, 1390)) + [0] * 100 +
+                                 list(range(1390, 1680))) * 1000,
+                "low": np.array(list(range(2000, 2390)) + [0] * 100 +
+                                list(range(2390, 2680))) * 1000,
+                "close": np.array(list(range(3000, 3390)) + [0] * 100 +
+                                  list(range(3390, 3680))) * 1000,
+                "volume": np.array(list(range(4000, 4390)) + [0] * 100 +
+                                   list(range(4390, 4680))),
+                "minute": minutes
+            })
+
+            MinuteBarWriterFromDataFrames(
+                pd.Timestamp('2002-01-02', tz='UTC')).write(
+                    tempdir.path, {0: df})
+
+            sim_params = SimulationParameters(
+                period_start=minutes[0],
+                period_end=minutes[-1],
+                data_frequency="minute",
+                env=env
+            )
+
+            # create a split for 6/24
+            adjustments_path = os.path.join(tempdir.path, "adjustments.db")
+            writer = SQLiteAdjustmentWriter(adjustments_path,
+                                            pd.date_range(start=start_day,
+                                                          end=end_day),
+                                            None)
+
+            splits = pd.DataFrame([{
+                'effective_date': int(end_day.value / 1e9),
+                'ratio': 0.5,
+                'sid': 0
+            }])
+
+            dividend_data = {
+                # Hackery to make the dtypes correct on an empty frame.
+                'ex_date': np.array([], dtype='datetime64[ns]'),
+                'pay_date': np.array([], dtype='datetime64[ns]'),
+                'record_date': np.array([], dtype='datetime64[ns]'),
+                'declared_date': np.array([], dtype='datetime64[ns]'),
+                'amount': np.array([], dtype=float),
+                'sid': np.array([], dtype=int),
+            }
+            dividends = pd.DataFrame(
+                dividend_data,
+                index=pd.DatetimeIndex([], tz='UTC'),
+                columns=['ex_date',
+                         'pay_date',
+                         'record_date',
+                         'declared_date',
+                         'amount',
+                         'sid']
+            )
+
+            merger_data = {
+                # Hackery to make the dtypes correct on an empty frame.
+                'effective_date': np.array([], dtype=int),
+                'ratio': np.array([], dtype=float),
+                'sid': np.array([], dtype=int),
+            }
+            mergers = pd.DataFrame(
+                merger_data,
+                index=pd.DatetimeIndex([], tz='UTC')
+            )
+
+            writer.write(splits, mergers, dividends)
+
+            equity_minute_reader = BcolzMinuteBarReader(tempdir.path)
+
+            dp = DataPortal(
+                env,
+                equity_minute_reader=equity_minute_reader,
+                sim_params=sim_params,
+                adjustment_reader=SQLiteAdjustmentReader(adjustments_path)
+            )
+
+            # phew, finally ready to start testing.
+            for idx, minute in enumerate(minutes[:390]):
+                for field_idx, field in enumerate(["open", "high", "low",
+                                                   "close", "volume"]):
+                    self.assertEqual(
+                        dp.get_spot_value(0, field, dt=minute),
+                        idx + (1000 * field_idx)
+                    )
+
+            for idx, minute in enumerate(minutes[390:490]):
+                # no actual data for this part, so we'll forward-fill.
+                # make sure the forward-filled values are adjusted.
+                for field_idx, field in enumerate(["open", "high", "low",
+                                                   "close"]):
+                    self.assertEqual(
+                        dp.get_spot_value(0, field, dt=minute),
+                        (389 + (1000 * field_idx)) / 2.0
+                    )
+
+                self.assertEqual(
+                    dp.get_spot_value(0, "volume", dt=minute),
+                    8778  # 4389 * 2
+                )
+
+            for idx, minute in enumerate(minutes[490:]):
+                # back to real data
+                for field_idx, field in enumerate(["open", "high", "low",
+                                                   "close", "volume"]):
+                    self.assertEqual(
+                        dp.get_spot_value(0, field, dt=minute),
+                        (390 + idx + (1000 * field_idx))
+                    )
+        finally:
+            tempdir.cleanup()
+
+    def test_spot_value_futures(self):
+        tempdir = TempDirectory()
+        try:
+            start_dt = pd.Timestamp("2015-11-20 20:11", tz='UTC')
+            end_dt = pd.Timestamp(start_dt + timedelta(minutes=10000))
+
+            zeroes_buffer = \
+                [0] * int((start_dt -
+                           normalize_date(start_dt)).total_seconds() / 60)
+
+            df = pd.DataFrame({
+                "open": np.array(zeroes_buffer + list(range(0, 10000))) * 1000,
+                "high": np.array(
+                    zeroes_buffer + list(range(10000, 20000))) * 1000,
+                "low": np.array(
+                    zeroes_buffer + list(range(20000, 30000))) * 1000,
+                "close": np.array(
+                    zeroes_buffer + list(range(30000, 40000))) * 1000,
+                "volume": np.array(zeroes_buffer + list(range(40000, 50000)))
+            })
+
+            path = os.path.join(tempdir.path, "123.bcolz")
+            ctable = bcolz.ctable.fromdataframe(df, rootdir=path)
+            ctable.attrs["start_dt"] = start_dt.value / 1e9
+            ctable.attrs["last_dt"] = end_dt.value / 1e9
+
+            env = TradingEnvironment()
+            env.write_data(futures_data={
+                123: {
+                    "start_date": normalize_date(start_dt),
+                    "end_date": env.next_trading_day(normalize_date(end_dt)),
+                    'symbol': 'TEST_FUTURE',
+                    'asset_type': 'future',
+                }
+            })
+
+            dp = DataPortal(
+                env,
+                minutes_futures_path=tempdir.path
+            )
+
+            future123 = env.asset_finder.retrieve_asset(123)
+
+            for i in range(0, 10000):
+                dt = pd.Timestamp(start_dt + timedelta(minutes=i))
+
+                self.assertEqual(i,
+                                 dp.get_spot_value(future123, "open", dt))
+                self.assertEqual(i + 10000,
+                                 dp.get_spot_value(future123, "high", dt))
+                self.assertEqual(i + 20000,
+                                 dp.get_spot_value(future123, "low", dt))
+                self.assertEqual(i + 30000,
+                                 dp.get_spot_value(future123, "close", dt))
+                self.assertEqual(i + 40000,
+                                 dp.get_spot_value(future123, "volume", dt))
+
+        finally:
+            tempdir.cleanup()

--- a/tests/utils/daily_bar_writer.py
+++ b/tests/utils/daily_bar_writer.py
@@ -1,0 +1,61 @@
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from numpy import (
+    float64,
+    uint32
+)
+from bcolz import ctable
+
+from zipline.data.us_equity_pricing import (
+    BcolzDailyBarWriter,
+    OHLC,
+    UINT32_MAX
+)
+
+
+class DailyBarWriterFromDataFrames(BcolzDailyBarWriter):
+    _csv_dtypes = {
+        'open': float64,
+        'high': float64,
+        'low': float64,
+        'close': float64,
+        'volume': float64,
+    }
+
+    def __init__(self, asset_map):
+        self._asset_map = asset_map
+
+    def gen_tables(self, assets):
+        for asset in assets:
+            yield asset, ctable.fromdataframe(assets[asset])
+
+    def to_uint32(self, array, colname):
+        arrmax = array.max()
+        if colname in OHLC:
+            self.check_uint_safe(arrmax * 1000, colname)
+            return (array * 1000).astype(uint32)
+        elif colname == 'volume':
+            self.check_uint_safe(arrmax, colname)
+            return array.astype(uint32)
+        elif colname == 'day':
+            nanos_per_second = (1000 * 1000 * 1000)
+            self.check_uint_safe(arrmax.view(int) / nanos_per_second, colname)
+            return (array.view(int) / nanos_per_second).astype(uint32)
+
+    @staticmethod
+    def check_uint_safe(value, colname):
+        if value >= UINT32_MAX:
+            raise ValueError(
+                "Value %s from column '%s' is too large" % (value, colname)
+            )

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -1,0 +1,479 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bcolz
+from logbook import Logger
+
+import numpy as np
+import pandas as pd
+from pandas.tslib import normalize_date
+
+from zipline.assets import Future, Equity
+from zipline.data.us_equity_pricing import NoDataOnDate
+
+from zipline.utils import tradingcalendar
+from zipline.errors import (
+    NoTradeDataAvailableTooEarly,
+    NoTradeDataAvailableTooLate
+)
+
+log = Logger('DataPortal')
+
+BASE_FIELDS = {
+    'open': 'open',
+    'open_price': 'open',
+    'high': 'high',
+    'low': 'low',
+    'close': 'close',
+    'close_price': 'close',
+    'volume': 'volume',
+    'price': 'close'
+}
+
+
+class DataPortal(object):
+    def __init__(self,
+                 env,
+                 sim_params=None,
+                 equity_minute_reader=None,
+                 minutes_futures_path=None,
+                 daily_equities_path=None,
+                 adjustment_reader=None,
+                 futures_sid_path_func=None):
+        self.env = env
+
+        # Internal pointers to the current dt (can be minute) and current day.
+        # In daily mode, they point to the same thing. In minute mode, it's
+        # useful to have separate pointers to the current day and to the
+        # current minute.  These pointers are updated by the
+        # AlgorithmSimulator's transform loop.
+        self.current_dt = None
+        self.current_day = None
+
+        self.views = {}
+
+        self._daily_equities_path = daily_equities_path
+        self._minutes_futures_path = minutes_futures_path
+
+        self._asset_finder = env.asset_finder
+
+        self._carrays = {
+            'open': {},
+            'high': {},
+            'low': {},
+            'close': {},
+            'volume': {},
+            'sid': {},
+            'dt': {},
+        }
+
+        self._adjustment_reader = adjustment_reader
+
+        # caches of sid -> adjustment list
+        self._splits_dict = {}
+        self._mergers_dict = {}
+        self._dividends_dict = {}
+
+        # Cache of sid -> the first trading day of an asset, even if that day
+        # is before 1/2/2002.
+        self._asset_start_dates = {}
+        self._asset_end_dates = {}
+
+        # Handle extra sources, like Fetcher.
+        self._augmented_sources_map = {}
+        self._extra_source_df = None
+
+        if self._sim_params is not None:
+            self._data_frequency = self._sim_params.data_frequency
+        else:
+            self._data_frequency = "minute"
+
+        self._futures_sid_path_func = futures_sid_path_func
+
+        self.MINUTE_PRICE_ADJUSTMENT_FACTOR = 0.001
+
+        if daily_equities_path is not None:
+            self._daily_bar_reader = BcolzDailyBarReader(daily_equities_path)
+        else:
+            self._daily_bar_reader = None
+
+        self._equity_minute_reader = equity_minute_reader
+
+    def _open_minute_file(self, field, asset):
+        sid_str = str(int(asset))
+
+        try:
+            carray = self._carrays[field][sid_str]
+        except KeyError:
+            carray = self._carrays[field][sid_str] = \
+                self._get_ctable(asset)[field]
+
+        return carray
+
+    def _get_ctable(self, asset):
+        sid = int(asset)
+
+        if isinstance(asset, Future):
+            if self._futures_sid_path_func is not None:
+                path = self._futures_sid_path_func(
+                    self._minutes_futures_path, sid
+                )
+            else:
+                path = "{0}/{1}.bcolz".format(self._minutes_futures_path, sid)
+        elif isinstance(asset, Equity):
+            if self._equity_minute_reader.sid_path_func is not None:
+                path = self._equity_minute_reader.sid_path_func(
+                    self._equity_minute_reader.rootdir, sid
+                )
+            else:
+                path = "{0}/{1}.bcolz".format(
+                    self._equity_minute_reader.rootdir, sid)
+
+        return bcolz.open(path, mode='r')
+
+    def get_spot_value(self, asset, field, dt=None):
+        """
+        Public API method that returns a scalar value representing the value
+        of the desired asset's field at either the given dt, or this data
+        portal's current_dt.
+
+        Parameters
+        ---------
+        asset : Asset
+            The asset whose data is desired.
+
+        field: string
+            The desired field of the asset.  Valid values are "open",
+            "open_price", "high", "low", "close", "close_price", "volume", and
+            "price".
+
+        dt: pd.Timestamp
+            (Optional) The timestamp for the desired value.
+
+        Returns
+        -------
+        The value of the desired field at the desired time.
+        """
+        if field not in BASE_FIELDS:
+            raise KeyError("Invalid column: " + str(field))
+
+        column_to_use = BASE_FIELDS[field]
+
+        if isinstance(asset, int):
+            asset = self._asset_finder.retrieve_asset(asset)
+
+        self._check_is_currently_alive(asset, dt)
+
+        if self._data_frequency == "daily":
+            day_to_use = dt or self.current_day
+            day_to_use = normalize_date(day_to_use)
+            return self._get_daily_data(asset, column_to_use, day_to_use)
+        else:
+            dt_to_use = dt or self.current_dt
+
+            if isinstance(asset, Future):
+                return self._get_minute_spot_value_future(
+                    asset, column_to_use, dt_to_use)
+            else:
+                return self._get_minute_spot_value(
+                    asset, column_to_use, dt_to_use)
+
+    def _get_minute_spot_value_future(self, asset, column, dt):
+        # Futures bcolz files have 1440 bars per day (24 hours), 7 days a week.
+        # The file attributes contain the "start_dt" and "last_dt" fields,
+        # which represent the time period for this bcolz file.
+
+        # The start_dt is midnight of the first day that this future started
+        # trading.
+
+        # figure out the # of minutes between dt and this asset's start_dt
+        start_date = self._get_asset_start_date(asset)
+        minute_offset = int((dt - start_date).total_seconds() / 60)
+
+        if minute_offset < 0:
+            # asking for a date that is before the asset's start date, no dice
+            return 0.0
+
+        # then just index into the bcolz carray at that offset
+        carray = self._open_minute_file(column, asset)
+        result = carray[minute_offset]
+
+        # if there's missing data, go backwards until we run out of file
+        while result == 0 and minute_offset > 0:
+            minute_offset -= 1
+            result = carray[minute_offset]
+
+        if column != 'volume':
+            return result * self.MINUTE_PRICE_ADJUSTMENT_FACTOR
+        else:
+            return result
+
+    def _get_minute_spot_value(self, asset, column, dt):
+        # if dt is before the first market minute, minute_index
+        # will be 0.  if it's after the last market minute, it'll
+        # be len(minutes_for_day)
+        given_day = pd.Timestamp(dt.date(), tz='utc')
+        day_index = self._equity_minute_reader.trading_days.searchsorted(
+            given_day)
+
+        # if dt is before the first market minute, minute_index
+        # will be 0.  if it's after the last market minute, it'll
+        # be len(minutes_for_day)
+        minute_index = self.env.market_minutes_for_day(given_day).\
+            searchsorted(dt)
+
+        minute_offset_to_use = (day_index * 390) + minute_index
+
+        carray = self._equity_minute_reader._open_minute_file(column, asset)
+        result = carray[minute_offset_to_use]
+
+        if result == 0:
+            # if the given minute doesn't have data, we need to seek
+            # backwards until we find data. This makes the data
+            # forward-filled.
+
+            # get this asset's start date, so that we don't look before it.
+            start_date = self._get_asset_start_date(asset)
+            start_date_idx = self._equity_minute_reader.trading_days.\
+                searchsorted(start_date)
+            start_day_offset = start_date_idx * 390
+
+            original_start = minute_offset_to_use
+
+            while result == 0 and minute_offset_to_use > start_day_offset:
+                minute_offset_to_use -= 1
+                result = carray[minute_offset_to_use]
+
+            # once we've found data, we need to check whether it needs
+            # to be adjusted.
+            if result != 0:
+                minutes = self.env.market_minute_window(
+                    start=(dt or self.current_dt),
+                    count=(original_start - minute_offset_to_use + 1),
+                    step=-1
+                ).order()
+
+                # only need to check for adjustments if we've gone back
+                # far enough to cross the day boundary.
+                if minutes[0].date() != minutes[-1].date():
+                    # create a np array of size minutes, fill it all with
+                    # the same value.  and adjust the array.
+                    arr = np.array([result] * len(minutes),
+                                   dtype=np.float64)
+                    self._apply_all_adjustments(
+                        data=arr,
+                        asset=asset,
+                        dts=minutes,
+                        field=column
+                    )
+
+                    # The first value of the adjusted array is the value
+                    # we want.
+                    result = arr[0]
+
+        if column != 'volume':
+            return result * self.MINUTE_PRICE_ADJUSTMENT_FACTOR
+        else:
+            return result
+
+    def _get_daily_data(self, asset, column, dt):
+        while True:
+            try:
+                value = self._daily_bar_reader.spot_price(asset, dt, column)
+                if value != -1:
+                    return value
+                else:
+                    dt -= tradingcalendar.trading_day
+            except NoDataOnDate:
+                return 0
+
+    def _apply_all_adjustments(self, data, asset, dts, field,
+                               price_adj_factor=1.0):
+        """
+        Internal method that applies all the necessary adjustments on the
+        given data array.
+
+        The adjustments are:
+        - splits
+        - if field != "volume":
+            - mergers
+            - dividends
+            - * 0.001
+            - any zero fields replaced with NaN
+        - all values rounded to 3 digits after the decimal point.
+
+        Parameters
+        ----------
+        data : np.array
+            The data to be adjusted.
+
+        asset: Asset
+            The asset whose data is being adjusted.
+
+        dts: pd.DateTimeIndex
+            The list of minutes or days representing the desired window.
+
+        field: string
+            The field whose values are in the data array.
+
+        price_adj_factor: float
+            Factor with which to adjust OHLC values.
+        Returns
+        -------
+        None.  The data array is modified in place.
+        """
+        self._apply_adjustments_to_window(
+            self._get_adjustment_list(
+                asset, self._splits_dict, "SPLITS"
+            ),
+            data,
+            dts,
+            field != 'volume'
+        )
+
+        if field != 'volume':
+            self._apply_adjustments_to_window(
+                self._get_adjustment_list(
+                    asset, self._mergers_dict, "MERGERS"
+                ),
+                data,
+                dts,
+                True
+            )
+
+            self._apply_adjustments_to_window(
+                self._get_adjustment_list(
+                    asset, self._dividends_dict, "DIVIDENDS"
+                ),
+                data,
+                dts,
+                True
+            )
+
+            data *= price_adj_factor
+
+            # if anything is zero, it's a missing bar, so replace it with NaN.
+            # we only want to do this for non-volume fields, because a missing
+            # volume should be 0.
+            data[data == 0] = np.NaN
+
+        np.around(data, 3, out=data)
+
+    @staticmethod
+    def _apply_adjustments_to_window(adjustments_list, window_data,
+                                     dts_in_window, multiply):
+        if len(adjustments_list) == 0:
+            return
+
+        # advance idx to the correct spot in the adjustments list, based on
+        # when the window starts
+        idx = 0
+
+        while idx < len(adjustments_list) and dts_in_window[0] >\
+                adjustments_list[idx][0]:
+            idx += 1
+
+        # if we've advanced through all the adjustments, then there's nothing
+        # to do.
+        if idx == len(adjustments_list):
+            return
+
+        while idx < len(adjustments_list):
+            adjustment_to_apply = adjustments_list[idx]
+
+            if adjustment_to_apply[0] > dts_in_window[-1]:
+                break
+
+            range_end = dts_in_window.searchsorted(adjustment_to_apply[0])
+            if multiply:
+                window_data[0:range_end] *= adjustment_to_apply[1]
+            else:
+                window_data[0:range_end] /= adjustment_to_apply[1]
+
+            idx += 1
+
+    def _get_adjustment_list(self, asset, adjustments_dict, table_name):
+        """
+        Internal method that returns a list of adjustments for the given sid.
+
+        Parameters
+        ----------
+        asset : Asset
+            The asset for which to return adjustments.
+
+        adjustments_dict: dict
+            A dictionary of sid -> list that is used as a cache.
+
+        table_name: string
+            The table that contains this data in the adjustments db.
+
+        Returns
+        -------
+        adjustments: list
+            A list of [multiplier, pd.Timestamp], earliest first
+
+        """
+        if self._adjustment_reader is None:
+            return []
+
+        sid = int(asset)
+
+        try:
+            adjustments = adjustments_dict[sid]
+        except KeyError:
+            adjustments = adjustments_dict[sid] = self._adjustment_reader.\
+                get_adjustments_for_sid(table_name, sid)
+
+        return adjustments
+
+    def _check_is_currently_alive(self, asset, dt):
+        if dt is None:
+            dt = self.current_day
+
+        sid = int(asset)
+
+        if sid not in self._asset_start_dates:
+            self._get_asset_start_date(asset)
+
+        start_date = self._asset_start_dates[sid]
+        if self._asset_start_dates[sid] > dt:
+            raise NoTradeDataAvailableTooEarly(
+                sid=sid,
+                dt=dt,
+                start_dt=start_date
+            )
+
+        end_date = self._asset_end_dates[sid]
+        if self._asset_end_dates[sid] < dt:
+            raise NoTradeDataAvailableTooLate(
+                sid=sid,
+                dt=dt,
+                end_dt=end_date
+            )
+
+    def _get_asset_start_date(self, asset):
+        self._ensure_asset_dates(asset)
+        return self._asset_start_dates[asset]
+
+    def _get_asset_end_date(self, asset):
+        self._ensure_asset_dates(asset)
+        return self._asset_end_dates[asset]
+
+    def _ensure_asset_dates(self, asset):
+        sid = int(asset)
+
+        if sid not in self._asset_start_dates:
+            self._asset_start_dates[sid] = asset.start_date
+            self._asset_end_dates[sid] = asset.end_date

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -49,9 +49,9 @@ class DataPortal(object):
                  sim_params=None,
                  equity_daily_reader=None,
                  equity_minute_reader=None,
-                 minutes_futures_path=None,
-                 adjustment_reader=None,
-                 futures_sid_path_func=None):
+                 future_daily_reader=None,
+                 future_minute_reader=None,
+                 adjustment_reader=None):
         self.env = env
 
         # Internal pointers to the current dt (can be minute) and current day.
@@ -63,8 +63,6 @@ class DataPortal(object):
         self.current_day = None
 
         self.views = {}
-
-        self._minutes_futures_path = minutes_futures_path
 
         self._asset_finder = env.asset_finder
 
@@ -99,12 +97,12 @@ class DataPortal(object):
         else:
             self._data_frequency = "minute"
 
-        self._futures_sid_path_func = futures_sid_path_func
-
         self.MINUTE_PRICE_ADJUSTMENT_FACTOR = 0.001
 
         self._equity_daily_reader = equity_daily_reader
         self._equity_minute_reader = equity_minute_reader
+        self._future_daily_reader = future_daily_reader
+        self._future_minute_reader = future_minute_reader
 
     def _open_minute_file(self, field, asset):
         sid_str = str(int(asset))
@@ -121,12 +119,13 @@ class DataPortal(object):
         sid = int(asset)
 
         if isinstance(asset, Future):
-            if self._futures_sid_path_func is not None:
-                path = self._futures_sid_path_func(
-                    self._minutes_futures_path, sid
+            if self._future_minute_reader.sid_path_func is not None:
+                path = self._future_minute_reader.sid_path_func(
+                    self._future_minute_reader.rootdir, sid
                 )
             else:
-                path = "{0}/{1}.bcolz".format(self._minutes_futures_path, sid)
+                path = "{0}/{1}.bcolz".format(
+                    self._future_minute_reader.rootdir, sid)
         elif isinstance(asset, Equity):
             if self._equity_minute_reader.sid_path_func is not None:
                 path = self._equity_minute_reader.sid_path_func(

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -47,9 +47,9 @@ class DataPortal(object):
     def __init__(self,
                  env,
                  sim_params=None,
+                 equity_daily_reader=None,
                  equity_minute_reader=None,
                  minutes_futures_path=None,
-                 daily_equities_path=None,
                  adjustment_reader=None,
                  futures_sid_path_func=None):
         self.env = env
@@ -64,7 +64,6 @@ class DataPortal(object):
 
         self.views = {}
 
-        self._daily_equities_path = daily_equities_path
         self._minutes_futures_path = minutes_futures_path
 
         self._asset_finder = env.asset_finder
@@ -104,11 +103,7 @@ class DataPortal(object):
 
         self.MINUTE_PRICE_ADJUSTMENT_FACTOR = 0.001
 
-        if daily_equities_path is not None:
-            self._daily_bar_reader = BcolzDailyBarReader(daily_equities_path)
-        else:
-            self._daily_bar_reader = None
-
+        self._equity_daily_reader = equity_daily_reader
         self._equity_minute_reader = equity_minute_reader
 
     def _open_minute_file(self, field, asset):
@@ -291,7 +286,8 @@ class DataPortal(object):
     def _get_daily_data(self, asset, column, dt):
         while True:
             try:
-                value = self._daily_bar_reader.spot_price(asset, dt, column)
+                value = self._equity_daily_reader.spot_price(
+                    asset, dt, column)
                 if value != -1:
                     return value
                 else:

--- a/zipline/data/future_pricing.py
+++ b/zipline/data/future_pricing.py
@@ -1,0 +1,27 @@
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class FutureDailyReader(object):
+    """
+    Stubbed out. Currently unimplemented.
+    """
+    pass
+
+
+class FutureMinuteReader(object):
+
+    def __init__(self, rootdir, sid_path_func=None):
+        self.rootdir = rootdir
+        self.sid_path_func = sid_path_func

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -1,0 +1,316 @@
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+import bcolz
+import json
+import os
+from bcolz import ctable
+from datetime import datetime
+import numpy as np
+from numpy import float64
+from os.path import join
+import pandas as pd
+from pandas import read_csv
+from six import with_metaclass
+
+from zipline.finance.trading import TradingEnvironment
+from zipline.utils import tradingcalendar
+
+MINUTES_PER_DAY = 390
+
+_writer_env = TradingEnvironment()
+
+METADATA_FILENAME = 'metadata.json'
+
+
+def write_metadata(directory, first_trading_day):
+    metadata_path = os.path.join(directory, METADATA_FILENAME)
+
+    metadata = {
+        'first_trading_day': str(first_trading_day.date())
+    }
+
+    with open(metadata_path, 'w') as fp:
+        json.dump(metadata, fp)
+
+
+class BcolzMinuteBarWriter(with_metaclass(ABCMeta)):
+    """
+    Class capable of writing minute OHLCV data to disk into bcolz format.
+    """
+    @property
+    def first_trading_day(self):
+        return self._first_trading_day
+
+    @abstractmethod
+    def gen_frames(self, assets):
+        """
+        Return an iterator of pairs of (asset_id, pd.dataframe).
+        """
+        raise NotImplementedError()
+
+    def write(self, directory, assets, sid_path_func=None):
+        _iterator = self.gen_frames(assets)
+
+        return self._write_internal(directory, _iterator,
+                                    sid_path_func=sid_path_func)
+
+    @staticmethod
+    def full_minutes_for_days(env, dt1, dt2):
+        start_date = env.normalize_date(dt1)
+        end_date = env.normalize_date(dt2)
+
+        all_minutes = []
+
+        for day in env.days_in_range(start_date, end_date):
+            minutes_in_day = pd.date_range(
+                start=pd.Timestamp(
+                    datetime(
+                        year=day.year,
+                        month=day.month,
+                        day=day.day,
+                        hour=9,
+                        minute=31),
+                    tz='US/Eastern').tz_convert('UTC'),
+                periods=390,
+                freq="min"
+            )
+
+            all_minutes.append(minutes_in_day)
+
+        # flatten
+        return pd.DatetimeIndex(
+            np.concatenate(all_minutes), copy=False, tz='UTC'
+        )
+
+    def _write_internal(self, directory, iterator, sid_path_func=None):
+        first_trading_day = self.first_trading_day
+
+        write_metadata(directory, first_trading_day)
+
+        first_open = pd.Timestamp(
+            datetime(
+                year=first_trading_day.year,
+                month=first_trading_day.month,
+                day=first_trading_day.day,
+                hour=9,
+                minute=31
+            ), tz='US/Eastern').tz_convert('UTC')
+
+        for asset_id, df in iterator:
+            if sid_path_func is None:
+                path = join(directory, "{0}.bcolz".format(asset_id))
+            else:
+                path = sid_path_func(directory, asset_id)
+
+            os.makedirs(path)
+
+            minutes = self.full_minutes_for_days(_writer_env,
+                                                 first_open, df.index[-1])
+            minutes_count = len(minutes)
+
+            dt_col = np.zeros(minutes_count, dtype=np.uint32)
+            open_col = np.zeros(minutes_count, dtype=np.uint32)
+            high_col = np.zeros(minutes_count, dtype=np.uint32)
+            low_col = np.zeros(minutes_count, dtype=np.uint32)
+            close_col = np.zeros(minutes_count, dtype=np.uint32)
+            vol_col = np.zeros(minutes_count, dtype=np.uint32)
+
+            for row in df.iterrows():
+                dt = row[0]
+                idx = minutes.searchsorted(dt)
+
+                dt_col[idx] = dt.value / 1e9
+                open_col[idx] = row[1].loc["open"]
+                high_col[idx] = row[1].loc["high"]
+                low_col[idx] = row[1].loc["low"]
+                close_col[idx] = row[1].loc["close"]
+                vol_col[idx] = row[1].loc["volume"]
+
+            ctable(
+                columns=[
+                    open_col,
+                    high_col,
+                    low_col,
+                    close_col,
+                    vol_col,
+                    dt_col
+                ],
+                names=[
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "dt"
+                ],
+                rootdir=path,
+                mode='w'
+            )
+
+
+class MinuteBarWriterFromDataFrames(BcolzMinuteBarWriter):
+    _csv_dtypes = {
+        'open': float64,
+        'high': float64,
+        'low': float64,
+        'close': float64,
+        'volume': float64,
+    }
+
+    def __init__(self, first_trading_day):
+        self._first_trading_day = first_trading_day
+
+    def gen_frames(self, assets):
+        for asset in assets:
+            df = assets[asset]
+            yield asset, df.set_index("minute")
+
+
+class MinuteBarWriterFromCSVs(BcolzMinuteBarWriter):
+    """
+    BcolzMinuteBarWriter constructed from a map of CSVs to assets.
+
+    Parameters
+    ----------
+    asset_map: dict
+        A map from asset_id -> path to csv with data for that asset.
+
+    CSVs should have the following columns:
+        minute : datetime64
+        open : float64
+        high : float64
+        low : float64
+        close : float64
+        volume : int64
+    """
+    _csv_dtypes = {
+        'open': float64,
+        'high': float64,
+        'low': float64,
+        'close': float64,
+        'volume': float64,
+    }
+
+    def __init__(self, asset_map, first_trading_day):
+        self._asset_map = asset_map
+        self._first_trading_day = first_trading_day
+
+    def gen_frames(self, assets):
+        """
+        Read CSVs as DataFrames from our asset map.
+        """
+        dtypes = self._csv_dtypes
+
+        for asset in assets:
+            path = self._asset_map.get(asset)
+            if path is None:
+                raise KeyError("No path supplied for asset %s" % asset)
+            df = read_csv(path, parse_dates=['minute'], dtype=dtypes)
+            df = df.set_index("minute").tz_localize("UTC")
+
+            yield asset, df
+
+
+class BcolzMinuteBarReader(object):
+
+    def __init__(self, rootdir, sid_path_func=None):
+        self.rootdir = rootdir
+
+        metadata = self._get_metadata()
+
+        self.first_trading_day = pd.Timestamp(
+            metadata['first_trading_day'], tz='UTC')
+        mask = tradingcalendar.trading_days.slice_indexer(
+            self.first_trading_day)
+        # TODO: Read/write calendar to match daily, so that calendar is not
+        # 'hardcoded'.
+        self.trading_days = tradingcalendar.trading_days[mask]
+        self._sid_path_func = sid_path_func
+
+        self._carrays = {
+            'open': {},
+            'high': {},
+            'low': {},
+            'close': {},
+            'volume': {},
+            'sid': {},
+            'dt': {},
+        }
+
+    def _get_metadata(self):
+        with open(os.path.join(self.rootdir, METADATA_FILENAME)) as fp:
+            return json.load(fp)
+
+    def _get_ctable(self, asset):
+        sid = int(asset)
+        if self._sid_path_func is not None:
+            path = self._sid_path_func(self.rootdir, sid)
+        else:
+            path = "{0}/{1}.bcolz".format(self.rootdir, sid)
+
+        return bcolz.open(path, mode='r')
+
+    def _find_position_of_minute(self, minute_dt):
+        """
+        Internal method that returns the position of the given minute in the
+        list of every trading minute since market open on 1/2/2002.
+
+        IMPORTANT: This method assumes every day is 390 minutes long, even
+        early closes.  Our minute bcolz files are generated like this to
+        support fast lookup.
+
+        ex. this method would return 2 for 1/2/2002 9:32 AM Eastern.
+
+        Parameters
+        ----------
+        minute_dt: pd.Timestamp
+            The minute whose position should be calculated.
+
+        Returns
+        -------
+        The position of the given minute in the list of all trading minutes
+        since market open on 1/2/2002.
+        """
+        day = minute_dt.date()
+        day_idx = self.trading_days.searchsorted(day)
+        if day_idx < 0:
+            return -1
+
+        day_open = pd.Timestamp(
+            datetime(
+                year=day.year,
+                month=day.month,
+                day=day.day,
+                hour=9,
+                minute=31),
+            tz='US/Eastern').tz_convert('UTC')
+
+        minutes_offset = int((minute_dt - day_open).total_seconds()) / 60
+
+        return int((390 * day_idx) + minutes_offset)
+
+    def _open_minute_file(self, field, asset):
+        sid_str = str(int(asset))
+
+        try:
+            carray = self._carrays[field][sid_str]
+        except KeyError:
+            carray = self._carrays[field][sid_str] = \
+                self._get_ctable(asset)[field]
+
+        return carray

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -24,6 +24,7 @@ from bcolz import (
     carray,
     ctable,
 )
+from collections import namedtuple
 from click import progressbar
 from numpy import (
     array,
@@ -387,6 +388,8 @@ class BcolzDailyBarReader(object):
         # process first.
         self._spot_cols = {}
 
+        self.PRICE_ADJUSTMENT_FACTOR = 0.001
+
     def _compute_slices(self, start_idx, end_idx, assets):
         """
         Compute the raw row indices to load for each asset on a query for the
@@ -447,6 +450,15 @@ class BcolzDailyBarReader(object):
             offsets,
         )
 
+    def history_window(self, column, start_date, end_date, asset):
+        start_idx = self.sid_day_index(asset, start_date)
+        end_idx = self.sid_day_index(asset, end_date) + 1
+        col = self._spot_col(column)
+        window = col[start_idx:end_idx]
+        if column != 'volume':
+            window = window.astype(float64) * self.PRICE_ADJUSTMENT_FACTOR
+        return window
+
     def _spot_col(self, colname):
         """
         Get the colname from daily_bar_table and read all of it into memory,
@@ -466,7 +478,7 @@ class BcolzDailyBarReader(object):
         try:
             col = self._spot_cols[colname]
         except KeyError:
-            col = self._spot_cols[colname] = self._table[colname][:]
+            col = self._spot_cols[colname] = self._table[colname]
         return col
 
     def sid_day_index(self, sid, day):
@@ -485,7 +497,11 @@ class BcolzDailyBarReader(object):
             Raises a NoDataOnDate exception if the given day and sid is before
             or after the date range of the equity.
         """
-        day_loc = self._calendar.get_loc(day)
+        try:
+            day_loc = self._calendar.get_loc(day)
+        except KeyError:
+            raise NoDataOnDate("day={0} is outside of calendar={1}".format(
+                day, self._calendar))
         offset = day_loc - self._calendar_offsets[sid]
         if offset < 0:
             raise NoDataOnDate(
@@ -898,6 +914,23 @@ class SQLiteAdjustmentWriter(object):
         self.conn.close()
 
 
+UNPAID_QUERY_TEMPLATE = """
+SELECT sid, amount, pay_date from dividend_payouts
+WHERE ex_date=? AND sid IN ({0})
+"""
+
+Dividend = namedtuple('Dividend', ['sid', 'amount', 'pay_date'])
+
+UNPAID_STOCK_DIVIDEND_QUERY_TEMPLATE = """
+SELECT sid, payment_sid, ratio, pay_date from stock_dividend_payouts
+WHERE ex_date=? AND sid IN ({0})
+"""
+
+StockDividend = namedtuple(
+    'StockDividend',
+    ['sid', 'payment_sid', 'ratio', 'pay_date'])
+
+
 class SQLiteAdjustmentReader(object):
     """
     Loads adjustments based on corporate actions from a SQLite database.
@@ -922,3 +955,53 @@ class SQLiteAdjustmentReader(object):
             dates,
             assets,
         )
+
+    def get_adjustments_for_sid(self, table_name, sid):
+        t = (sid,)
+        c = self.conn.cursor()
+        adjustments_for_sid = c.execute(
+            "SELECT effective_date, ratio FROM %s WHERE sid = ?" %
+            table_name, t).fetchall()
+        c.close()
+
+        return [[Timestamp(adjustment[0], unit='s', tz='UTC'), adjustment[1]]
+                for adjustment in
+                adjustments_for_sid]
+
+    def get_dividends_with_ex_date(self, assets, date):
+        seconds = date.value / int(1e9)
+        c = self.conn.cursor()
+
+        query = UNPAID_QUERY_TEMPLATE.format(",".join(['?' for _ in assets]))
+        t = (seconds,) + tuple(map(lambda x: int(x), assets))
+
+        c.execute(query, t)
+
+        rows = c.fetchall()
+        c.close()
+        divs = []
+        for row in rows:
+            div = Dividend(
+                row[0], row[1], Timestamp(row[2], unit='s', tz='UTC'))
+            divs.append(div)
+        return divs
+
+    def get_stock_dividends_with_ex_date(self, assets, date):
+        seconds = date.value / int(1e9)
+        c = self.conn.cursor()
+
+        query = UNPAID_STOCK_DIVIDEND_QUERY_TEMPLATE.format(
+            ",".join(['?' for _ in assets]))
+        t = (seconds,) + tuple(map(lambda x: int(x), assets))
+
+        c.execute(query, t)
+
+        rows = c.fetchall()
+        c.close()
+
+        stock_divs = []
+        for row in rows:
+            stock_div = StockDividend(
+                row[0], row[1], row[2], Timestamp(row[3], unit='s', tz='UTC'))
+            stock_divs.append(stock_div)
+        return stock_divs

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,33 @@ class ZiplineError(Exception):
 
     __unicode__ = __str__
     __repr__ = __str__
+
+
+class NoTradeDataAvailable(ZiplineError):
+    pass
+
+
+class NoTradeDataAvailableTooEarly(NoTradeDataAvailable):
+    msg = "{sid} does not exist on {dt}. It started trading on {start_dt}."
+
+
+class NoTradeDataAvailableTooLate(NoTradeDataAvailable):
+    msg = "{sid} does not exist on {dt}. It stopped trading on {end_dt}."
+
+
+class BenchmarkAssetNotAvailableTooEarly(NoTradeDataAvailableTooEarly):
+    pass
+
+
+class BenchmarkAssetNotAvailableTooLate(NoTradeDataAvailableTooLate):
+    pass
+
+
+class InvalidBenchmarkAsset(ZiplineError):
+    msg = """
+{sid} cannot be used as the benchmark because it has a stock \
+dividend on {dt}.  Choose another asset to use as the benchmark.
+""".strip()
 
 
 class WrongDataForTransform(ZiplineError):
@@ -160,6 +187,13 @@ class OrderDuringInitialize(ZiplineError):
     Raised if order is called during initialize()
     """
     msg = "{msg}"
+
+
+class SetBenchmarkOutsideInitialize(ZiplineError):
+    """
+    Raised if set_benchmark is called outside initialize()
+    """
+    msg = "'set_benchmark' can only be called within initialize function."
 
 
 class AccountControlViolation(ZiplineError):


### PR DESCRIPTION
    ENH: Add initial commit for DataPortal and readers

    Moved from the `lazy-mainline` branch,
    https://github.com/quantopian/zipline/pull/858

    With the removal of methods that are not covered by the test_dataportal
    suite.

    The intent of this patch to provide the basic class and readers
    developed on that branch, so that the use of creating the object and
    opening paths etc. can be tested internally.

    Important to note that the only usage is in the test_dataportal suite,
    before any usage of the data_portal by the tradesimulation, a writer
    will should be provided for publicly available data.

# Extra notes

If I may, I ask for the bulk of review to be on the structure/composition of the class. There is a plan to refactor more responsibility and logic into the readers. The focus of this branch and the larger lazy-mainline is to get over the hump of accessing the data lazily throughout the system.

(e.g. the calculation of the index into the  minutes. The lazy-mainline branch currently provides some lookup tables for minute -> day -> index, though we may want to provide that lookup via a DatetimeIndex of all minutes, with changing the minute bar reader to provide that DattimeIndex.)

Much of the initial patch is with @jbredeche on this branch https://github.com/quantopian/zipline/tree/lazy-mainline