### PR TITLE
REF: Make dt required for spot value.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,10 @@ ext_modules = LazyCythonizingList([
         'zipline.data._adjustments',
         ['zipline/data/_adjustments.pyx'],
     ),
+    (
+        'zipline._protocol',
+        ['zipline/_protocol.pyx'],
+    ),
     ('zipline.gens.sim_engine', ['zipline/gens/sim_engine.pyx']),
 ])
 

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -1,0 +1,91 @@
+#
+# Copyright 2015 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pandas.tslib import normalize_date
+
+cdef class BarData:
+    """
+    Holds the event data for all sids for a given dt.
+
+    This is what is passed as `data` to the `handle_data` function.
+    """
+    cdef object data_portal
+    cdef object simulator
+    cdef dict _views
+
+    def __init__(self, data_portal, simulator):
+        self.data_portal = data_portal
+        self.simulator = simulator
+        self._views = {}
+
+    property simulation_dt:
+        def __get__(self):
+            return self.simulator.simulation_dt
+
+    def _get_equity_price_view(self, asset):
+        """
+        Returns a DataPortalSidView for the given asset.  Used to support the
+        data[sid(N)] public API.  Not needed if DataPortal is used standalone.
+
+        Parameters
+        ----------
+        asset : Asset
+            Asset that is being queried.
+
+        Returns
+        -------
+        SidView: Accessor into the given asset's data.
+        """
+        try:
+            view = self._views[asset]
+        except KeyError:
+            view = self._views[asset] = \
+                SidView(asset, self.data_portal, self)
+
+        return view
+
+    def __getitem__(self, name):
+        return self._get_equity_price_view(name)
+
+    def __iter__(self):
+        raise TypeError('%r object is not iterable'
+                        % self.__class__.__name__)
+
+    @property
+    def fetcher_assets(self):
+        return self.data_portal.get_fetcher_assets(
+            normalize_date(self.simulation_dt)
+        )
+
+cdef class SidView:
+
+    cdef object asset
+    cdef object data_portal
+    cdef object bar_data
+    
+    def __init__(self, asset, data_portal, bar_data):
+        self.asset = asset
+        self.data_portal = data_portal
+        self.bar_data = bar_data
+
+    def __getattr__(self, column):
+        return self.data_portal.get_spot_value(
+            self.asset, column, self.bar_data.simulation_dt)
+
+    def __contains__(self, column):
+        return self.data_portal.contains(self.asset, column)
+
+    def __getitem__(self, column):
+        return self.__getattr__(column)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 import bcolz
 from logbook import Logger
 
@@ -80,7 +79,6 @@ class DataPortal(object):
         # current minute.  These pointers are updated by the
         # AlgorithmSimulator's transform loop.
         self.current_dt = None
-        self.current_day = None
 
         # This is a bit ugly, but is here for performance reasons.  In minute
         # simulations, we need to very quickly go from dt -> (# of minutes
@@ -317,19 +315,18 @@ class DataPortal(object):
                     loc[day, column]
             except:
                 log.error(
-                    "Could not find value for asset={0}, current_day={1},"
+                    "Could not find value for asset={0}, day={1},"
                     "column={2}".format(
                         str(asset),
-                        str(self.current_day),
+                        str(day),
                         str(column)))
 
                 raise KeyError
 
-    def get_spot_value(self, asset, field, dt=None):
+    def get_spot_value(self, asset, field, dt):
         """
         Public API method that returns a scalar value representing the value
-        of the desired asset's field at either the given dt, or this data
-        portal's current_dt.
+        of the desired asset's field at either the given dt.
 
         Parameters
         ---------
@@ -351,7 +348,7 @@ class DataPortal(object):
         extra_source_val = self._check_extra_sources(
             asset,
             field,
-            (dt or self.current_dt)
+            dt,
         )
 
         if extra_source_val is not None:
@@ -368,18 +365,16 @@ class DataPortal(object):
         self._check_is_currently_alive(asset, dt)
 
         if self._data_frequency == "daily":
-            day_to_use = dt or self.current_day
+            day_to_use = dt
             day_to_use = normalize_date(day_to_use)
             return self._get_daily_data(asset, column_to_use, day_to_use)
         else:
-            dt_to_use = dt or self.current_dt
-
             if isinstance(asset, Future):
                 return self._get_minute_spot_value_future(
-                    asset, column_to_use, dt_to_use)
+                    asset, column_to_use, dt)
             else:
                 return self._get_minute_spot_value(
-                    asset, column_to_use, dt_to_use)
+                    asset, column_to_use, dt)
 
     def _get_minute_spot_value_future(self, asset, column, dt):
         # Futures bcolz files have 1440 bars per day (24 hours), 7 days a week.
@@ -480,7 +475,7 @@ class DataPortal(object):
             # to be adjusted.
             if result != 0:
                 minutes = self.env.market_minute_window(
-                    start=(dt or self.current_dt),
+                    start=dt,
                     count=(original_start - minute_offset_to_use + 1),
                     step=-1
                 ).order()
@@ -1134,9 +1129,6 @@ class DataPortal(object):
         return view
 
     def _check_is_currently_alive(self, asset, dt):
-        if dt is None:
-            dt = self.current_day
-
         sid = int(asset)
 
         if sid not in self._asset_start_dates:
@@ -1258,7 +1250,7 @@ class DataPortal(object):
             (field in self._augmented_sources_map and
              asset in self._augmented_sources_map[field])
 
-    def get_fetcher_assets(self):
+    def get_fetcher_assets(self, day):
         """
         Returns a list of assets for the current date, as defined by the
         fetcher data.
@@ -1277,12 +1269,12 @@ class DataPortal(object):
         if self._extra_source_df is None:
             return []
 
-        if self.current_day in self._extra_source_df.index:
-            date_to_use = self.current_day
+        if day in self._extra_source_df.index:
+            date_to_use = day
         else:
             # current day isn't in the fetcher df, go back the last
             # available day
-            idx = self._extra_source_df.index.searchsorted(self.current_day)
+            idx = self._extra_source_df.index.searchsorted(day)
             if idx == 0:
                 return []
 
@@ -1301,9 +1293,11 @@ class DataPortalSidView(object):
     def __init__(self, asset, portal):
         self.asset = asset
         self.portal = portal
+        self.current_dt = None
 
     def __getattr__(self, column):
-        return self.portal.get_spot_value(self.asset, column)
+        return self.portal.get_spot_value(
+            self.asset, column, self.portal.current_dt)
 
     def __contains__(self, column):
         return self.portal.contains(self.asset, column)

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -414,7 +414,7 @@ class PositionTracker(object):
             return None
 
         amount = self.positions.get(event.sid).amount
-        price = self._data_portal.get_spot_value(event.sid, 'close')
+        price = self._data_portal.get_spot_value(event.sid, 'close', event.dt)
 
         txn = Transaction(
             sid=event.sid,

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -57,7 +57,7 @@ class AlgorithmSimulator(object):
         # The algorithm's data as of our most recent event.
         # We want an object that will have empty objects as default
         # values on missing keys.
-        self.current_data = BarData(data_portal=self.data_portal)
+        self.current_data = BarData(data_portal, self)
 
         # We don't have a datetime for the current snapshot until we
         # receive a message.
@@ -99,7 +99,6 @@ class AlgorithmSimulator(object):
         def every_bar(dt_to_use):
             # called every tick (minute or day).
 
-            data_portal.current_dt = dt_to_use
             self.simulation_dt = dt_to_use
             algo.on_dt_changed(dt_to_use)
 

--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from . utils.protocol_utils import Enum
 
+from pandas.tslib import normalize_date
 from zipline.utils.serialization_utils import (
     VERSION_LABEL
 )
@@ -252,4 +253,6 @@ class BarData(object):
 
     @property
     def fetcher_assets(self):
-        return self.data_portal.get_fetcher_assets()
+        return self.data_portal.get_fetcher_assets(
+            normalize_date(self.data_portal.current_dt)
+        )


### PR DESCRIPTION
Make interface for get_spot_value more more precise by always requiring
the dt parameter, no longer sometimes using a current_dt value if set.

Still relies on a current_dt to be updated on data_portal from
tradesimulation, but that value is now accessed and passed more
explicitly by the bar data views.