### PR TITLE
REF: Require data_frequency as spot_value param

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -137,8 +137,12 @@ class SlippageTestCase(TestCase):
             orders_txns = list(slippage_model.simulate(
                 open_orders,
                 self.minutes[0],
-                data_portal.get_spot_value(133, 'close', self.minutes[0]),
-                data_portal.get_spot_value(133, 'volume', self.minutes[0])
+                data_portal.get_spot_value(
+                    133, 'close', self.minutes[0],
+                    self.sim_params.data_frequency),
+                data_portal.get_spot_value(
+                    133, 'volume', self.minutes[0],
+                    self.sim_params.data_frequency)
             ))
 
             self.assertEquals(len(orders_txns), 1)
@@ -180,8 +184,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[3],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[3]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[3])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[3],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[3],
+                self.sim_params.data_frequency)
         ))
         self.assertEquals(len(orders_txns), 0)
 
@@ -198,8 +206,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[3],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[3]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[3])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[3],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[3],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -217,8 +229,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[3],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[3]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[3])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[3],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[3],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 1)
@@ -253,8 +269,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[0],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[0]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[0])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[0],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[0],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -272,8 +292,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[0],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[0]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[0])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[0],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[0],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -291,8 +315,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[1],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[1]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[1])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[1],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[1],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 1)
@@ -476,8 +504,12 @@ class SlippageTestCase(TestCase):
                 _, txn = next(slippage_model.simulate(
                     [order],
                     dt,
-                    data_portal.get_spot_value(133, "close", dt),
-                    data_portal.get_spot_value(133, "volume", dt)
+                    data_portal.get_spot_value(
+                        133, "close", dt,
+                        self.sim_params.data_frequency),
+                    data_portal.get_spot_value(
+                        133, "volume", dt,
+                        self.sim_params.data_frequency)
                 ))
             except StopIteration:
                 txn = None
@@ -510,8 +542,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[2],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[2]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[2])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[2],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[2],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -519,8 +555,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[3],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[3]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[3])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[3],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[3],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -539,8 +579,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[2],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[2]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[2])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[2],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[2],
+                self.sim_params.data_frequency),
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -548,8 +592,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[3],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[3]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[3])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[3],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[3],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -568,8 +616,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[2],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[2]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[2])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[2],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[2],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -577,8 +629,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[3],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[3]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[3])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[3],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[3],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 1)
@@ -610,8 +666,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[0],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[0]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[0])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[0],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[0],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -619,8 +679,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[1],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[1]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[1])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[1],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[1],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -639,8 +703,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[0],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[0]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[0])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[0],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[0],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -648,8 +716,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[1],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[1]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[1])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[1],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[1],
+                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -668,8 +740,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[0],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[0]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[0]),
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[0],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[0],
+                self.sim_params.data_frequency),
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -677,8 +753,12 @@ class SlippageTestCase(TestCase):
         orders_txns = list(slippage_model.simulate(
             open_orders,
             self.minutes[1],
-            self.data_portal.get_spot_value(133, 'close', self.minutes[1]),
-            self.data_portal.get_spot_value(133, 'volume', self.minutes[1])
+            self.data_portal.get_spot_value(
+                133, 'close', self.minutes[1],
+                self.sim_params.data_frequency),
+            self.data_portal.get_spot_value(
+                133, 'volume', self.minutes[1],
+                self.sim_params.data_frequency),
         ))
 
         self.assertEquals(len(orders_txns), 1)

--- a/tests/serialization_cases.py
+++ b/tests/serialization_cases.py
@@ -60,14 +60,16 @@ returns = factory.create_returns_from_list(
 def object_serialization_cases(skip_daily=False):
     # Wrapped in a function to recreate DI objects.
     cases = [
-        (Blotter, (), {}, 'repr'),
+        (Blotter, ('minute',), {}, 'repr'),
         (Order, (datetime.datetime(2013, 6, 19), 8554, 100), {}, 'dict'),
         (PerShare, (), {}, 'dict'),
         (PerTrade, (), {}, 'dict'),
         (PerDollar, (), {}, 'dict'),
-        (PerformancePeriod, (10000, cases_env.asset_finder), {}, 'dict'),
+        (PerformancePeriod, (10000, cases_env.asset_finder, 'minute'), {},
+         'dict'),
         (Position, (8554,), {}, 'dict'),
-        (PositionTracker, (cases_env.asset_finder, None), {}, 'dict'),
+        (PositionTracker, (cases_env.asset_finder, None, 'minute'),
+         {}, 'dict'),
         # FIXME temporarily commenting out because of dataportal issues
         # (PerformanceTracker, (sim_params_minute, cases_env, None), {},
         # 'to_dict'),

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -99,7 +99,7 @@ class BlotterTestCase(TestCase):
                            (StopLimitOrder(10, 20), 10, 20)])
     def test_blotter_order_types(self, style_obj, expected_lmt, expected_stp):
 
-        blotter = Blotter()
+        blotter = Blotter('daily')
 
         blotter.order(24, 100, style_obj)
         result = blotter.open_orders[24][0]
@@ -108,7 +108,7 @@ class BlotterTestCase(TestCase):
         self.assertEqual(result.stop, expected_stp)
 
     def test_order_rejection(self):
-        blotter = Blotter()
+        blotter = Blotter(self.sim_params.data_frequency)
 
         # Reject a nonexistent order -> no order appears in new_order,
         # no exceptions raised out
@@ -137,7 +137,7 @@ class BlotterTestCase(TestCase):
 
         # Do it again, but reject it at a later time (after tradesimulation
         # pulls it from new_orders)
-        blotter = Blotter()
+        blotter = Blotter(self.sim_params.data_frequency)
 
         new_open_id = blotter.order(24, 10, MarketOrder())
         new_open_order = blotter.open_orders[24][0]
@@ -153,7 +153,8 @@ class BlotterTestCase(TestCase):
         self.assertEqual(rejected_order.reason, rejection_reason)
 
         # You can't reject a filled order.
-        blotter = Blotter()   # Reset for paranoia
+        # Reset for paranoia
+        blotter = Blotter(self.sim_params.data_frequency)
         blotter.slippage_func = FixedSlippage()
         filled_id = blotter.order(24, 100, MarketOrder())
         filled_order = None
@@ -177,7 +178,7 @@ class BlotterTestCase(TestCase):
         status indication. When a fill happens, the order should switch
         status to OPEN/FILLED as necessary
         """
-        blotter = Blotter()
+        blotter = Blotter(self.sim_params.data_frequency)
         # Nothing happens on held of a non-existent order
         blotter.hold(56)
         self.assertEqual(blotter.new_orders, [])
@@ -213,7 +214,7 @@ class BlotterTestCase(TestCase):
             expected_status = ORDER_STATUS.OPEN if expected_open else \
                 ORDER_STATUS.FILLED
 
-            blotter = Blotter()
+            blotter = Blotter(self.sim_params.data_frequency)
             open_id = blotter.order(24, order_size, MarketOrder())
             open_order = blotter.open_orders[24][0]
             self.assertEqual(open_id, open_order.id)

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -75,7 +75,10 @@ class TestDataPortal(TestCase):
             for minute_idx, minute in enumerate(minutes):
                 for field_idx, field in enumerate(
                         ["open", "high", "low", "close", "volume"]):
-                    val = dp.get_spot_value(0, field, dt=minute)
+                    val = dp.get_spot_value(
+                        0, field,
+                        dt=minute,
+                        data_frequency=sim_params.data_frequency)
                     if minute_idx == 0:
                         self.assertEqual(0, val)
                     elif minute_idx < 200:
@@ -140,7 +143,10 @@ class TestDataPortal(TestCase):
             for day_idx, day in enumerate(days):
                 for field_idx, field in enumerate(
                         ["open", "high", "low", "close", "volume"]):
-                    val = dp.get_spot_value(0, field, dt=day)
+                    val = dp.get_spot_value(
+                        0, field,
+                        dt=day,
+                        data_frequency=sim_params.data_frequency)
                     if day_idx == 0:
                         self.assertEqual(0, val)
                     elif day_idx < 9:
@@ -258,7 +264,10 @@ class TestDataPortal(TestCase):
                 for field_idx, field in enumerate(["open", "high", "low",
                                                    "close", "volume"]):
                     self.assertEqual(
-                        dp.get_spot_value(0, field, dt=minute),
+                        dp.get_spot_value(
+                            0, field,
+                            dt=minute,
+                            data_frequency=sim_params.data_frequency),
                         idx + (1000 * field_idx)
                     )
 
@@ -268,12 +277,18 @@ class TestDataPortal(TestCase):
                 for field_idx, field in enumerate(["open", "high", "low",
                                                    "close"]):
                     self.assertEqual(
-                        dp.get_spot_value(0, field, dt=minute),
+                        dp.get_spot_value(
+                            0, field,
+                            dt=minute,
+                            data_frequency=sim_params.data_frequency),
                         (389 + (1000 * field_idx)) / 2.0
                     )
 
                 self.assertEqual(
-                    dp.get_spot_value(0, "volume", dt=minute),
+                    dp.get_spot_value(
+                        0, "volume",
+                        dt=minute,
+                        data_frequency=sim_params.data_frequency),
                     8778  # 4389 * 2
                 )
 
@@ -282,7 +297,11 @@ class TestDataPortal(TestCase):
                 for field_idx, field in enumerate(["open", "high", "low",
                                                    "close", "volume"]):
                     self.assertEqual(
-                        dp.get_spot_value(0, field, dt=minute),
+                        dp.get_spot_value(
+                            0, field,
+                            dt=minute,
+                            data_frequency=sim_params.data_frequency
+                        ),
                         (390 + idx + (1000 * field_idx))
                     )
         finally:
@@ -331,19 +350,26 @@ class TestDataPortal(TestCase):
 
             future123 = env.asset_finder.retrieve_asset(123)
 
+            data_frequency = 'minute'
+
             for i in range(0, 10000):
                 dt = pd.Timestamp(start_dt + timedelta(minutes=i))
 
                 self.assertEqual(i,
-                                 dp.get_spot_value(future123, "open", dt))
+                                 dp.get_spot_value(
+                                     future123, "open", dt, data_frequency))
                 self.assertEqual(i + 10000,
-                                 dp.get_spot_value(future123, "high", dt))
+                                 dp.get_spot_value(
+                                     future123, "high", dt, data_frequency))
                 self.assertEqual(i + 20000,
-                                 dp.get_spot_value(future123, "low", dt))
+                                 dp.get_spot_value(
+                                     future123, "low", dt, data_frequency))
                 self.assertEqual(i + 30000,
-                                 dp.get_spot_value(future123, "close", dt))
+                                 dp.get_spot_value(
+                                     future123, "close", dt, data_frequency))
                 self.assertEqual(i + 40000,
-                                 dp.get_spot_value(future123, "volume", dt))
+                                 dp.get_spot_value(
+                                     future123, "volume", dt, data_frequency))
 
         finally:
             tempdir.cleanup()

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -199,11 +199,6 @@ class FinanceTestCase(TestCase):
             complete_fill = params.get('complete_fill')
 
             env = TradingEnvironment()
-            blotter = Blotter()
-
-            if "default_slippage" not in params or \
-                    not params["default_slippage"]:
-                blotter.slippage_func = FixedSlippage()
 
             sid = 1
 
@@ -267,6 +262,15 @@ class FinanceTestCase(TestCase):
                     daily_equities_path=path,
                     sim_params=sim_params
                 )
+
+            if "default_slippage" not in params or \
+               not params["default_slippage"]:
+                slippage_func = FixedSlippage()
+            else:
+                slippage_func = None
+
+            blotter = Blotter(sim_params.data_frequency,
+                              slippage_func)
 
             env.write_data(equities_data={
                 sid: {
@@ -347,7 +351,8 @@ class FinanceTestCase(TestCase):
             tempdir.cleanup()
 
     def test_blotter_processes_splits(self):
-        blotter = Blotter(slippage_func=FixedSlippage())
+        blotter = Blotter('daily',
+                          slippage_func=FixedSlippage())
 
         # set up two open limit orders with very low limit prices,
         # one for sid 1 and one for sid 2

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -1244,8 +1244,11 @@ class TestPositionPerformance(unittest.TestCase):
             {1: trades_1, 2: trades_2}
         )
 
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
-        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
+        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder,
+                                    self.sim_params.data_frequency,
+                                    data_portal)
         pt.execute_transaction(txn1)
         pp.handle_execution(txn1)
         pt.execute_transaction(txn2)
@@ -1338,8 +1341,11 @@ class TestPositionPerformance(unittest.TestCase):
             {1: trades})
 
         txn = create_txn(trades[1].sid, trades[1].dt, 10.0, 1000)
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
-        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
+        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder,
+                                    self.sim_params.data_frequency,
+                                    data_portal)
 
         pt.execute_transaction(txn)
         pp.handle_execution(txn)
@@ -1429,8 +1435,10 @@ class TestPositionPerformance(unittest.TestCase):
             {1: trades})
 
         txn = create_txn(trades[1].sid, trades[1].dt, 10.0, 100)
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
         pp = perf.PerformancePeriod(1000.0, self.env.asset_finder,
+                                    self.sim_params.data_frequency,
                                     period_open=self.sim_params.period_start,
                                     period_close=self.sim_params.period_end)
         pt.execute_transaction(txn)
@@ -1544,8 +1552,12 @@ single short-sale transaction"""
             {1: trades})
 
         txn = create_txn(trades[1].sid, trades[1].dt, 10.0, -100)
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
-        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
+        pp = perf.PerformancePeriod(
+            1000.0, self.env.asset_finder,
+            self.sim_params.data_frequency,
+            data_portal)
 
         pt.execute_transaction(txn)
         pp.handle_execution(txn)
@@ -1663,8 +1675,10 @@ single short-sale transaction"""
         )
 
         # now run a performance period encompassing the entire trade sample.
-        ptTotal = perf.PositionTracker(self.env.asset_finder, data_portal)
+        ptTotal = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                       self.sim_params.data_frequency)
         ppTotal = perf.PerformancePeriod(1000.0, self.env.asset_finder,
+                                         self.sim_params.data_frequency,
                                          data_portal)
 
         ptTotal.execute_transaction(txn)
@@ -1777,8 +1791,10 @@ trade after cover"""
             -100,
         )
         cover_txn = create_txn(trades[6].sid, trades[6].dt, 7.0, 100)
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
         pp = perf.PerformancePeriod(1000.0, self.env.asset_finder,
+                                    self.sim_params.data_frequency,
                                     data_portal)
 
         pt.execute_transaction(short_txn)
@@ -1888,10 +1904,12 @@ shares in position"
             self.sim_params,
             {1: trades})
 
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
         pp = perf.PerformancePeriod(
             1000.0,
             self.env.asset_finder,
+            self.sim_params.data_frequency,
             period_open=self.sim_params.period_start,
             period_close=self.sim_params.trading_days[-1]
         )
@@ -1961,9 +1979,10 @@ shares in position"
         self.assertEqual(pp_stats.pnl, -800,
                          "this period goes from +400 to -400")
 
-        pt3 = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pt3 = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                   self.sim_params.data_frequency)
         pp3 = perf.PerformancePeriod(1000.0, self.env.asset_finder,
-                                     data_portal)
+                                     self.sim_params.data_frequency)
 
         average_cost = 0
         for i, txn in enumerate(transactions):
@@ -2022,8 +2041,10 @@ shares in position"
             self.sim_params,
             {1: trades})
 
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
-        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  self.sim_params.data_frequency)
+        pp = perf.PerformancePeriod(1000.0, self.env.asset_finder, data_portal,
+                                    self.sim_params.data_frequency)
 
         for txn, cb in zip(transactions, cost_bases):
             pt.execute_transaction(txn)
@@ -2093,7 +2114,8 @@ class TestPositionTracker(unittest.TestCase):
             sim_params,
             {1: trades})
 
-        pt = perf.PositionTracker(self.env.asset_finder, data_portal)
+        pt = perf.PositionTracker(self.env.asset_finder, data_portal,
+                                  sim_params.data_frequency)
         pos_stats = pt.stats()
 
         stats = [
@@ -2114,7 +2136,7 @@ class TestPositionTracker(unittest.TestCase):
             self.assertNotIsInstance(val, (bool, np.bool_))
 
     def test_position_values_and_exposures(self):
-        pt = perf.PositionTracker(self.env.asset_finder, None)
+        pt = perf.PositionTracker(self.env.asset_finder, None, None)
         dt = pd.Timestamp("1984/03/06 3:00PM")
         pos1 = perf.Position(1, amount=np.float64(10.0),
                              last_sale_date=dt, last_sale_price=10)
@@ -2147,7 +2169,7 @@ class TestPositionTracker(unittest.TestCase):
         self.assertEqual(100 - 200 + 300000 - 400000, pos_stats.net_exposure)
 
     def test_serialization(self):
-        pt = perf.PositionTracker(self.env.asset_finder, None)
+        pt = perf.PositionTracker(self.env.asset_finder, None, None)
         dt = pd.Timestamp("1984/03/06 3:00PM")
         pos1 = perf.Position(1, amount=np.float64(120.0),
                              last_sale_date=dt, last_sale_price=3.4)
@@ -2167,7 +2189,7 @@ class TestPerformancePeriod(unittest.TestCase):
 
     def test_serialization(self):
         env = TradingEnvironment()
-        pp = perf.PerformancePeriod(100, env.asset_finder)
+        pp = perf.PerformancePeriod(100, env.asset_finder, 'minute')
 
         p_string = dumps_with_persistent_ids(pp)
         test = loads_with_persistent_ids(p_string, env=env)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -236,7 +236,8 @@ class TradingAlgorithm(object):
         if not self.blotter:
             self.blotter = Blotter(
                 slippage_func=VolumeShareSlippage(),
-                commission=PerShare()
+                commission=PerShare(),
+                data_frequency=self.data_frequency,
             )
 
         # The symbol lookup date specifies the date to use when resolving

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -328,7 +328,11 @@ class DataPortal(object):
             "price".
 
         dt: pd.Timestamp
-            (Optional) The timestamp for the desired value.
+            The timestamp for the desired value.
+
+        data_frequency: string
+            The frequency of the data to query; i.e. whether the data is
+            'daily' or 'minute' bars
 
         Returns
         -------

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -279,6 +279,10 @@ class DataPortal(object):
         dt: pd.Timestamp
             The timestamp from which to go back in time one slot.
 
+        data_frequency: string
+            The frequency of the data to query; i.e. whether the data is
+            'daily' or 'minute' bars
+
         Returns
         -------
         The value of the desired field at the desired time.

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -116,10 +116,6 @@ class DataPortal(object):
         self._extra_source_df = None
 
         self._sim_params = sim_params
-        if self._sim_params is not None:
-            self._data_frequency = self._sim_params.data_frequency
-        else:
-            self._data_frequency = "minute"
 
         self._futures_sid_path_func = futures_sid_path_func
 
@@ -263,7 +259,7 @@ class DataPortal(object):
 
         return bcolz.open(path, mode='r')
 
-    def get_previous_value(self, asset, field, dt):
+    def get_previous_value(self, asset, field, dt, data_frequency):
         """
         Given an asset and a column and a dt, returns the previous value for
         the same asset/column pair.  If this data portal is in minute mode,
@@ -287,12 +283,12 @@ class DataPortal(object):
         -------
         The value of the desired field at the desired time.
         """
-        if self._data_frequency == 'daily':
+        if data_frequency == 'daily':
             prev_dt = self.env.previous_trading_day(dt)
-        elif self._data_frequency == 'minute':
+        elif data_frequency == 'minute':
             prev_dt = self.env.previous_market_minute(dt)
 
-        return self.get_spot_value(asset, field, prev_dt)
+        return self.get_spot_value(asset, field, prev_dt, data_frequency)
 
     def _check_extra_sources(self, asset, column, day):
         # If we have an extra source with a column called "price", only look
@@ -316,7 +312,7 @@ class DataPortal(object):
 
                 raise KeyError
 
-    def get_spot_value(self, asset, field, dt):
+    def get_spot_value(self, asset, field, dt, data_frequency):
         """
         Public API method that returns a scalar value representing the value
         of the desired asset's field at either the given dt.
@@ -357,7 +353,7 @@ class DataPortal(object):
 
         self._check_is_currently_alive(asset, dt)
 
-        if self._data_frequency == "daily":
+        if data_frequency == "daily":
             day_to_use = dt
             day_to_use = normalize_date(day_to_use)
             return self._get_daily_data(asset, column_to_use, day_to_use)

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -154,6 +154,7 @@ class PerformancePeriod(object):
             self,
             starting_cash,
             asset_finder,
+            data_frequency,
             period_open=None,
             period_close=None,
             keep_transactions=True,
@@ -162,6 +163,7 @@ class PerformancePeriod(object):
             name=None):
 
         self.asset_finder = asset_finder
+        self.data_frequency = data_frequency
 
         self.period_open = period_open
         self.period_close = period_close
@@ -276,11 +278,11 @@ class PerformancePeriod(object):
                     continue
 
                 old_price = data_portal.get_previous_value(
-                    sid, 'close', dt=old_price_dt
+                    sid, 'close', old_price_dt, self.data_frequency
                 )
 
                 price = data_portal.get_spot_value(
-                    sid, 'close', dt=self.period_close
+                    sid, 'close', self.period_close, self.data_frequency,
                 )
 
                 payout = (
@@ -452,6 +454,7 @@ class PerformancePeriod(object):
 
         state_dict['_portfolio_store'] = self._portfolio_store
         state_dict['_account_store'] = self._account_store
+        state_dict['data_frequency'] = self.data_frequency
 
         state_dict['processed_transactions'] = \
             dict(self.processed_transactions)

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -109,8 +109,10 @@ class PerformanceTracker(object):
         else:
             self._adjustment_reader = None
 
-        self.position_tracker = PositionTracker(asset_finder=env.asset_finder,
-                                                data_portal=data_portal)
+        self.position_tracker = PositionTracker(
+            asset_finder=env.asset_finder,
+            data_portal=data_portal,
+            data_frequency=self.sim_params.data_frequency)
 
         if self.emission_rate == 'daily':
             self.all_benchmark_returns = pd.Series(
@@ -131,6 +133,7 @@ class PerformanceTracker(object):
         self.cumulative_performance = PerformancePeriod(
             # initial cash is your capital base.
             starting_cash=self.capital_base,
+            data_frequency=self.sim_params.data_frequency,
             # the cumulative period will be calculated over the entire test.
             period_open=self.period_start,
             period_close=self.period_end,
@@ -148,6 +151,7 @@ class PerformanceTracker(object):
         self.todays_performance = PerformancePeriod(
             # initial cash is your capital base.
             starting_cash=self.capital_base,
+            data_frequency=self.sim_params.data_frequency,
             # the daily period will be calculated for the market day
             period_open=self.market_open,
             period_close=self.market_close,

--- a/zipline/sources/benchmark_source.py
+++ b/zipline/sources/benchmark_source.py
@@ -175,9 +175,9 @@ class BenchmarkSource(object):
 
                 # get a minute history window of the first day
                 first_open = data_portal.get_spot_value(
-                    sid, 'open', trading_days[0])
+                    sid, 'open', trading_days[0], 'daily')
                 first_close = data_portal.get_spot_value(
-                    sid, 'close', trading_days[0])
+                    sid, 'close', trading_days[0], 'daily')
 
                 first_day_return = (first_close - first_open) / first_open
 

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -763,11 +763,11 @@ class FetcherDataPortal(DataPortal):
             sim_params
         )
 
-    def get_spot_value(self, asset, field, dt=None):
+    def get_spot_value(self, asset, field, dt, data_frequency):
         # if this is a fetcher field, exercise the regular code path
         if self._check_extra_sources(asset, field, (dt or self.current_dt)):
             return super(FetcherDataPortal, self).get_spot_value(
-                asset, field, dt)
+                asset, field, dt, data_frequency)
 
         # otherwise just return a fixed value
         return int(asset)


### PR DESCRIPTION
So that the data_portal is not tied to solely daily or minute data
frequencies, make the get_spot_value method require a data frequency.

This change required that more classes held a reference to the
simulation's data frequency, e.g. the blotter and performance trackers.

Update serialization to reflect those changes.