### PR TITLE
MAINT: Remove perf_periods member.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -256,7 +256,11 @@ def check_perf_tracker_serialization(perf_tracker):
     for k in scalar_keys:
         nt.assert_equal(getattr(test, k), getattr(perf_tracker, k), k)
 
-    for period in test.perf_periods:
+    perf_periods = (
+        test.cumulative_performance,
+        test.todays_performance
+    )
+    for period in perf_periods:
         nt.assert_true(hasattr(period, '_position_tracker'))
 
 

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -111,8 +111,6 @@ class PerformanceTracker(object):
 
         self.position_tracker = PositionTracker(asset_finder=env.asset_finder)
 
-        self.perf_periods = []
-
         if self.emission_rate == 'daily':
             self.all_benchmark_returns = pd.Series(
                 index=self.trading_days)
@@ -145,7 +143,6 @@ class PerformanceTracker(object):
             asset_finder=self.env.asset_finder,
         )
         self.cumulative_performance.position_tracker = self.position_tracker
-        self.perf_periods.append(self.cumulative_performance)
 
         # this performance period will span just the current market day
         self.todays_performance = PerformancePeriod(
@@ -160,8 +157,6 @@ class PerformanceTracker(object):
             asset_finder=self.env.asset_finder,
         )
         self.todays_performance.position_tracker = self.position_tracker
-
-        self.perf_periods.append(self.todays_performance)
 
         self.saved_dt = self.period_start
         # one indexed so that we reach 100%
@@ -239,8 +234,8 @@ class PerformanceTracker(object):
 
     def update_performance(self):
         # calculate performance as of last trade
-        for perf_period in self.perf_periods:
-            perf_period.calculate_performance()
+        self.cumulative_performance.calculate_performance()
+        self.todays_performance.calculate_performance()
 
     def get_portfolio(self, performance_needs_update):
         if performance_needs_update:
@@ -292,8 +287,8 @@ class PerformanceTracker(object):
         # updates last sale, and pays out a cash adjustment if applicable
         cash_adjustment = self.position_tracker.update_last_sale(event)
         if cash_adjustment != 0:
-            for perf_period in self.perf_periods:
-                perf_period.handle_cash_payment(cash_adjustment)
+            self.cumulative_performance.handle_cash_payment(cash_adjustment)
+            self.todays_performance.handle_cash_payment(cash_adjustment)
 
     def process_trade(self, event):
         self._handle_event_price(event)
@@ -302,8 +297,8 @@ class PerformanceTracker(object):
         self._handle_event_price(event)
         self.txn_count += 1
         self.position_tracker.execute_transaction(event)
-        for perf_period in self.perf_periods:
-            perf_period.handle_execution(event)
+        self.cumulative_performance.handle_execution(event)
+        self.todays_performance.handle_execution(event)
 
     def process_dividend(self, dividend):
 
@@ -312,18 +307,18 @@ class PerformanceTracker(object):
     def process_split(self, event):
         leftover_cash = self.position_tracker.handle_split(event)
         if leftover_cash > 0:
-            for perf_period in self.perf_periods:
-                perf_period.handle_cash_payment(leftover_cash)
+            self.cumulative_performance.handle_cash_payment(leftover_cash)
+            self.todays_performance.handle_cash_payment(leftover_cash)
 
     def process_order(self, event):
-        for perf_period in self.perf_periods:
-            perf_period.record_order(event)
+        self.cumulative_performance.record_order(event)
+        self.todays_performance.record_order(event)
 
     def process_commission(self, event):
 
         self.position_tracker.handle_commission(event)
-        for perf_period in self.perf_periods:
-            perf_period.handle_commission(event)
+        self.cumulative_performance.handle_commission(event)
+        self.todays_performance.handle_commission(event)
 
     def process_benchmark(self, event):
         if self.sim_params.data_frequency == 'minute' and \
@@ -394,9 +389,8 @@ class PerformanceTracker(object):
 
         net_cash_payment = position_tracker.pay_dividends(dividends_payable)
 
-        for period in self.perf_periods:
-            # notify periods to update their stats
-            period.handle_dividends_paid(net_cash_payment)
+        self.cumulative_performance.handle_dividends_paid(net_cash_payment)
+        self.todays_performance.handle_dividends_paid(net_cash_payment)
 
     def check_asset_auto_closes(self, next_trading_day):
         """
@@ -553,9 +547,6 @@ class PerformanceTracker(object):
 
         state_dict['_dividend_count'] = self._dividend_count
 
-        # we already store perf periods as attributes
-        del state_dict['perf_periods']
-
         STATE_VERSION = 4
         state_dict[VERSION_LABEL] = STATE_VERSION
 
@@ -575,12 +566,10 @@ class PerformanceTracker(object):
         self.dividend_frame = pickle.loads(state['dividend_frame'])
 
         # properly setup the perf periods
-        self.perf_periods = []
-        p_types = ['cumulative', 'todays', 'minute']
+        p_types = ['cumulative', 'todays']
         for p_type in p_types:
             name = p_type + '_performance'
             period = getattr(self, name, None)
             if period is None:
                 continue
             period._position_tracker = self.position_tracker
-            self.perf_periods.append(period)


### PR DESCRIPTION
Refer to cumulative and todays performance explicitly instead of always
looping through.

The third value (minute) for which this was useful, has been removed.

Also, there are some actions where only cumulative may need application,
e.g. application of dividends. (However, this patch does not remove
dividend processing from todays performance, but opens up later patches
to make that distinction.)

Other Notes:

For compatibility with developments on the Q2.0 branch, https://github.com/quantopian/zipline/pull/858/files

Originally done here, https://github.com/quantopian/zipline/commit/db425553f5f60ce6e5b9a07db2afab7d0e5929bd