### PR TITLE
MAINT: Pass leverage instead of account to risk.

### DIFF
--- a/tests/risk/test_risk_cumulative.py
+++ b/tests/risk/test_risk_cumulative.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Quantopian, Inc.
+# Copyright 2015 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ class TestRisk(unittest.TestCase):
             self.cumulative_metrics_06.update(dt,
                                               returns['Algorithm Returns'],
                                               returns['Benchmark Returns'],
-                                              {'leverage': 0.0})
+                                              0.0)
 
     def test_algorithm_volatility_06(self):
         algo_vol_answers = answer_key.RISK_CUMULATIVE.volatility

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -436,7 +436,7 @@ class PerformanceTracker(object):
         self.cumulative_risk_metrics.update(todays_date,
                                             self.todays_performance.returns,
                                             bench_since_open,
-                                            account)
+                                            account.leverage)
 
         minute_packet = self.to_dict(emission_type='minute')
 
@@ -461,7 +461,7 @@ class PerformanceTracker(object):
             completed_date,
             self.todays_performance.returns,
             self.all_benchmark_returns[completed_date],
-            account)
+            account.leverage)
 
         return self._handle_market_close(completed_date)
 

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -91,8 +91,7 @@ class RiskMetricsCumulative(object):
     )
 
     def __init__(self, sim_params, env,
-                 create_first_day_stats=False,
-                 account=None):
+                 create_first_day_stats=False):
         self.treasury_curves = env.treasury_curves
         self.start_date = sim_params.period_start.replace(
             hour=0, minute=0, second=0, microsecond=0
@@ -172,7 +171,7 @@ class RiskMetricsCumulative(object):
 
         self.num_trading_days = 0
 
-    def update(self, dt, algorithm_returns, benchmark_returns, account):
+    def update(self, dt, algorithm_returns, benchmark_returns, leverage):
         # Keep track of latest dt for use in to_dict and other methods
         # that report current state.
         self.latest_dt = dt
@@ -236,7 +235,7 @@ class RiskMetricsCumulative(object):
         self.annualized_mean_benchmark_returns = \
             self.annualized_mean_benchmark_returns_cont[:dt_loc + 1]
 
-        self.algorithm_cumulative_leverages_cont[dt_loc] = account['leverage']
+        self.algorithm_cumulative_leverages_cont[dt_loc] = leverage
         self.algorithm_cumulative_leverages = \
             self.algorithm_cumulative_leverages_cont[:dt_loc + 1]
 


### PR DESCRIPTION
The only value used in the account is leverage, so pass the leverage
value directly.

Also, remove account from risk init, since it is not used.