### PR TITLE
Make commission and split handling compatible with event removal

### DIFF
--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -198,9 +198,9 @@ class PerformancePeriod(object):
     def handle_cash_payment(self, payment_amount):
         self.adjust_cash(payment_amount)
 
-    def handle_commission(self, commission):
+    def handle_commission(self, cost):
         # Deduct from our total cash pool.
-        self.adjust_cash(-commission.cost)
+        self.adjust_cash(-cost)
 
     def adjust_cash(self, amount):
         self.period_cash_flow += amount

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -82,20 +82,18 @@ class Position(object):
         payment_owed = zp.dividend_payment(out)
         return payment_owed
 
-    def handle_split(self, split):
+    def handle_split(self, sid, ratio):
         """
         Update the position by the split ratio, and return the resulting
         fractional share that will be converted into cash.
 
         Returns the unused cash.
         """
-        if self.sid != split.sid:
+        if self.sid != sid:
             raise Exception("updating split with the wrong sid!")
 
-        ratio = split.ratio
-
-        log.info("handling split for sid = " + str(split.sid) +
-                 ", ratio = " + str(split.ratio))
+        log.info("handling split for sid = " + str(sid) +
+                 ", ratio = " + str(ratio))
         log.info("before split: " + str(self))
 
         # adjust the # of shares by the ratio

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -165,7 +165,7 @@ class Position(object):
 
         self.amount = total_shares
 
-    def adjust_commission_cost_basis(self, commission):
+    def adjust_commission_cost_basis(self, sid, cost):
         """
         A note about cost-basis in zipline: all positions are considered
         to share a cost basis, even if they were executed in different
@@ -176,9 +176,9 @@ class Position(object):
         all shares in a position.
         """
 
-        if commission.sid != self.sid:
+        if sid != self.sid:
             raise Exception('Updating a commission for a different sid?')
-        if commission.cost == 0.0:
+        if cost == 0.0:
             return
 
         # If we no longer hold this position, there is no cost basis to
@@ -187,7 +187,7 @@ class Position(object):
             return
 
         prev_cost = self.cost_basis * self.amount
-        new_cost = prev_cost + commission.cost
+        new_cost = prev_cost + cost
         self.cost_basis = new_cost / self.amount
 
     def __repr__(self):

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -327,7 +327,7 @@ class PositionTracker(object):
             # Make the position object handle the split. It returns the
             # leftover cash from a fractional share, if there is any.
             position = self.positions[split.sid]
-            leftover_cash = position.handle_split(split)
+            leftover_cash = position.handle_split(split.sid, split.ratio)
             self._update_asset(split.sid)
             return leftover_cash
 

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -317,11 +317,10 @@ class PositionTracker(object):
         position.update(txn)
         self._update_asset(sid)
 
-    def handle_commission(self, commission):
+    def handle_commission(self, sid, cost):
         # Adjust the cost basis of the stock if we own it
-        if commission.sid in self.positions:
-            self.positions[commission.sid].\
-                adjust_commission_cost_basis(commission)
+        if sid in self.positions:
+            self.positions[sid].adjust_commission_cost_basis(sid, cost)
 
     def handle_split(self, split):
         if split.sid in self.positions:

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -314,11 +314,13 @@ class PerformanceTracker(object):
         self.cumulative_performance.record_order(event)
         self.todays_performance.record_order(event)
 
-    def process_commission(self, event):
+    def process_commission(self, commission):
+        sid = commission.sid
+        cost = commission.cost
 
-        self.position_tracker.handle_commission(event)
-        self.cumulative_performance.handle_commission(event)
-        self.todays_performance.handle_commission(event)
+        self.position_tracker.handle_commission(sid, cost)
+        self.cumulative_performance.handle_commission(cost)
+        self.todays_performance.handle_commission(cost)
 
     def process_benchmark(self, event):
         if self.sim_params.data_frequency == 'minute' and \


### PR DESCRIPTION
Change the method signatures for split and commission handling so that the sid and corresponding values are accepted instead of an event from which those values are accessed.

In preparation of lazy-mainline branch which removes the event and passes the coarse values down.

Based on 2b02aab120acf6429dae419bc12620ad1923b9ec and fc60804ff15865c772461fc847182ef8d5b31d4c from lazy-mainline branch.