### PR TITLE
STY: Align all build_ext definitions the same way.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,14 +67,8 @@ ext_modules = LazyCythonizingList([
     ('zipline.lib._int64window', ['zipline/lib/_int64window.pyx']),
     ('zipline.lib._uint8window', ['zipline/lib/_uint8window.pyx']),
     ('zipline.lib.rank', ['zipline/lib/rank.pyx']),
-    (
-        'zipline.data._equities',
-        ['zipline/data/_equities.pyx'],
-    ),
-    (
-        'zipline.data._adjustments',
-        ['zipline/data/_adjustments.pyx'],
-    ),
+    ('zipline.data._equities', ['zipline/data/_equities.pyx']),
+    ('zipline.data._adjustments', ['zipline/data/_adjustments.pyx']),
 ])
 
 


### PR DESCRIPTION
No functional change.

Done to improve diff with Q2.0 which adds more modules, and re-aligned the two modules changed here.