### PR TITLE
MAINT: fix error messages for set_(commission|slippage)

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -39,11 +39,11 @@ from zipline.errors import (
     HistoryInInitialize,
     NoSuchPipeline,
     OrderDuringInitialize,
-    OverrideCommissionPostInit,
-    OverrideSlippagePostInit,
     PipelineOutputDuringInitialize,
     RegisterAccountControlPostInit,
     RegisterTradingControlPostInit,
+    SetCommissionPostInit,
+    SetSlippagePostInit,
     UnsupportedCommissionModel,
     UnsupportedDatetimeFormat,
     UnsupportedOrderParameters,
@@ -1072,7 +1072,7 @@ class TradingAlgorithm(object):
         if not isinstance(slippage, SlippageModel):
             raise UnsupportedSlippageModel()
         if self.initialized:
-            raise OverrideSlippagePostInit()
+            raise SetSlippagePostInit()
         self.slippage = slippage
 
     @api_method
@@ -1081,7 +1081,7 @@ class TradingAlgorithm(object):
             raise UnsupportedCommissionModel()
 
         if self.initialized:
-            raise OverrideCommissionPostInit()
+            raise SetCommissionPostInit()
         self.commission = commission
 
     @api_method

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -41,22 +41,22 @@ class WrongDataForTransform(ZiplineError):
 
 class UnsupportedSlippageModel(ZiplineError):
     """
-    Raised if a user script calls the override_slippage magic
+    Raised if a user script calls the set_slippage magic
     with a slipage object that isn't a VolumeShareSlippage or
     FixedSlipapge
     """
     msg = """
-You attempted to override slippage with an unsupported class. \
+You attempted to set slippage with an unsupported class. \
 Please use VolumeShareSlippage or FixedSlippage.
 """.strip()
 
 
-class OverrideSlippagePostInit(ZiplineError):
-    # Raised if a users script calls override_slippage magic
+class SetSlippagePostInit(ZiplineError):
+    # Raised if a users script calls set_slippage magic
     # after the initialize method has returned.
     msg = """
-You attempted to override slippage outside of `initialize`. \
-You may only call override_slippage in your initialize method.
+You attempted to set slippage outside of `initialize`. \
+You may only call 'set_slippage' in your initialize method.
 """.strip()
 
 
@@ -80,24 +80,24 @@ Account controls may only be set in your initialize method.
 
 class UnsupportedCommissionModel(ZiplineError):
     """
-    Raised if a user script calls the override_commission magic
+    Raised if a user script calls the set_commission magic
     with a commission object that isn't a PerShare, PerTrade or
     PerDollar commission
     """
     msg = """
-You attempted to override commission with an unsupported class. \
+You attempted to set commission with an unsupported class. \
 Please use PerShare or PerTrade.
 """.strip()
 
 
-class OverrideCommissionPostInit(ZiplineError):
+class SetCommissionPostInit(ZiplineError):
     """
-    Raised if a users script calls override_commission magic
+    Raised if a users script calls set_commission magic
     after the initialize method has returned.
     """
     msg = """
 You attempted to override commission outside of `initialize`. \
-You may only call override_commission in your initialize method.
+You may only call 'set_commission' in your initialize method.
 """.strip()
 
 


### PR DESCRIPTION
These called the functions 'update_(commission|slippage) leading to
confusing messages when you called them post init.