### PR TITLE
Lazy latest dt

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -405,10 +405,6 @@ class TradingAlgorithm(object):
                 env.trading_days,
                 minutely_emission
             )
-            self.data_portal.setup_offset_cache(
-                clock.minutes_by_day,
-                clock.minutes_to_day,
-                self.sim_params.trading_days)
             return clock
         else:
             return DailySimulationClock(self.sim_params.trading_days)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -56,15 +56,6 @@ class DataPortal(object):
                  adjustment_reader=None):
         self.env = env
 
-        # This is a bit ugly, but is here for performance reasons.  In minute
-        # simulations, we need to very quickly go from dt -> (# of minutes
-        # since Jan 1 2002 9:30 Eastern).
-        #
-        # The clock that heartbeats the simulation has all the necessary
-        # information to do this calculation very quickly.  This value is
-        # calculated there, and then set here
-        self.cur_data_offset = 0
-
         self.views = {}
 
         self._asset_finder = env.asset_finder

--- a/zipline/gens/sim_engine.pyx
+++ b/zipline/gens/sim_engine.pyx
@@ -46,7 +46,7 @@ cdef class MinuteSimulationClock:
         self.market_closes = market_closes
         self.trading_days = trading_days
         self.all_trading_days = all_trading_days
-        self.minutes_by_day, self.minutes_to_day = self.calc_minutes_by_day()
+        self.minutes_by_day = self.calc_minutes_by_day()
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -61,14 +61,11 @@ cdef class MinuteSimulationClock:
 
     cpdef calc_minutes_by_day(self):
         minutes_by_day = {}
-        minutes_to_day = {}
         for day_idx, day in enumerate(self.trading_days):
             minutes = pd.to_datetime(
                 self.market_minutes(day_idx), utc=True, box=True)
             minutes_by_day[day] = minutes
-            for minute in minutes:
-                minutes_to_day[minute] = day
-        return minutes_by_day, minutes_to_day
+        return minutes_by_day
 
     def __iter__(self):
 
@@ -86,7 +83,7 @@ cdef class MinuteSimulationClock:
                     yield minute, MINUTE_END
 
             if not minute_emission:
-                yield day, DAY_END
+                yield minutes[-1], DAY_END
 
 
 cdef class DailySimulationClock:

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -179,7 +179,7 @@ class AlgorithmSimulator(object):
                     once_a_day(dt)
                 elif action == DAY_END:
                     # End of the day.
-                    handle_benchmark(dt)
+                    handle_benchmark(normalize_date(dt))
                     yield self._get_daily_message(dt, algo, algo.perf_tracker)
                 elif action == MINUTE_END:
                     handle_benchmark(dt)


### PR DESCRIPTION
    ENH: Provide method for last trade dt.

    Add a data_portal method `get_last_traded_dt` which the dt passed to the
    method if there is a trade on that bar, or the previous dt with a trade
    if there is no trade on the current dt.

    This method will be used to proved a `.dt` lookup on SidView, but the
    connection to the SidView is not made with this patch.

    To implement the get_last_traded_dt a corresponding method
    was added to the minute bar reader, with a supporting DatetimeIndex
    which matches the data sets indices. Also, change
    `_find_position_of_minute` to use the index, since the lookup is faster
    than calculating a Timestamp and doing the offset calculation every
    time. (As seen by the improvement in the ffill tests in test_dataportal.)

    Also, change history tests to use a shared data_portal to avoid setup
    cost of repeatedly creating the lookup table in the reader.