### PR TITLE
Lazy wire up datetime

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -265,6 +265,24 @@ def handle_data(context, data):
 
         algo.run(self.data_portal)
 
+    def test_sid_datetime(self):
+        algo_text = """
+from zipline.api import sid, get_datetime
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    aapl = data[sid(1)]
+    assert aapl.datetime == get_datetime()
+"""
+
+        algo = TradingAlgorithm(script=algo_text,
+                                sim_params=self.sim_params,
+                                env=self.env)
+
+        algo.run(self.data_portal)
+
     def test_get_environment(self):
         expected_env = {
             'arena': 'backtest',

--- a/tests/test_dataportal.py
+++ b/tests/test_dataportal.py
@@ -384,6 +384,11 @@ class TestDataPortal(TestCase):
             last_traded = dp.get_last_traded_dt(asset, minute_without_trade,
                                                 'minute')
 
+            minute_without_trade = minutes[489]
+
+            last_traded = dp.get_last_traded_dt(asset, minute_without_trade,
+                                                'minute')
+
             self.assertEqual(last_traded, minute_with_trade)
         finally:
             tempdir.cleanup()

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -95,6 +95,10 @@ cdef class SidView:
         def __get__(self):
             return self.asset
 
+    property dt:
+        def __get__(self):
+            return self.datetime
+
     property datetime:
         def __get__(self):
             return self.data_portal.get_last_traded_dt(

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -95,3 +95,9 @@ cdef class SidView:
         def __get__(self):
             return self.asset
 
+    property datetime:
+        def __get__(self):
+            return self.data_portal.get_last_traded_dt(
+                self.asset,
+                self.simulator.simulation_dt,
+                self.data_frequency)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -221,6 +221,8 @@ class DataPortal(object):
         """
         if data_frequency == 'minute':
             return self._equity_minute_reader.get_last_traded_dt(asset, dt)
+        elif data_frequency == 'daily':
+            return self._equity_daily_reader.get_last_traded_dt(asset, dt)
 
     def get_previous_value(self, asset, field, dt, data_frequency):
         """

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -481,6 +481,13 @@ class BcolzDailyBarReader(object):
             col = self._spot_cols[colname] = self._table[colname]
         return col
 
+    def get_last_traded_dt(self, asset, day):
+        volumes = self._spot_col('volume')
+        ix = self.sid_day_index(asset, day)
+        while True:
+            if volumes[ix] != 0:
+                return day
+
     def sid_day_index(self, sid, day):
         """
         Parameters

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -483,10 +483,19 @@ class BcolzDailyBarReader(object):
 
     def get_last_traded_dt(self, asset, day):
         volumes = self._spot_col('volume')
-        ix = self.sid_day_index(asset, day)
+        search_day = day
         while True:
+            try:
+                ix = self.sid_day_index(asset, search_day)
+            except NoDataOnDate:
+                return None
             if volumes[ix] != 0:
-                return day
+                return search_day
+            prev_day_ix = self._calendar.get_loc(search_day) - 1
+            if prev_day_ix > -1:
+                search_day = self._calendar[prev_day_ix]
+            else:
+                return None
 
     def sid_day_index(self, sid, day):
         """


### PR DESCRIPTION
Build upon recently added `get_last_traded_dt` so that following algocode works again.

```
def handle_data(context, data):
    data[sid(24)].dt
    data[sid(24)].datetime
```