### PR TITLE
Use master-alike create_transaction interface.

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -41,6 +41,7 @@ import zipline.utils.math_utils as zp_math
 
 from zipline.finance.blotter import Order
 from zipline.finance.commission import PerShare, PerTrade, PerDollar
+from zipline.finance.slippage import TradeBar
 from zipline.finance.trading import TradingEnvironment
 from zipline.pipeline.loaders.synthetic import NullAdjustmentReader
 from zipline.utils.factory import create_simulation_parameters
@@ -126,7 +127,8 @@ def create_txn(sid, dt, price, amount):
     of a given trade event.
     """
     mock_order = Order(dt, sid, amount, id=None)
-    return create_transaction(sid, dt, mock_order, price, amount)
+    trade_bar = TradeBar(sid, dt, price, None)
+    return create_transaction(trade_bar, mock_order, price, amount)
 
 
 def benchmark_events_in_range(sim_params, env):

--- a/zipline/finance/transaction.py
+++ b/zipline/finance/transaction.py
@@ -78,7 +78,7 @@ class Transaction(object):
         self.__dict__.update(state)
 
 
-def create_transaction(sid, dt, order, price, amount):
+def create_transaction(trade_bar, order, price, amount):
 
     # floor the amount to protect against non-whole number orders
     # TODO: Investigate whether we can add a robust check in blotter
@@ -89,9 +89,9 @@ def create_transaction(sid, dt, order, price, amount):
         raise Exception("Transaction magnitude must be at least 1.")
 
     transaction = Transaction(
-        sid=sid,
+        sid=trade_bar.sid,
         amount=int(amount),
-        dt=dt,
+        dt=trade_bar.dt,
         price=price,
         order_id=order.id
     )


### PR DESCRIPTION
Make the interface to the slippage `create_transaction` and
`process_order` as it is on master, so that there is less of a chance
for breaking existing algorithms that override slippage.

Create a TradeBar instance in slippage simulate, which holds the `price`
and `volume` for use by both process_order and create_transaction.

Other notes:

- This patch is in service of reducing the edit distance between master and lazy-mainline both in code and functionality.
- `trade_bar` is used in place of where `event` is on master. This aligns with the documentation of the function on https://www.quantopian.com/help.
- We may need to make TradeBar a dynamic object which can also access `open` and `close`, to support different models implemented by `process_order`. But that may not be in scope, since `price` and `volume` were sufficient for existing coverage.