### PR TITLE
BUG: Handle no previous values when ffilling.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -504,6 +504,25 @@ class HistoryTestCase(TestCase):
 
         np.testing.assert_allclose(window.loc[:, self.FOO], expected)
 
+    def test_ffill_minute_equity_window_no_previous(self):
+        """
+        Test that forward filling handles the case where the window starts
+        with a nan, and there are no previous values.
+        """
+
+        window = self.data_portal.get_history_window(
+            [self.FOO],
+            pd.Timestamp("2014-03-19 13:41:00+00:00", tz='UTC'),
+            20,
+            "1m",
+            "price"
+        )
+
+        # There should be no values, since there is no data before 2014-03-20
+        expected = np.full(20, np.nan)
+
+        np.testing.assert_allclose(window.loc[:, self.FOO], expected)
+
     def test_ffill_minute_future_window_starts_with_nan(self):
         """
         Test that forward filling does not leave leading nan if there is data

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -792,6 +792,8 @@ class DataPortal(object):
                 asset = assets[missing_loc]
                 previous_dt = self.get_last_traded_dt(
                     asset, dt_to_fill, data_frequency)
+                if pd.isnull(previous_dt):
+                    continue
                 previous_value = self._get_adjusted_value(
                     asset,
                     field,

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -297,13 +297,22 @@ class BcolzMinuteBarReader(object):
         return bcolz.open(path, mode='r')
 
     def get_last_traded_dt(self, asset, dt):
-        return self._minute_index[
-            self._find_last_traded_position(asset, dt)]
+        minute_pos = self._find_last_traded_position(asset, dt)
+        if minute_pos == -1:
+            return pd.NaT
+        return self._minute_index[minute_pos]
 
     def _find_last_traded_position(self, asset, dt):
         volumes = self._open_minute_file('volume', asset)
+        start_date = asset.start_date
+        _minute_index = self._minute_index
+
         minute_pos = self._find_position_of_minute(dt)
+
         while True:
+            dt = _minute_index[minute_pos]
+            if dt < start_date:
+                return -1
             if minute_pos == 0 or volumes[minute_pos] != 0:
                 return minute_pos
             minute_pos -= 1


### PR DESCRIPTION
The value for latest_dt would search back until getting an index error
when there were no previous values.

Add test case in history with no previous values, and prevent forward
filling when the answer to latest dt is 'NaT'.