### PR TITLE
Conda source build

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -12,6 +12,7 @@ conda-build you should be able to:
 ```
 conda build ta-lib
 conda build logbook
+conda build cyordereddict
 conda build zipline
 ```
 

--- a/conda/cyordereddict/bld.bat
+++ b/conda/cyordereddict/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda/cyordereddict/build.sh
+++ b/conda/cyordereddict/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda/cyordereddict/meta.yaml
+++ b/conda/cyordereddict/meta.yaml
@@ -1,11 +1,11 @@
 package:
-  name: logbook
-  version: "0.10.0"
+  name: cyordereddict
+  version: "0.2.2"
 
 source:
-  fn: Logbook-0.10.0.tar.gz
-  url: https://pypi.python.org/packages/source/L/Logbook/Logbook-0.10.0.tar.gz
-  md5: 92439ce6f71f3120d65d84c2a3ab5047
+  fn: cyordereddict-0.2.2.tar.gz
+  url: https://pypi.python.org/packages/source/c/cyordereddict/cyordereddict-0.2.2.tar.gz
+  md5: 6279eb0bf9819f0293ad5315b2d484d0
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -17,9 +17,9 @@ source:
     # Put any entry points (scripts to be generated automatically) here. The
     # syntax is module:function.  For example
     #
-    # - logbook = logbook:main
+    # - cyordereddict = cyordereddict:main
     #
-    # Would create an entry point called logbook that calls logbook.main()
+    # Would create an entry point called cyordereddict that calls cyordereddict.main()
 
 
   # If this is a new build for the same version, increment the build
@@ -29,17 +29,15 @@ source:
 requirements:
   build:
     - python
-    - setuptools
-    - six >=1.4.0
 
   run:
     - python
-    - six >=1.4.0
 
 test:
   # Python imports
   imports:
-    - logbook
+    - cyordereddict
+    - cyordereddict.benchmark
 
   # commands:
     # You can put test commands to be run here.  Use this to test that the
@@ -54,9 +52,9 @@ test:
     # - nose
 
 about:
-  home: http://logbook.pocoo.org/
-  license: BSD
-  summary: 'A logging replacement for Python'
+  home: https://github.com/shoyer/cyordereddict
+  license: BSD License
+  summary: "Cython implementation of Python's collections.OrderedDict"
 
 # See
 # http://docs.continuum.io/conda/build.html for

--- a/conda/zipline/meta.yaml
+++ b/conda/zipline/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   build:
     - python
     - setuptools
-    - cython ==0.22.1
+    - cython
     - numpy
   run:
     - python

--- a/conda/zipline/meta.yaml
+++ b/conda/zipline/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python
     - setuptools
     - cython ==0.22.1
-    - numpy ==1.9.2
+    - numpy
   run:
     - python
     {% for req in data.get('install_requires', []) -%}

--- a/conda/zipline/meta.yaml
+++ b/conda/zipline/meta.yaml
@@ -1,28 +1,37 @@
+{% set data = load_setuptools() %}
+
 package:
   name: zipline
-  version: 0.8.3
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '')}}
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
+  {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
+
 
 source:
-  fn: zipline-0.8.3.tar.gz
-  url: https://pypi.python.org/packages/source/z/zipline/zipline-0.8.3.tar.gz
-  md5: 042ffcee614d2279add9a1bfd27a33cf
+  git_url: ../../
 
 requirements:
   build:
     - python
     - setuptools
-    - cython
+    - cython ==0.22.1
+    - numpy ==1.9.2
   run:
     - python
-    - pytz
-    - requests
-    - numpy
-    - pandas
-    - scipy
-    - matplotlib
-    - logbook
+    {% for req in data.get('install_requires', []) -%}
+    - {{req}}
+    {% endfor %}
 
 test:
+  {#  When we include the tests module in the zipline package, we can use this:
+  requires:
+    {% for req in data.get('extras_require', {}).get('dev', []) -%}
+    - {{req}}
+    {% endfor %}
+  #}
   # Python imports
   imports:
     - zipline

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -126,6 +126,9 @@ Build
 * Use ``versioneer`` to manage the project ``__version__`` and setup.py version
   (:issue:`829`).
 * Fixed coveralls integration on travis build (:issue:`840`).
+* Fixed conda build, which now uses git source as its source and reads
+  requirements using setup.py, instead of copying them and letting them get out
+  of sync (:issue:`937`).
 
 Documentation
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -133,12 +133,14 @@ def _with_bounds(req):
         return ''.join(with_bounds)
 
 
+REQ_PATTERN = re.compile("([^=<>]+)([<=>]{1,2})(.*)")
+
+
 def _conda_format(req):
-    return re.sub(
-            '([^=<>]+)([=<>]{1,2})',
-            lambda m: '%s %s' % (m.group(1).lower(), m.group(2)),
-            req,
-            1,
+    return REQ_PATTERN.sub(
+        lambda m: '%s %s%s' % (m.group(1).lower(), m.group(2), m.group(3)),
+        req,
+        1,
     )
 
 
@@ -184,14 +186,12 @@ def module_requirements(requirements_path, module_names):
     module_names = set(module_names)
     found = set()
     module_lines = []
-    parser = re.compile("([^=<>]+)([<=>]{1,2})(.*)")
     for line in read_requirements(requirements_path, strict_bounds=True):
-        match = parser.match(line)
+        match = REQ_PATTERN.match(line)
         if match is None:
             raise AssertionError("Could not parse requirement: '%s'" % line)
 
-        groups = match.groups()
-        name = groups[0]
+        name = match.group(1)
         if name in module_names:
             found.add(name)
             module_lines.append(line)

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ def _filter_requirements(lines_iter):
 
 
 REQ_UPPER_BOUNDS = {
+    'numpy': '<1.10',
 }
 
 
@@ -256,8 +257,7 @@ setup(
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: System :: Distributed Computing',
     ],
-    install_requires=install_requires(strict_bounds=conda_build,
-                                      conda_format=conda_build),
+    install_requires=install_requires(conda_format=conda_build),
     extras_require=extras_requires(conda_format=conda_build),
     url="http://zipline.io",
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import print_function
-
+import os
 import re
 import sys
 from operator import lt, gt, eq, le, ge
@@ -133,7 +133,16 @@ def _with_bounds(req):
         return ''.join(with_bounds)
 
 
-def read_requirements(path, strict_bounds):
+def _conda_format(req):
+    return re.sub(
+            '([^=<>]+)([=<>]{1,2})',
+            lambda m: '%s %s' % (m.group(1).lower(), m.group(2)),
+            req,
+            1,
+    )
+
+
+def read_requirements(path, strict_bounds, conda_format=False):
     """
     Read a requirements.txt file, expressed as a path relative to Zipline root.
 
@@ -144,20 +153,25 @@ def read_requirements(path, strict_bounds):
     with open(real_path) as f:
         reqs = _filter_requirements(f.readlines())
 
-        if strict_bounds:
-            return list(reqs)
-        else:
-            return list(map(_with_bounds, reqs))
+        if not strict_bounds:
+            reqs = map(_with_bounds, reqs)
+
+        if conda_format:
+            reqs = map(_conda_format, reqs)
+
+        return list(reqs)
 
 
-def install_requires(strict_bounds=False):
+def install_requires(strict_bounds=False, conda_format=False):
     return read_requirements('etc/requirements.txt',
-                             strict_bounds=strict_bounds)
+                             strict_bounds=strict_bounds,
+                             conda_format=conda_format)
 
 
-def extras_requires():
+def extras_requires(conda_format=False):
     dev_reqs = read_requirements('etc/requirements_dev.txt',
-                                 strict_bounds=True)
+                                 strict_bounds=True,
+                                 conda_format=conda_format)
     talib_reqs = ['TA-Lib==0.4.9']
     return {
         'dev': dev_reqs,
@@ -171,7 +185,7 @@ def module_requirements(requirements_path, module_names):
     found = set()
     module_lines = []
     parser = re.compile("([^=<>]+)([<=>]{1,2})(.*)")
-    for line in read_requirements(requirements_path, strict_bounds=False):
+    for line in read_requirements(requirements_path, strict_bounds=True):
         match = parser.match(line)
         if match is None:
             raise AssertionError("Could not parse requirement: '%s'" % line)
@@ -214,6 +228,7 @@ def pre_setup():
 
 pre_setup()
 
+conda_build = os.path.basename(sys.argv[0]) == 'conda-build'
 
 setup(
     name='zipline',
@@ -241,7 +256,8 @@ setup(
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: System :: Distributed Computing',
     ],
-    install_requires=install_requires(),
-    extras_require=extras_requires(),
+    install_requires=install_requires(strict_bounds=conda_build,
+                                      conda_format=conda_build),
+    extras_require=extras_requires(conda_format=conda_build),
     url="http://zipline.io",
 )


### PR DESCRIPTION
Allows us to build conda packages for the latest zipline and its dependencies.  Builds from local source instead of pypi, pulling in requirements from our requirements.txt.

Requires this change to conda-build: https://github.com/conda/conda-build/pull/717