### PR TITLE
BUG: fix bug that caused symbols to be added to the asset finder twice

### DIFF
--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -99,6 +99,9 @@ Bug Fixes
   :class:`~zipline.errors.SetSlippagePostInit` and
   :class:`~zipline.errors.SetCommissionPostInit` (:issue:`923`).
 
+* Fixed an issue in the CLI that would cause assets to be added twice.
+  This would map the same symbol to two different sids (:issue:`942`).
+
 
 Performance
 ~~~~~~~~~~~

--- a/zipline/utils/cli.py
+++ b/zipline/utils/cli.py
@@ -241,7 +241,6 @@ def run_pipeline(print_algo=True, **kwargs):
                                     capital_base=float(kwargs['capital_base']),
                                     algo_filename=kwargs.get('algofile'),
                                     equities_metadata=asset_metadata,
-                                    identifiers=symbols,
                                     start=start,
                                     end=end)
 


### PR DESCRIPTION
When using the cli, assets would be added twice from yahoo because the items of the data panel are strings. By not passing them in the constructor, the run will put them into the asset finder.