### PR TITLE
Allow OHLCV in slippage models.

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -37,6 +37,7 @@ from zipline.finance.blotter import Order
 from zipline.data.us_equity_minutes import MinuteBarWriterFromDataFrames
 from zipline.data.us_equity_minutes import BcolzMinuteBarReader
 from zipline.data.data_portal import DataPortal
+from zipline.protocol import BarData
 
 
 class SlippageTestCase(TestCase):
@@ -132,15 +133,13 @@ class SlippageTestCase(TestCase):
                 )
             ]
 
+            bar_data = BarData(data_portal,
+                               lambda: self.minutes[0],
+                               'minute')
+
             orders_txns = list(slippage_model.simulate(
+                bar_data[133],
                 open_orders,
-                self.minutes[0],
-                data_portal.get_spot_value(
-                    133, 'close', self.minutes[0],
-                    self.sim_params.data_frequency),
-                data_portal.get_spot_value(
-                    133, 'volume', self.minutes[0],
-                    self.sim_params.data_frequency)
             ))
 
             self.assertEquals(len(orders_txns), 1)
@@ -179,16 +178,15 @@ class SlippageTestCase(TestCase):
                 'limit': 3.5})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[3],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[3],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[3],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[3],
-                self.sim_params.data_frequency)
         ))
+
         self.assertEquals(len(orders_txns), 0)
 
         # long, does not trade - impacted price worse than limit price
@@ -201,15 +199,13 @@ class SlippageTestCase(TestCase):
                 'limit': 3.5})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[3],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[3],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[3],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[3],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -224,15 +220,13 @@ class SlippageTestCase(TestCase):
                 'limit': 3.6})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[3],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[3],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[3],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[3],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 1)
@@ -264,15 +258,13 @@ class SlippageTestCase(TestCase):
                 'limit': 3.5})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[0],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[0],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[0],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[0],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -287,15 +279,13 @@ class SlippageTestCase(TestCase):
                 'limit': 3.5})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[0],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[0],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[0],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[0],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -310,15 +300,13 @@ class SlippageTestCase(TestCase):
                 'limit': 3.4})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[1],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[1],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[1],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[1],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 1)
@@ -498,15 +486,12 @@ class SlippageTestCase(TestCase):
 
             try:
                 dt = pd.Timestamp('2006-01-05 14:31', tz='UTC')
+                bar_data = BarData(data_portal,
+                                   lambda: dt,
+                                   'minute')
                 _, txn = next(slippage_model.simulate(
+                    bar_data[133],
                     [order],
-                    dt,
-                    data_portal.get_spot_value(
-                        133, "close", dt,
-                        self.sim_params.data_frequency),
-                    data_portal.get_spot_value(
-                        133, "volume", dt,
-                        self.sim_params.data_frequency)
                 ))
             except StopIteration:
                 txn = None
@@ -536,28 +521,24 @@ class SlippageTestCase(TestCase):
                 'limit': 3.0})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[2],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[2],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[2],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[2],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[3],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[3],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[3],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[3],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -573,28 +554,24 @@ class SlippageTestCase(TestCase):
                 'limit': 3.5})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[2],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[2],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[2],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[2],
-                self.sim_params.data_frequency),
         ))
 
         self.assertEquals(len(orders_txns), 0)
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[3],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[3],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[3],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[3],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -610,28 +587,24 @@ class SlippageTestCase(TestCase):
                 'limit': 3.6})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[2],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[2],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[2],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[2],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[3],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[3],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[3],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[3],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 1)
@@ -660,28 +633,24 @@ class SlippageTestCase(TestCase):
                 'limit': 4.0})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[0],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[0],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[0],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[0],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[1],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[1],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[1],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[1],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -697,28 +666,24 @@ class SlippageTestCase(TestCase):
                 'limit': 3.5})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[0],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[0],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[0],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[0],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[1],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[1],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[1],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[1],
-                self.sim_params.data_frequency)
         ))
 
         self.assertEquals(len(orders_txns), 0)
@@ -734,28 +699,24 @@ class SlippageTestCase(TestCase):
                 'limit': 3.4})
         ]
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[0],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[0],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[0],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[0],
-                self.sim_params.data_frequency),
         ))
 
         self.assertEquals(len(orders_txns), 0)
 
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[1],
+                           self.sim_params.data_frequency)
+
         orders_txns = list(slippage_model.simulate(
+            bar_data[133],
             open_orders,
-            self.minutes[1],
-            self.data_portal.get_spot_value(
-                133, 'close', self.minutes[1],
-                self.sim_params.data_frequency),
-            self.data_portal.get_spot_value(
-                133, 'volume', self.minutes[1],
-                self.sim_params.data_frequency),
         ))
 
         self.assertEquals(len(orders_txns), 1)

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -40,6 +40,7 @@ from zipline.finance.slippage import DEFAULT_VOLUME_SLIPPAGE_BAR_LIMIT, \
 from .utils.daily_bar_writer import DailyBarWriterFromDataFrames
 from zipline.data.us_equity_pricing import BcolzDailyBarReader
 from zipline.data.data_portal import DataPortal
+from zipline.protocol import BarData
 
 
 class BlotterTestCase(TestCase):
@@ -161,7 +162,12 @@ class BlotterTestCase(TestCase):
         filled_id = blotter.order(24, 100, MarketOrder())
         filled_order = None
         blotter.current_dt = self.sim_params.trading_days[-1]
-        txns, _ = blotter.get_transactions(self.data_portal)
+        bar_data = BarData(
+            self.data_portal,
+            lambda: self.sim_params.trading_days[-1],
+            self.sim_params.data_frequency,
+        )
+        txns, _ = blotter.get_transactions(bar_data)
         for txn in txns:
             filled_order = blotter.orders[txn.order_id]
 
@@ -225,7 +231,12 @@ class BlotterTestCase(TestCase):
 
             filled_order = None
             blotter.current_dt = dt
-            txns, _ = blotter.get_transactions(self.data_portal)
+            bar_data = BarData(
+                self.data_portal,
+                lambda: dt,
+                self.sim_params.data_frequency,
+            )
+            txns, _ = blotter.get_transactions(bar_data)
             for txn in txns:
                 filled_order = blotter.orders[txn.order_id]
 

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -49,6 +49,7 @@ from zipline.data.us_equity_minutes import (
 )
 from zipline.data.data_portal import DataPortal
 from zipline.finance.slippage import FixedSlippage
+from zipline.protocol import BarData
 
 from .utils.daily_bar_writer import DailyBarWriterFromDataFrames
 
@@ -317,7 +318,12 @@ class FinanceTestCase(TestCase):
                             order_date = order_date + timedelta(days=1)
                             order_date = order_date.replace(hour=14, minute=30)
                 else:
-                    txns, _ = blotter.get_transactions(data_portal)
+                    bar_data = BarData(
+                        data_portal,
+                        lambda: tick,
+                        sim_params.data_frequency
+                    )
+                    txns, _ = blotter.get_transactions(bar_data)
                     for txn in txns:
                         tracker.process_transaction(txn)
                         transactions.append(txn)

--- a/zipline/_protocol.pxd
+++ b/zipline/_protocol.pxd
@@ -15,12 +15,12 @@
 
 cdef class BarData:
     cdef object data_portal
-    cdef object simulator
+    cdef object simulation_dt_func
     cdef object data_frequency
     cdef dict _views
 
 cdef class SidView:
     cdef object asset
     cdef object data_portal
-    cdef object simulator
+    cdef object simulation_dt_func
     cdef object data_frequency

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -23,6 +23,20 @@ cdef class BarData:
     This is what is passed as `data` to the `handle_data` function.
     """
     def __init__(self, data_portal, simulation_dt_func, data_frequency):
+        """
+        Parameters
+        ---------
+        data_portal : DataPortal
+            Provider for bar pricing data.
+
+        simulation_dt_func: function
+            Function which returns the current simulation time.
+            This is usually bound to a method of TradingSimulation.
+
+        data_frequency: string
+            The frequency of the bar data; i.e. whether the data is
+            'daily' or 'minute' bars
+        """
         self.data_portal = data_portal
         self.simulation_dt_func = simulation_dt_func
         self.data_frequency = data_frequency
@@ -79,6 +93,23 @@ cdef class BarData:
 
 cdef class SidView:
     def __init__(self, asset, data_portal, simulation_dt_func, data_frequency):
+        """
+        Parameters
+        ---------
+        asset : Asset
+            The asset for which the instance retrieves data.
+
+        data_portal : DataPortal
+            Provider for bar pricing data.
+
+        simulation_dt_func: function
+            Function which returns the current simulation time.
+            This is usually bound to a method of TradingSimulation.
+
+        data_frequency: string
+            The frequency of the bar data; i.e. whether the data is
+            'daily' or 'minute' bars
+        """
         self.asset = asset
         self.data_portal = data_portal
         self.simulation_dt_func = simulation_dt_func

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -22,10 +22,10 @@ cdef class BarData:
 
     This is what is passed as `data` to the `handle_data` function.
     """
-    def __init__(self, data_portal, simulator):
+    def __init__(self, data_portal, simulation_dt_func, data_frequency):
         self.data_portal = data_portal
-        self.simulator = simulator
-        self.data_frequency = simulator.sim_params.data_frequency
+        self.simulation_dt_func = simulation_dt_func
+        self.data_frequency = data_frequency
         self._views = {}
 
     def _get_equity_price_view(self, asset):
@@ -45,6 +45,11 @@ cdef class BarData:
         try:
             view = self._views[asset]
         except KeyError:
+            try:
+                asset = self.data_portal.env.asset_finder.retrieve_asset(asset)
+            except ValueError:
+                # assume fetcher
+                pass
             view = self._views[asset] = self._create_sid_view(asset)
 
         return view
@@ -53,7 +58,7 @@ cdef class BarData:
         return SidView(
             asset,
             self.data_portal,
-            self.simulator,
+            self.simulation_dt_func,
             self.data_frequency
         )
 
@@ -69,20 +74,21 @@ cdef class BarData:
     @property
     def fetcher_assets(self):
         return self.data_portal.get_fetcher_assets(
-            normalize_date(self.simulator.simulation_dt)
+            normalize_date(self.simulation_dt_func())
         )
 
 cdef class SidView:
-    def __init__(self, asset, data_portal, simulator, data_frequency):
+    def __init__(self, asset, data_portal, simulation_dt_func, data_frequency):
         self.asset = asset
         self.data_portal = data_portal
-        self.simulator = simulator
+        self.simulation_dt_func = simulation_dt_func
         self.data_frequency = data_frequency
 
     def __getattr__(self, column):
         return self.data_portal.get_spot_value(
-            self.asset, column,
-            self.simulator.simulation_dt,
+            self.asset,
+            column,
+            self.simulation_dt_func(),
             self.data_frequency)
 
     def __contains__(self, column):
@@ -103,5 +109,5 @@ cdef class SidView:
         def __get__(self):
             return self.data_portal.get_last_traded_dt(
                 self.asset,
-                self.simulator.simulation_dt,
+                self.simulation_dt_func(),
                 self.data_frequency)

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -196,7 +196,7 @@ class Blotter(object):
             for order in orders_to_modify:
                 order.handle_split(split[1])
 
-    def get_transactions(self, data_portal):
+    def get_transactions(self, bar_data):
         """
         Creates a list of transactions based on the current open orders,
         slippage model, and commission model.
@@ -230,14 +230,9 @@ class Blotter(object):
         transactions = []
 
         for asset, asset_orders in iteritems(self.open_orders):
-            price = data_portal.get_spot_value(
-                asset, 'close', self.current_dt, self.data_frequency)
+            trade_bar = bar_data[asset]
 
-            volume = data_portal.get_spot_value(
-                asset, 'volume', self.current_dt, self.data_frequency)
-
-            for order, txn in self.slippage_func(asset_orders, self.current_dt,
-                                                 price, volume):
+            for order, txn in self.slippage_func(trade_bar, asset_orders):
                 direction = math.copysign(1, txn.amount)
                 per_share, total_commission = self.commission.calculate(txn)
                 txn.price += per_share * direction

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -78,10 +78,14 @@ class AlgorithmSimulator(object):
                 record.extra['algo_dt'] = self.simulation_dt
         self.processor = Processor(inject_algo_dt)
 
+    def get_simulation_dt(self):
+        return self.simulation_dt
+
     def _create_bar_data(self):
         return BarData(
             data_portal=self.data_portal,
-            simulator=self
+            simulation_dt_func=self.get_simulation_dt,
+            data_frequency=self.sim_params.data_frequency,
         )
 
     def transform(self):
@@ -114,7 +118,7 @@ class AlgorithmSimulator(object):
             # handle any transactions and commissions coming out new orders
             # placed in the last bar
             new_transactions, new_commissions = \
-                blotter.get_transactions(data_portal)
+                blotter.get_transactions(current_data)
 
             for transaction in new_transactions:
                 perf_tracker.process_transaction(transaction)


### PR DESCRIPTION
Fix bug where the SidView's asset was an integer.

Change BarData to take a simulation dt func instead of simulation
instance, since testing with new interface required creating a BarData
object to pass to slippage. (And it is easier to create a lambda that
provides a dt instead of instantiating or mocking out the
TradeSimulation object.)