### PR TITLE
Use earliest trading day from bcolz readers to calculate valid history windows

### DIFF
--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -137,7 +137,7 @@ class FetcherTestCase(TestCase):
         )
 
         results = test_algo.run(
-            data_portal=FetcherDataPortal(self.env, self.sim_params)
+            data_portal=FetcherDataPortal(self.env)
         )
 
         return results
@@ -164,7 +164,7 @@ def handle_data(context, data):
         # manually setting data portal and getting generator because we need
         # the minutely emission packets here.  TradingAlgorithm.run() only
         # returns daily packets.
-        test_algo.data_portal = FetcherDataPortal(self.env, sim_params)
+        test_algo.data_portal = FetcherDataPortal(self.env)
         gen = test_algo.get_generator()
         perf_packets = list(gen)
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1093,12 +1093,14 @@ class TradingAlgorithm(object):
 
     @api_method
     @require_initialized(HistoryInInitialize())
-    def history(self, sids, bar_count, frequency, field, ffill=True):
-        if self.data_portal is None:
-            raise Exception("no data portal!")
+    def history(self, assets, bar_count, frequency, field, ffill=True):
+        try:
+            assets = list(assets)
+        except TypeError:
+            assets = [assets]
 
         return self.data_portal.get_history_window(
-            sids,
+            assets,
             self.datetime,
             bar_count,
             frequency,

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -759,11 +759,8 @@ class FetcherDataPortal(DataPortal):
     Mock dataportal that returns fake data for history and non-fetcher
     spot value.
     """
-    def __init__(self, env, sim_params):
-        super(FetcherDataPortal, self).__init__(
-            env,
-            sim_params
-        )
+    def __init__(self, env):
+        super(FetcherDataPortal, self).__init__(env)
 
     def get_spot_value(self, asset, field, dt, data_frequency):
         # if this is a fetcher field, exercise the regular code path


### PR DESCRIPTION
When getting a daily history window, we were using the asset's start date to figure out the first valid day for the history window. The problem is that the asset's start date can be before the first day in the daily bcolz file.

This PR makes it so that we use the max(asset start date, first trading day in bcolz file) to size history windows.  It also adds the property to the daily bcolz writer and reader.