### PR TITLE
BUG: Account object's total_position_value is incorrect

### DIFF
--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -122,6 +122,11 @@ Bug Fixes
 * Fixed an issue in the CLI that would cause assets to be added twice.
   This would map the same symbol to two different sids (:issue:`942`).
 
+* Fixed an issue where the
+  :class:"`~zipline.finance.performance.period.PerformancePeriod` incorrectly
+  reported the total_positions_value when creating a
+  :class:`~zipline.protocol.Account` (:issue:`950`).
+
 
 Performance
 ~~~~~~~~~~~

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -457,7 +457,7 @@ class PerformancePeriod(object):
                     self.ending_cash + self.ending_value)
         account.total_positions_value = \
             getattr(self, 'total_positions_value', self.ending_value)
-        account.total_positions_value = \
+        account.total_positions_exposure = \
             getattr(self, 'total_positions_exposure', self.ending_exposure)
         account.regt_equity = \
             getattr(self, 'regt_equity', self.ending_cash)


### PR DESCRIPTION
Mea culpa. There was a typo that incorrectly assigned the 'total_positions_exposure' value to the 'total_positions_value' field.

This PR fixes that bug and adds tests to prevent a regression.