### PR TITLE
Asset KeyError

### DIFF
--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -127,6 +127,9 @@ Bug Fixes
   reported the total_positions_value when creating a
   :class:`~zipline.protocol.Account` (:issue:`950`).
 
+* Fixed issues around KeyErrors coming from history and BarData on 32-bit
+  python, where Assets did not compare properly with int64s (:issue:`959`).
+
 
 Performance
 ~~~~~~~~~~~

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -29,7 +29,7 @@ from pandas.tseries.tools import normalize_date
 from pandas.util.testing import assert_frame_equal
 
 from nose_parameterized import parameterized
-from numpy import full
+from numpy import full, int32, int64
 import sqlalchemy as sa
 
 from zipline.assets import (
@@ -39,7 +39,7 @@ from zipline.assets import (
     AssetFinder,
     AssetFinderCachedEquities,
 )
-from six import itervalues
+from six import itervalues, integer_types
 from toolz import valmap
 
 from zipline.assets.futures import (
@@ -212,6 +212,14 @@ class AssetTestCase(TestCase):
         self.assertEqual(s_23, s_23)
         self.assertEqual(s_23, 23)
         self.assertEqual(23, s_23)
+        self.assertEqual(int32(23), s_23)
+        self.assertEqual(int64(23), s_23)
+        self.assertEqual(s_23, int32(23))
+        self.assertEqual(s_23, int64(23))
+        # Check all int types (includes long on py2):
+        for int_type in integer_types:
+            self.assertEqual(int_type(23), s_23)
+            self.assertEqual(s_23, int_type(23))
 
         self.assertNotEqual(s_23, s_24)
         self.assertNotEqual(s_23, 24)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -559,15 +559,11 @@ class TradingAlgorithm(object):
 
         # The sids field of the source is the reference for the universe at
         # the start of the run
-        self._current_universe = set()
-        for source in self.sources:
-            for sid in source.sids:
-                self._current_universe.add(sid)
+        sids = {sid for source in self.sources for sid in source.sids}
         # Check that all sids from the source are accounted for in
         # the AssetFinder. This retrieve call will raise an exception if the
         # sid is not found.
-        for sid in self._current_universe:
-            self.asset_finder.retrieve_asset(sid)
+        self._current_universe = set(self.asset_finder.retrieve_all(sids))
 
         # force a reset of the performance tracker, in case
         # this is a repeat run of the algorithm.

--- a/zipline/assets/_assets.pyx
+++ b/zipline/assets/_assets.pyx
@@ -19,6 +19,8 @@ Cythonized Asset object.
 """
 cimport cython
 
+from numbers import Integral
+
 import numpy as np
 import warnings
 cimport numpy as np
@@ -86,14 +88,20 @@ cdef class Asset:
         if isinstance(x, Asset):
             x_as_int = x.sid
         elif isinstance(x, int):
+            # ints are Integral, but much faster to special case
             x_as_int = x
+        elif isinstance(x, (long, np.int64, np.int32, Integral)):
+            x_as_int = int(x)
         else:
             return NotImplemented
 
         if isinstance(y, Asset):
             y_as_int = y.sid
         elif isinstance(y, int):
+            # ints are Integral, but much faster to special case
             y_as_int = y
+        elif isinstance(y, (long, np.int64, np.int32, Integral)):
+            y_as_int = int(y)
         else:
             return NotImplemented
 


### PR DESCRIPTION
Enable comparison of an Asset to an int64 on 32-bit python

by supporting any Integral. We use a number of mappings keyed by
int64, which otherwise raise KeyErrors for Assets.

Also ensures `algo.current_sids()` returns a list of Assets, instead of identifiers.

For #650 and #926