### PR TITLE
ENH: Add writer for equity minute bcolz format.

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -105,3 +105,9 @@ Asset Metadata
 
 .. autoclass:: zipline.assets.assets.AssetConvertible
    :members:
+
+Data API
+~~~~
+
+.. autoclass:: zipline.data.us_equity_minutes.BcolzMinuteBarWriter
+   :members:

--- a/tests/data/test_us_equity_minutes.py
+++ b/tests/data/test_us_equity_minutes.py
@@ -38,6 +38,7 @@ from zipline.finance.trading import TradingEnvironment
 TEST_CALENDAR_START = Timestamp('2015-06-01', tz='UTC')
 TEST_CALENDAR_STOP = Timestamp('2015-06-30', tz='UTC')
 
+
 class BcolzMinuteBarTestCase(TestCase):
 
     @classmethod
@@ -172,7 +173,6 @@ class BcolzMinuteBarTestCase(TestCase):
                 'volume': [50.0]
             },
             index=[minute])
-        days = DatetimeIndex([second_day])
         self.writer.write(sid, data)
 
         open_price = self.reader.get_value(sid, minute, 'open')
@@ -207,7 +207,6 @@ class BcolzMinuteBarTestCase(TestCase):
                 'volume': [0]
             },
             index=[minute])
-        days = DatetimeIndex([self.test_calendar_start])
         self.writer.write(sid, data)
 
         open_price = self.reader.get_value(sid, minute, 'open')

--- a/tests/data/test_us_equity_minutes.py
+++ b/tests/data/test_us_equity_minutes.py
@@ -81,7 +81,7 @@ class BcolzMinuteBarTestCase(TestCase):
             },
             index=[minute])
         days = DatetimeIndex([self.test_calendar_start])
-        self.writer.write(sid, days, data)
+        self.writer.write(sid, data)
 
         open_price = self.reader.get_value(sid, minute, 'open')
 
@@ -117,7 +117,7 @@ class BcolzMinuteBarTestCase(TestCase):
             },
             index=[minute_0, minute_1])
         days = DatetimeIndex([self.test_calendar_start])
-        self.writer.write(sid, days, data)
+        self.writer.write(sid, data)
 
         open_price = self.reader.get_value(sid, minute_0, 'open')
 
@@ -173,7 +173,7 @@ class BcolzMinuteBarTestCase(TestCase):
             },
             index=[minute])
         days = DatetimeIndex([second_day])
-        self.writer.write(sid, days, data)
+        self.writer.write(sid, data)
 
         open_price = self.reader.get_value(sid, minute, 'open')
 
@@ -198,9 +198,17 @@ class BcolzMinuteBarTestCase(TestCase):
     def test_write_empty(self):
         minute = self.market_opens[self.test_calendar_start]
         sid = 1
-        data = None
+        data = DataFrame(
+            data={
+                'open': [0],
+                'high': [0],
+                'low': [0],
+                'close': [0],
+                'volume': [0]
+            },
+            index=[minute])
         days = DatetimeIndex([self.test_calendar_start])
-        self.writer.write(sid, days, data)
+        self.writer.write(sid, data)
 
         open_price = self.reader.get_value(sid, minute, 'open')
 
@@ -243,7 +251,7 @@ class BcolzMinuteBarTestCase(TestCase):
                 'volume': [50.0, 51.0]
             },
             index=minutes)
-        self.writer.write(sid, days, data)
+        self.writer.write(sid, data)
 
         minute = minutes[0]
 
@@ -302,7 +310,7 @@ class BcolzMinuteBarTestCase(TestCase):
             },
             index=[minute])
         days = self.market_opens[0:1].index
-        self.writer.write(sid, days, data)
+        self.writer.write(sid, data)
 
         with self.assertRaises(BcolzMinuteOverlappingData):
-            self.writer.write(sid, days, data)
+            self.writer.write(sid, data)

--- a/tests/data/test_us_equity_minutes.py
+++ b/tests/data/test_us_equity_minutes.py
@@ -1,0 +1,308 @@
+#
+# Copyright 2016 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import timedelta
+import os
+
+from unittest import TestCase
+
+from numpy import nan
+from numpy.testing import assert_almost_equal
+from pandas import (
+    DataFrame,
+    DatetimeIndex,
+    Timestamp,
+    isnull
+)
+from testfixtures import TempDirectory
+
+from zipline.data.us_equity_minutes import (
+    BcolzMinuteBarWriter,
+    BcolzMinuteBarReader,
+    BcolzMinuteOverlappingData,
+)
+from zipline.finance.trading import TradingEnvironment
+
+
+TEST_CALENDAR_START = Timestamp('2015-06-01', tz='UTC')
+TEST_CALENDAR_STOP = Timestamp('2015-06-30', tz='UTC')
+
+class BcolzMinuteBarTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = TradingEnvironment()
+        all_market_opens = cls.env.open_and_closes.market_open
+        indexer = all_market_opens.index.slice_indexer(
+            start=TEST_CALENDAR_START,
+            end=TEST_CALENDAR_STOP
+        )
+        cls.market_opens = all_market_opens[indexer]
+        cls.test_calendar_start = cls.market_opens.index[0]
+        cls.test_calendar_stop = cls.market_opens.index[-1]
+
+    def setUp(self):
+
+        self.dir_ = TempDirectory()
+        self.dir_.create()
+        self.dest = self.dir_.getpath('equity_minute_pricing')
+        os.makedirs(self.dest)
+        self.writer = BcolzMinuteBarWriter(
+            TEST_CALENDAR_START,
+            self.dest,
+            self.market_opens
+        )
+        self.reader = BcolzMinuteBarReader(self.dest)
+
+    def tearDown(self):
+        self.dir_.cleanup()
+
+    def test_write_one_ohlcv(self):
+        minute = self.market_opens[self.test_calendar_start]
+        sid = 1
+        data = DataFrame(
+            data={
+                'open': [10.0],
+                'high': [20.0],
+                'low': [30.0],
+                'close': [40.0],
+                'volume': [50.0]
+            },
+            index=[minute])
+        days = DatetimeIndex([self.test_calendar_start])
+        self.writer.write(sid, days, data)
+
+        open_price = self.reader.get_value(sid, minute, 'open')
+
+        self.assertEquals(10.0, open_price)
+
+        high_price = self.reader.get_value(sid, minute, 'high')
+
+        self.assertEquals(20.0, high_price)
+
+        low_price = self.reader.get_value(sid, minute, 'low')
+
+        self.assertEquals(30.0, low_price)
+
+        close_price = self.reader.get_value(sid, minute, 'close')
+
+        self.assertEquals(40.0, close_price)
+
+        volume_price = self.reader.get_value(sid, minute, 'volume')
+
+        self.assertEquals(50.0, volume_price)
+
+    def test_write_two_bars(self):
+        minute_0 = self.market_opens[self.test_calendar_start]
+        minute_1 = minute_0 + timedelta(minutes=1)
+        sid = 1
+        data = DataFrame(
+            data={
+                'open': [10.0, 11.0],
+                'high': [20.0, 21.0],
+                'low': [30.0, 31.0],
+                'close': [40.0, 41.0],
+                'volume': [50.0, 51.0]
+            },
+            index=[minute_0, minute_1])
+        days = DatetimeIndex([self.test_calendar_start])
+        self.writer.write(sid, days, data)
+
+        open_price = self.reader.get_value(sid, minute_0, 'open')
+
+        self.assertEquals(10.0, open_price)
+
+        high_price = self.reader.get_value(sid, minute_0, 'high')
+
+        self.assertEquals(20.0, high_price)
+
+        low_price = self.reader.get_value(sid, minute_0, 'low')
+
+        self.assertEquals(30.0, low_price)
+
+        close_price = self.reader.get_value(sid, minute_0, 'close')
+
+        self.assertEquals(40.0, close_price)
+
+        volume_price = self.reader.get_value(sid, minute_0, 'volume')
+
+        self.assertEquals(50.0, volume_price)
+
+        open_price = self.reader.get_value(sid, minute_1, 'open')
+
+        self.assertEquals(11.0, open_price)
+
+        high_price = self.reader.get_value(sid, minute_1, 'high')
+
+        self.assertEquals(21.0, high_price)
+
+        low_price = self.reader.get_value(sid, minute_1, 'low')
+
+        self.assertEquals(31.0, low_price)
+
+        close_price = self.reader.get_value(sid, minute_1, 'close')
+
+        self.assertEquals(41.0, close_price)
+
+        volume_price = self.reader.get_value(sid, minute_1, 'volume')
+
+        self.assertEquals(51.0, volume_price)
+
+    def test_write_on_second_day(self):
+        second_day = self.test_calendar_start + 1
+        minute = self.market_opens[second_day]
+        sid = 1
+        data = DataFrame(
+            data={
+                'open': [10.0],
+                'high': [20.0],
+                'low': [30.0],
+                'close': [40.0],
+                'volume': [50.0]
+            },
+            index=[minute])
+        days = DatetimeIndex([second_day])
+        self.writer.write(sid, days, data)
+
+        open_price = self.reader.get_value(sid, minute, 'open')
+
+        self.assertEquals(10.0, open_price)
+
+        high_price = self.reader.get_value(sid, minute, 'high')
+
+        self.assertEquals(20.0, high_price)
+
+        low_price = self.reader.get_value(sid, minute, 'low')
+
+        self.assertEquals(30.0, low_price)
+
+        close_price = self.reader.get_value(sid, minute, 'close')
+
+        self.assertEquals(40.0, close_price)
+
+        volume_price = self.reader.get_value(sid, minute, 'volume')
+
+        self.assertEquals(50.0, volume_price)
+
+    def test_write_empty(self):
+        minute = self.market_opens[self.test_calendar_start]
+        sid = 1
+        data = None
+        days = DatetimeIndex([self.test_calendar_start])
+        self.writer.write(sid, days, data)
+
+        open_price = self.reader.get_value(sid, minute, 'open')
+
+        assert_almost_equal(nan, open_price)
+
+        high_price = self.reader.get_value(sid, minute, 'high')
+
+        assert_almost_equal(nan, high_price)
+
+        low_price = self.reader.get_value(sid, minute, 'low')
+
+        assert_almost_equal(nan, low_price)
+
+        close_price = self.reader.get_value(sid, minute, 'close')
+
+        assert_almost_equal(nan, close_price)
+
+        volume_price = self.reader.get_value(sid, minute, 'volume')
+
+        assert_almost_equal(0, volume_price)
+
+    def test_write_on_multiple_days(self):
+
+        tds = self.market_opens.index
+        days = tds[tds.slice_indexer(
+            start=self.test_calendar_start + 1,
+            end=self.test_calendar_start + 3
+        )]
+        minutes = DatetimeIndex([
+            self.market_opens[days[0]] + timedelta(minutes=60),
+            self.market_opens[days[1]] + timedelta(minutes=120),
+        ])
+        sid = 1
+        data = DataFrame(
+            data={
+                'open': [10.0, 11.0],
+                'high': [20.0, 21.0],
+                'low': [30.0, 31.0],
+                'close': [40.0, 41.0],
+                'volume': [50.0, 51.0]
+            },
+            index=minutes)
+        self.writer.write(sid, days, data)
+
+        minute = minutes[0]
+
+        open_price = self.reader.get_value(sid, minute, 'open')
+
+        self.assertEquals(10.0, open_price)
+
+        high_price = self.reader.get_value(sid, minute, 'high')
+
+        self.assertEquals(20.0, high_price)
+
+        low_price = self.reader.get_value(sid, minute, 'low')
+
+        self.assertEquals(30.0, low_price)
+
+        close_price = self.reader.get_value(sid, minute, 'close')
+
+        self.assertEquals(40.0, close_price)
+
+        volume_price = self.reader.get_value(sid, minute, 'volume')
+
+        self.assertEquals(50.0, volume_price)
+
+        minute = minutes[1]
+
+        open_price = self.reader.get_value(sid, minute, 'open')
+
+        self.assertEquals(11.0, open_price)
+
+        high_price = self.reader.get_value(sid, minute, 'high')
+
+        self.assertEquals(21.0, high_price)
+
+        low_price = self.reader.get_value(sid, minute, 'low')
+
+        self.assertEquals(31.0, low_price)
+
+        close_price = self.reader.get_value(sid, minute, 'close')
+
+        self.assertEquals(41.0, close_price)
+
+        volume_price = self.reader.get_value(sid, minute, 'volume')
+
+        self.assertEquals(51.0, volume_price)
+
+    def test_no_overwrite(self):
+        minute = self.market_opens[TEST_CALENDAR_START]
+        sid = 1
+        data = DataFrame(
+            data={
+                'open': [10.0],
+                'high': [20.0],
+                'low': [30.0],
+                'close': [40.0],
+                'volume': [50.0]
+            },
+            index=[minute])
+        days = self.market_opens[0:1].index
+        self.writer.write(sid, days, data)
+
+        with self.assertRaises(BcolzMinuteOverlappingData):
+            self.writer.write(sid, days, data)

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -251,10 +251,6 @@ class BcolzMinuteBarWriter(object):
     def first_trading_day(self):
         return self._first_trading_day
 
-    @property
-    def metadata_path(self):
-        return os.path.join(self._rootdir, METADATA_FILENAME)
-
     def sidpath(self, sid):
         """
         Parameters:
@@ -362,6 +358,11 @@ class BcolzMinuteBarWriter(object):
         df : pd.DataFrame
             DataFrame of market data with the following characteristics.
             columns : ('open', 'high', 'low', 'close', 'volume')
+                open : float64
+                high : float64
+                low  : float64
+                close : float64
+                volume : float64|int64
             index : DatetimeIndex of market minutes.
         """
         table = self._ensure_ctable(sid)

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -54,7 +54,7 @@ def _sid_subdir_path(sid):
 
     Parameters:
     -----------
-    sid - int
+    sid : int
         Asset identifier.
 
     Returns:

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -413,20 +413,16 @@ class BcolzMinuteBarWriter(object):
         close_col = np.zeros(minutes_count, dtype=np.uint32)
         vol_col = np.zeros(minutes_count, dtype=np.uint32)
 
-        if df is not None:
-            dt_ixs = np.searchsorted(all_minutes_in_window.values,
-                                     df.index.values)
+        dt_ixs = np.searchsorted(all_minutes_in_window.values,
+                                 df.index.values)
 
-            ohlc_ratio = self._ohlc_ratio
-            open_col[dt_ixs] = (df.open.values * ohlc_ratio).astype(np.uint32)
-            high_col[dt_ixs] = (df.high.values * ohlc_ratio).astype(np.uint32)
-            low_col[dt_ixs] = (df.low.values * ohlc_ratio).astype(np.uint32)
-            close_col[dt_ixs] = (df.close.values * ohlc_ratio).astype(
-                np.uint32)
-            vol_col[dt_ixs] = df.volume.values.astype(np.uint32)
-        else:
-            # If df is None, add zero rows for the given days.
-            pass
+        ohlc_ratio = self._ohlc_ratio
+        open_col[dt_ixs] = (df.open.values * ohlc_ratio).astype(np.uint32)
+        high_col[dt_ixs] = (df.high.values * ohlc_ratio).astype(np.uint32)
+        low_col[dt_ixs] = (df.low.values * ohlc_ratio).astype(np.uint32)
+        close_col[dt_ixs] = (df.close.values * ohlc_ratio).astype(
+            np.uint32)
+        vol_col[dt_ixs] = df.volume.values.astype(np.uint32)
 
         table.append([
             open_col,

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -342,11 +342,8 @@ class BcolzMinuteBarWriter(object):
         if days_to_zerofill is not None and len(days_to_zerofill):
             self._zerofill(table, len(days_to_zerofill))
 
-        days_to_write_indexer = self._trading_days.slice_indexer(
-            start=input_first_day,
-            end=days[-1]
-        )
-        days_to_write = self._trading_days[days_to_write_indexer]
+        days_to_write = tds[tds.slice_indexer(start=input_first_day,
+                                              end=days[-1])]
         minutes_count = len(days_to_write) * self._minutes_per_day
 
         all_minutes = self._minute_index

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -257,8 +257,7 @@ class BcolzMinuteBarWriter(object):
         """
         # Only create the subdir on container creation.
         sid_dirname = os.path.dirname(path)
-        if not os.path.exists(sid_dirname):
-            os.makedirs(sid_dirname)
+        os.makedirs(sid_dirname)
         initial_array = np.empty(0, np.uint32)
         table = ctable(
             rootdir=path,

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -158,7 +158,7 @@ class BcolzMinuteBarWriter(object):
             If the expectedlen is not used, the chunksize and corresponding
             compression ratios are not ideal.
 
-            Defaults to supporting 15 years of market data.
+            Defaults to supporting 15 years of NYSE equity market data.
 
             see: http://bcolz.blosc.org/opt-tips.html#informing-about-the-length-of-your-carrays
         """

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -128,7 +128,6 @@ class BcolzMinuteBarWriter(object):
         """
         Parameters:
         -----------
-
         first_trading_day : datetime-like
             The first trading day in the data set.
         
@@ -251,7 +250,6 @@ class BcolzMinuteBarWriter(object):
 
         Parameters:
         -----------
-
         path : string
             The path to rootdir of the new ctable.
         """

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Quantopian, Inc.
+# Copyright 2016 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,27 +11,402 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from textwrap import dedent
+
 import bcolz
+from bcolz import ctable
+import numpy as np
+from os.path import join
 import json
 import os
 import pandas as pd
 
 MINUTES_PER_DAY = 390
-
+DEFAULT_EXPECTEDLEN = 390 * 252 * 15
+OHLC_RATIO = 1000
 METADATA_FILENAME = 'metadata.json'
+
+
+class BcolzMinuteOverlappingData(Exception):
+    pass
+
+
+def _calc_minute_index(market_opens, minutes_per_day):
+    minutes = np.zeros(len(market_opens) * minutes_per_day,
+                       dtype='datetime64[ns]')
+    deltas = np.arange(0, minutes_per_day, dtype='timedelta64[m]')
+    for i, market_open in enumerate(market_opens):
+        start = market_open.asm8
+        minute_values = start + deltas
+        start_ix = minutes_per_day * i
+        end_ix = start_ix + minutes_per_day
+        minutes[start_ix:end_ix] = minute_values
+    return pd.to_datetime(minutes, utc=True, box=True)
+
+
+def _sid_subdir_path(sid):
+    """
+    Format subdir path to limit the number directories in any given
+    subdirectory to 100.
+
+    The number in each directory is designed to support at least 100000
+    equities.
+
+    Parameters:
+    -----------
+    sid - int
+        Asset identifier.
+
+    Returns:
+    --------
+    string
+        A path for the bcolz rootdir, including subdirectory prefixes based on
+        the padded string representation of the given sid.
+
+        e.g. 1 is formatted as 00/00/000001.bcolz
+    """
+    padded_sid = format(sid, '06')
+    return os.path.join(
+        # subdir 1 00/XX
+        padded_sid[0:2],
+        # subdir 2 XX/00
+        padded_sid[2:4],
+        "{0}.bcolz".format(str(padded_sid))
+    )
+
+
+class BcolzMinuteBarWriter(object):
+    """
+    Class capable of writing minute OHLCV data to disk into bcolz format.
+
+    Writes a bcolz directory for each individual sid, all contained within
+    a root directory which also contains metadata about the entire dataset.
+
+    Each individual asset's data is stored as a bcolz table with a column for
+    each pricing field: (open, high, low, close, volume)
+
+    The open, high, low, and close columns are integers which are 1000 times
+    the quoted price, so that the data can represented and stored as an
+    np.uint32, supporting market prices quoted up to the thousands place.
+
+    volume is a np.uint32 with no mutation of the tens place.
+
+    The 'index' for each individual asset are a repeating period of minutes of
+    length `minutes_per_day` starting from each market open.
+    The file format does not account for half-days.
+    e.g.:
+    2016-01-19 14:31
+    2016-01-19 14:32
+    ...
+    2016-01-19 20:59
+    2016-01-19 21:00
+    2016-01-20 14:31
+    2016-01-20 14:32
+    ...
+    2016-01-20 20:59
+    2016-01-20 21:00
+
+    All assets are written with a common 'index', sharing a common first
+    trading day. Assets that do not begin trading until after the first trading
+    day will have zeros for all pricing data up and until data is traded.
+
+    'index' is in quotations, because bcolz does not provide an index. The
+    format allows index-like behavior by writing each minute's data into the
+    corresponding position of the enumeration of the aforementioned datetime
+    index.
+
+    The datetimes which correspond to each position are written in the metadata
+    as integer nanoseconds since the epoch into the `minute_index` key.
+    """
+    def __init__(self,
+                 first_trading_day,
+                 rootdir,
+                 market_opens,
+                 minutes_per_day=MINUTES_PER_DAY,
+                 ohlc_ratio=OHLC_RATIO,
+                 expectedlen=DEFAULT_EXPECTEDLEN):
+        """
+        Parameters:
+        -----------
+
+        first_trading_day : datetime-like
+            The first trading day in the data set.
+        
+        rootdir : string
+            Path to the root directory into which to write the metadata and
+            bcolz subdirectories.
+
+        market_opens : pd.Series
+            The market opens used as a starting point for each periodic span of
+            minutes in the index.
+
+        minutes_per_day : int
+            The number of minutes per each period. Defaults to 390, the mode
+            of minutes in NYSE trading days.
+
+        ohlc_ratio : int
+            The ratio by which to multiply the pricing data to convert the floats
+            from floats to an integer to fit within the np.uint32.
+
+            The default is 1000 to support pricing data which comes in to the
+            thousands place.
+
+        expectedlen : int
+            The expected length of the dataset, used when creating the initial
+            bcolz ctable.
+
+            If the expectedlen is not used, the chunksize and corresponding
+            compression ratios are not ideal.
+
+            Defaults to supporting 15 years of market data.
+
+            see: http://bcolz.blosc.org/opt-tips.html#informing-about-the-length-of-your-carrays
+        """
+        self._rootdir = rootdir
+        self._first_trading_day = first_trading_day
+        self._market_opens = market_opens[
+            market_opens.index.slice_indexer(start=self._first_trading_day)]
+        self._trading_days = market_opens.index
+        self._minutes_per_day = minutes_per_day
+        self._expectedlen = expectedlen
+        self._ohlc_ratio = ohlc_ratio
+
+        self._minute_index = _calc_minute_index(
+            self._market_opens, self._minutes_per_day)
+
+        self._write_metadata()
+
+    @property
+    def first_trading_day(self):
+        return self._first_trading_day
+
+    @property
+    def metadata_path(self):
+        return os.path.join(self._rootdir, METADATA_FILENAME)
+
+    def _write_metadata(self):
+        """
+        Write the metadata to a JSON file in the rootdir.
+
+        Values contained in the metadata are:
+        first_trading_day : string
+            'YYYY-MM-DD' formatted representation of the first trading day
+             available in the dataset.
+        minute_index : list of integers
+             nanosecond integer representation of the minutes, the enumeration of which
+             corresponds to the values in each bcolz carray.
+        """
+        metadata = {
+            'first_trading_day': str(self.first_trading_day.date()),
+            'minute_index': self._minute_index.asi8.tolist(),
+            'ohlc_ratio': self._ohlc_ratio,
+        }
+        with open(self.metadata_path, 'w+') as fp:
+            json.dump(metadata, fp)
+
+    def sidpath(self, sid):
+        """
+        Parameters:
+        -----------
+        sid : int
+            Asset identifier.
+
+        Returns:
+        --------
+        string
+
+            Full path to the bcolz rootdir for the given sid.
+        """
+        sid_subdir = _sid_subdir_path(sid)
+        return join(self._rootdir, sid_subdir)
+
+    def last_date_in_output_for_sid(self, sid):
+        """
+        Parameters:
+        -----------
+        sid : int
+            Asset identifier.
+
+        Returns:
+        --------
+        pd.Timestamp
+            The midnight of the last date written in to the output for the
+            given sid.
+        """
+        try:
+            sizes_path = "{0}/close/meta/sizes".format(self.sidpath(sid))
+            with open(sizes_path, mode='r') as f:
+                sizes = f.read()
+            data = json.loads(sizes)
+            num_days = data['shape'][0] / self._minutes_per_day
+            if num_days == 0:
+                # empty container
+                return None
+            return self._trading_days[num_days - 1]
+        except IOError:
+            return None
+
+    def _init_ctable(self, path):
+        """
+        Create empty ctable for given path.
+
+        Parameters:
+        -----------
+
+        path : string
+            The path to rootdir of the new ctable.
+        """
+        # Only create the subdir on container creation.
+        sid_dirname = os.path.dirname(path)
+        if not os.path.exists(sid_dirname):
+            os.makedirs(sid_dirname)
+        initial_array = np.empty(0, np.uint32)
+        table = ctable(
+            rootdir=path,
+            columns=[
+                initial_array,
+                initial_array,
+                initial_array,
+                initial_array,
+                initial_array,
+            ],
+            names=[
+                'open',
+                'high',
+                'low',
+                'close',
+                'volume'
+            ],
+            expectedlen=self._expectedlen,
+            mode='w',
+        )
+        table.flush()
+
+    def _zerofill(self, table, numdays):
+        num_to_prepend = numdays * self._minutes_per_day
+        prepend_array = np.zeros(num_to_prepend, np.uint32)
+        # Fill all OHLCV with zeros.
+        table.append([prepend_array] * 5)
+        table.flush()
+
+    def write(self, sid, days, df):
+        """
+        Write the OHLCV data for the given sid.
+
+        If there is no bcolz ctable yet created for the sid, create it.
+
+        If the length of the bcolz ctable is not exactly to the date before
+        the first day provided, fill the ctable with 0s up to that date.
+
+        Writes in blocks of the size of the days times minutes per day.
+
+        Parameters:
+        -----------
+        sid : int
+            The asset identifer for the data being written.
+        days : pd.DatetimeIndex
+            The days for which to write data from the given df.
+        df : pd.DataFrame
+            DataFrame of market data with the following characteristics.
+            columns : ('open', 'high', 'low', 'close', 'volume')
+            index : DatetimeIndex of market minutes.
+        """
+        path = self.sidpath(sid)
+        if not os.path.exists(path):
+            self._init_ctable(path)
+        table = ctable(rootdir=path)
+
+        last_date = self.last_date_in_output_for_sid(sid)
+        input_first_day = days[0]
+
+        tds = self._trading_days
+        if last_date is None:
+            # If there is no data, determine how many days to add so that
+            # desired days are written to the correct slots.
+            days_to_zerofill = tds[tds.slice_indexer(end=input_first_day)]
+            # Chop off the input first day.
+            days_to_zerofill = days_to_zerofill[:-1]
+        else:
+            next_date = last_date + 1
+            if next_date < input_first_day:
+                # If last_date and input_first_day are not adjacent need to
+                # fill in between.
+                days_to_zerofill = tds[tds.slice_indexer(
+                    start=last_date + 1,
+                    end=input_first_day)]
+                # Chop off the input first day.
+                days_to_zerofill = days_to_zerofill[:-1]
+            elif next_date >= input_first_day:
+                raise BcolzMinuteOverlappingData(dedent("""
+                window start={0} is before expected write date={1} for
+                sid={2}""".strip()).format(days[0], input_first_day, sid))
+            else:
+                days_to_zerofill = None
+
+        if days_to_zerofill is not None and len(days_to_zerofill):
+            self._zerofill(table, len(days_to_zerofill))
+
+        days_to_write_indexer = self._trading_days.slice_indexer(
+            start=input_first_day,
+            end=days[-1]
+        )
+        days_to_write = self._trading_days[days_to_write_indexer]
+        minutes_count = len(days_to_write) * self._minutes_per_day
+
+        all_minutes = self._minute_index
+        indexer = all_minutes.slice_indexer(start=days_to_write[0])
+        all_minutes_in_window = all_minutes[indexer]
+
+        open_col = np.zeros(minutes_count, dtype=np.uint32)
+        high_col = np.zeros(minutes_count, dtype=np.uint32)
+        low_col = np.zeros(minutes_count, dtype=np.uint32)
+        close_col = np.zeros(minutes_count, dtype=np.uint32)
+        vol_col = np.zeros(minutes_count, dtype=np.uint32)
+
+        if df is not None:
+            dt_ixs = np.searchsorted(all_minutes_in_window.values,
+                                     df.index.values)
+
+            ohlc_ratio = self._ohlc_ratio
+            open_col[dt_ixs] = (df.open.values * ohlc_ratio).astype(np.uint32)
+            high_col[dt_ixs] = (df.high.values * ohlc_ratio).astype(np.uint32)
+            low_col[dt_ixs] = (df.low.values * ohlc_ratio).astype(np.uint32)
+            close_col[dt_ixs] = (df.close.values * ohlc_ratio).astype(
+                np.uint32)
+            vol_col[dt_ixs] = df.volume.values.astype(np.uint32)
+        else:
+            # If df is None, add zero rows for the given days.
+            pass
+
+        table.append([
+            open_col,
+            high_col,
+            low_col,
+            close_col,
+            vol_col
+        ])
+        table.flush()
 
 
 class BcolzMinuteBarReader(object):
 
-    def __init__(self, rootdir, sid_path_func=None):
+    def __init__(self, rootdir):
+        """
+        Reader for data written by BcolzMinuteBarWriter
+
+        Parameters:
+        -----------
+        rootdir : string
+            The root directory containing the metadata and asset bcolz
+            directories.
+        """
         self.rootdir = rootdir
 
         metadata = self._get_metadata()
 
-        self.first_trading_day = pd.Timestamp(
-            metadata['first_trading_day'], tz='UTC')
-
-        self._sid_path_func = sid_path_func
+        self._first_trading_day = metadata['first_trading_day']
+        self._minute_index = metadata['minute_index']
+        self._ohlc_inverse = metadata['ohlc_inverse']
 
         self._carrays = {
             'open': {},
@@ -39,22 +414,73 @@ class BcolzMinuteBarReader(object):
             'low': {},
             'close': {},
             'volume': {},
-            'sid': {},
-            'dt': {},
         }
 
     def _get_metadata(self):
         with open(os.path.join(self.rootdir, METADATA_FILENAME)) as fp:
-            return json.load(fp)
+            raw_data = json.load(fp)
+            metadata = {
+                'first_trading_day': pd.Timestamp(
+                    raw_data['first_trading_day'], tz='UTC'),
+                'minute_index': pd.to_datetime(raw_data['minute_index'],
+                                               utc=True),
+                'ohlc_inverse': 1.0 / raw_data['ohlc_ratio']
+            }
+            return metadata
 
-    def _get_ctable(self, asset):
-        sid = int(asset)
-        if self._sid_path_func is not None:
-            path = self._sid_path_func(self.rootdir, sid)
-        else:
-            path = "{0}/{1}.bcolz".format(self.rootdir, sid)
+    def _get_carray_path(self, sid, field):
+        sid_subdir = _sid_subdir_path(sid)
+        # carrays are subdirectories of the sid's rootdir
+        return os.path.join(self.rootdir, sid_subdir, field)
 
-        return bcolz.open(path, mode='r')
+    def _open_minute_file(self, field, sid):
+        sid = int(sid)
+
+        try:
+            carray = self._carrays[field][sid]
+        except KeyError:
+            carray = self._carrays[field][sid] = \
+                bcolz.carray(rootdir=self._get_carray_path(sid, field),
+                             mode='r')
+
+        return carray
+
+    def get_value(self, sid, dt, field):
+        """
+        Retrieve the pricing info for the given sid, dt, and field.
+
+        Parameters:
+        -----------
+        sid : int
+            Asset identifier.
+        dt : datetime-like
+            The datetime at which the trade occurred.
+        field : string
+            The type of pricing data to retrieve. 
+            ('open', 'high', 'low', 'close', 'volume')
+
+        Returns:
+        --------
+        The market data for the given sid, dt, and field coordinates.
+
+        For OHLC:
+            Returns a float if a trade occurred at the given dt.
+            If no trade occurred, a np.nan is returned.
+
+        For volume:
+            Returns the integer value of the volume.
+            (A volume of 0 signifies no trades for the given dt.)
+        """
+        minute_pos = self._find_position_of_minute(dt)
+        value = self._open_minute_file(field, sid)[minute_pos]
+        if value == 0:
+            if field != 'volume':
+                return np.nan
+            else:
+                return 0
+        if field != 'volume':
+            value *= self._ohlc_inverse
+        return value
 
     def _find_position_of_minute(self, minute_dt):
         """
@@ -62,12 +488,8 @@ class BcolzMinuteBarReader(object):
         list of every trading minute since market open of the first trading
         day.
 
-        IMPORTANT: This method assumes every day is 390 minutes long, even
-        early closes.  Our minute bcolz files are generated like this to
-        support fast lookup.
-
-        ex. this method would return 2 for 1/2/2002 9:32 AM Eastern, if
-        1/2/2002 is the first trading day of the dataset.
+        ex. this method would return 1 for 2002-01-02 9:32 AM Eastern, if
+        2002-01-02 is the first trading day of the dataset.
 
         Parameters
         ----------
@@ -79,15 +501,4 @@ class BcolzMinuteBarReader(object):
         The position of the given minute in the list of all trading minutes
         since market open on the first trading day.
         """
-        NotImplementedError
-
-    def _open_minute_file(self, field, asset):
-        sid_str = str(int(asset))
-
-        try:
-            carray = self._carrays[field][sid_str]
-        except KeyError:
-            carray = self._carrays[field][sid_str] = \
-                self._get_ctable(asset)[field]
-
-        return carray
+        return self._minute_index.get_loc(minute_dt)

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -59,7 +59,7 @@ def _sid_subdir_path(sid):
 
     Returns:
     --------
-    string
+    out : string
         A path for the bcolz rootdir, including subdirectory prefixes based on
         the padded string representation of the given sid.
 
@@ -213,8 +213,7 @@ class BcolzMinuteBarWriter(object):
 
         Returns:
         --------
-        string
-
+        out : string
             Full path to the bcolz rootdir for the given sid.
         """
         sid_subdir = _sid_subdir_path(sid)
@@ -229,7 +228,7 @@ class BcolzMinuteBarWriter(object):
 
         Returns:
         --------
-        pd.Timestamp
+        out : pd.Timestamp
             The midnight of the last date written in to the output for the
             given sid.
         """
@@ -461,6 +460,8 @@ class BcolzMinuteBarReader(object):
 
         Returns:
         --------
+        out : float|int
+
         The market data for the given sid, dt, and field coordinates.
 
         For OHLC:
@@ -498,6 +499,8 @@ class BcolzMinuteBarReader(object):
 
         Returns
         -------
+        out : int
+
         The position of the given minute in the list of all trading minutes
         since market open on the first trading day.
         """

--- a/zipline/data/us_equity_minutes.py
+++ b/zipline/data/us_equity_minutes.py
@@ -96,6 +96,18 @@ class BcolzMinuteBarMetadata(object):
             return cls(first_trading_day, minute_index, ohlc_ratio)
 
     def __init__(self, first_trading_day, minute_index, ohlc_ratio):
+        """
+        Parameters:
+        -----------
+        first_trading_day : datetime-like
+            UTC midnight of the first day available in the dataset.
+        minute_index : pd.DatetimeIndex
+            The minutes which act as an index into the corresponding values
+            written into each sid's ctable.
+        ohlc_ratio : int
+             The factor by which the pricing data is multiplied so that the
+             float data can be stored as an integer.
+        """
         self.first_trading_day = first_trading_day
         self.minute_index = minute_index
         self.ohlc_ratio = ohlc_ratio
@@ -111,6 +123,9 @@ class BcolzMinuteBarMetadata(object):
         minute_index : list of integers
              nanosecond integer representation of the minutes, the enumeration
              of which corresponds to the values in each bcolz carray.
+        ohlc_ratio : int
+             The factor by which the pricing data is multiplied so that the
+             float data can be stored as an integer.
         """
         metadata = {
             'first_trading_day': str(self.first_trading_day.date()),


### PR DESCRIPTION
Implement a writer for minute data into a format comprised of multiple
ctables, one for each individual equity, with a common 'index' shared by
all ctables where a given a dt maps to the same array index for all
equities and fields.

This format is pulled from the lazy-mainline/Q2.0 branch, with some
changes to the interface.

Add basic retrieval of values at a given dt to reader. Not yet used by
Zipline simulations, but added to support unit tests.

# Other Notes

Questions:
- Currently the main entry point into the writer is `write(sid, days, df)`, where the df is a DataFrame for just the given sid. 
-- Providing `days` does feel redundant, when that information could be re-constructed from the `df` and the writer's `self._trading_days`.
-- `sid` could be also be redundant, if the df were formatted with a `MultiIndex` of (sid, dt), then the sids could be iterated over using `get_level_values`.

@ssanderson I took in a lot of notes from our in person conversation the other day.
Including taking in market_opens as a parameter, and then writing out the resulting index to free the writer/reader combo from requiring a `TradingEnvironment` or `tradingcalendar` module.

Where I did diverge from our discussion was:
- The writer class no longer requires subclassing to implement different sources, instead the `write` method takes a DataFrame with the OHLCV data. This change resulted from using the writer with our existing and incoming internal dataloader. I found having a writer which was agnostic of its input source more flexible to work with when wiring up different sources, and I believe is a more adoptable public API.

For some background on the choice of having the Writer agnostic to the input, I looked to the following:
- https://docs.python.org/2/library/csv.html
- https://golang.org/pkg/bufio/#example_Writer
- http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html

- The responsibility of the writer is just writing individual sid data, without adding the 'bring data up to date' logic that our internal loader provides. This change allowed dropping the writer into our existing internal loader. If/when we do make that logic a public API, I believe we should make a separate `Loader` (or some other name, `DataSet`/`DataSetManager`, I am not yet sure), which takes the writer as one of its components.

@jbredeche this implementation differs from our implementation in lazy-mainline in the following ways.
(For reference, https://github.com/quantopian/zipline/blob/lazy-mainline/zipline/data/us_equity_minutes.py)
- The aforementioned change to no longer using subclasses to get the data, instead passing in the DataFrame independent of the data source.
- Making the directory as part of the constructor. This change was 1) based on the above list of other Reader/Writers, 2) was more natural when using the writer with our existing internal loader 3) Allows more flexibility if we ever need to implement another writer that does not write to a directory, e.g. if a Postgres or SQLite writer is implemented then `write(sid, days, df)` would also work with a writer of that type.

- Allowing multiple passes on writing data, which is a requirement of our internal writers which read the source data in subgroups of days and equities. (Instead of only supporting reading all data for an equity at once.)