### PR TITLE
Pipeline missing values

### DIFF
--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -17,6 +17,11 @@ Highlights
 * :class:`~zipline.assets.assets.AssetFinder` speedups (:issue:`830` and
   :issue:`817`).
 
+* Improved support for non-float dtypes in Pipeline.  Most notably, we now
+  support ``datetime64`` and ``int64`` dtypes for ``Factor``, and
+  ``BoundColumn.latest`` now returns a proper ``Filter`` object when the column
+  is of dtype ``bool``.
+
 Enhancements
 ~~~~~~~~~~~~
 
@@ -82,6 +87,17 @@ Enhancements
   ``datetime.time(8, 45)`` and ``'US/Eastern'`` to the loader. This means that
   data that is timestamped on or after ``8:45`` will not seen on that day in the
   simulation. The data will be made available on the next day (:issue:`947`).
+
+* ``BoundColumn.latest`` now returns a
+  :class:`~zipline.pipeline.filters.Filter` for columns of dtype
+  ``bool`` (:issue:`962`).
+
+* Added support for :class:`~zipline.pipeline.factors.Factor` instances with
+  ``int64`` dtype.  :class:`~zipline.pipeline.data.dataset.Column` now requires
+  a ``missing_value`` when dtype is integral. (:issue:`962`)
+
+* It is also now possible to specify custom ``missing_value`` values for
+  ``float``, ``datetime``, and ``bool`` Pipeline terms. (:issue:`962`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -1,0 +1,63 @@
+"""
+Tests BoundColumn attributes and methods.
+"""
+from contextlib2 import ExitStack
+from unittest import TestCase
+
+from pandas import date_range, DataFrame
+from pandas.util.testing import assert_frame_equal
+
+from zipline.pipeline import Pipeline
+from zipline.pipeline.data.testing import TestingDataSet as TDS
+from zipline.utils.test_utils import chrange, temp_pipeline_engine
+
+
+class LatestTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._stack = stack = ExitStack()
+        cls.calendar = cal = date_range('2014', '2015', freq='D', tz='UTC')
+        cls.sids = list(range(5))
+        cls.engine = stack.enter_context(
+            temp_pipeline_engine(
+                cal,
+                cls.sids,
+                random_seed=100,
+                symbols=chrange('A', 'E'),
+            ),
+        )
+        cls.assets = cls.engine._finder.retrieve_all(cls.sids)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stack.close()
+
+    def expected_latest(self, column, slice_):
+        loader = self.engine.get_loader(column)
+        return DataFrame(
+            loader.values(column.dtype, self.calendar, self.sids)[slice_],
+            index=self.calendar[slice_],
+            columns=self.sids,
+        )
+
+    def test_latest(self):
+        pipe = Pipeline(
+            columns={
+                name: getattr(TDS, name + '_col').latest
+                # Intentionally not including int and bool because they're not
+                # yet supported.
+                for name in ('float', 'datetime')
+            }
+        )
+
+        cal_slice = slice(20, 40)
+        dates_to_test = self.calendar[cal_slice]
+        result = self.engine.run_pipeline(
+            pipe,
+            dates_to_test[0],
+            dates_to_test[-1],
+        )
+        float_result = result.float.unstack()
+        expected_float_result = self.expected_latest(TDS.float_col, cal_slice)
+        assert_frame_equal(float_result, expected_float_result)

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -42,13 +42,9 @@ class LatestTestCase(TestCase):
         )
 
     def test_latest(self):
+        columns = TDS.columns
         pipe = Pipeline(
-            columns={
-                name: getattr(TDS, name + '_col').latest
-                # Intentionally not including int and bool because they're not
-                # yet supported.
-                for name in ('float', 'datetime')
-            }
+            columns={c.name: c.latest for c in columns},
         )
 
         cal_slice = slice(20, 40)
@@ -58,6 +54,7 @@ class LatestTestCase(TestCase):
             dates_to_test[0],
             dates_to_test[-1],
         )
-        float_result = result.float.unstack()
-        expected_float_result = self.expected_latest(TDS.float_col, cal_slice)
-        assert_frame_equal(float_result, expected_float_result)
+        for column in columns:
+            float_result = result[column.name].unstack()
+            expected_float_result = self.expected_latest(column, cal_slice)
+            assert_frame_equal(float_result, expected_float_result)

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -38,7 +38,7 @@ class LatestTestCase(TestCase):
         return DataFrame(
             loader.values(column.dtype, self.calendar, self.sids)[slice_],
             index=self.calendar[slice_],
-            columns=self.sids,
+            columns=self.assets,
         )
 
     def test_latest(self):

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -162,7 +162,7 @@ class ConstantInputTestCase(TestCase):
         self.loader = PrecomputedLoader(
             constants=self.constants,
             dates=self.dates,
-            assets=self.asset_ids,
+            sids=self.asset_ids,
         )
 
         self.asset_info = make_simple_equity_info(
@@ -367,7 +367,7 @@ class ConstantInputTestCase(TestCase):
         loader = PrecomputedLoader(
             constants=constants,
             dates=self.dates,
-            assets=self.asset_ids,
+            sids=self.asset_ids,
         )
         engine = SimplePipelineEngine(
             lambda column: loader, self.dates, self.asset_finder,
@@ -415,7 +415,7 @@ class ConstantInputTestCase(TestCase):
     def test_loader_given_multiple_columns(self):
 
         class Loader1DataSet1(DataSet):
-            col1 = Column(float32)
+            col1 = Column(float)
             col2 = Column(float32)
 
         class Loader1DataSet2(DataSet):
@@ -433,12 +433,12 @@ class ConstantInputTestCase(TestCase):
 
         loader1 = RecordingPrecomputedLoader(constants=constants1,
                                              dates=self.dates,
-                                             assets=self.assets)
+                                             sids=self.assets)
         constants2 = {Loader2DataSet.col1: 5,
                       Loader2DataSet.col2: 6}
         loader2 = RecordingPrecomputedLoader(constants=constants2,
                                              dates=self.dates,
-                                             assets=self.assets)
+                                             sids=self.assets)
 
         engine = SimplePipelineEngine(
             lambda column:

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -41,7 +41,7 @@ from zipline.data.us_equity_pricing import BcolzDailyBarReader
 from zipline.finance.trading import TradingEnvironment
 from zipline.lib.adjustment import MULTIPLY
 from zipline.pipeline.loaders.synthetic import (
-    ConstantLoader,
+    PrecomputedLoader,
     NullAdjustmentReader,
     SyntheticDailyBarWriter,
 )
@@ -126,16 +126,16 @@ class ColumnArgs(tuple):
         return hash(frozenset(self))
 
 
-class RecordingConstantLoader(ConstantLoader):
+class RecordingPrecomputedLoader(PrecomputedLoader):
     def __init__(self, *args, **kwargs):
-        super(RecordingConstantLoader, self).__init__(*args, **kwargs)
+        super(RecordingPrecomputedLoader, self).__init__(*args, **kwargs)
 
         self.load_calls = []
 
     def load_adjusted_array(self, columns, dates, assets, mask):
         self.load_calls.append(ColumnArgs(*columns))
 
-        return super(RecordingConstantLoader, self).load_adjusted_array(
+        return super(RecordingPrecomputedLoader, self).load_adjusted_array(
             columns, dates, assets, mask,
         )
 
@@ -159,7 +159,7 @@ class ConstantInputTestCase(TestCase):
         }
         self.asset_ids = [1, 2, 3]
         self.dates = date_range('2014-01', '2014-03', freq='D', tz='UTC')
-        self.loader = ConstantLoader(
+        self.loader = PrecomputedLoader(
             constants=self.constants,
             dates=self.dates,
             assets=self.asset_ids,
@@ -364,7 +364,7 @@ class ConstantInputTestCase(TestCase):
         dates_to_test = self.dates[-30:]
 
         constants = {open_: 1, close: 2, volume: 3}
-        loader = ConstantLoader(
+        loader = PrecomputedLoader(
             constants=constants,
             dates=self.dates,
             assets=self.asset_ids,
@@ -430,14 +430,15 @@ class ConstantInputTestCase(TestCase):
                       Loader1DataSet1.col2: 2,
                       Loader1DataSet2.col1: 3,
                       Loader1DataSet2.col2: 4}
-        loader1 = RecordingConstantLoader(constants=constants1,
-                                          dates=self.dates,
-                                          assets=self.asset_ids)
+
+        loader1 = RecordingPrecomputedLoader(constants=constants1,
+                                             dates=self.dates,
+                                             assets=self.assets)
         constants2 = {Loader2DataSet.col1: 5,
                       Loader2DataSet.col2: 6}
-        loader2 = RecordingConstantLoader(constants=constants2,
-                                          dates=self.dates,
-                                          assets=self.asset_ids)
+        loader2 = RecordingPrecomputedLoader(constants=constants2,
+                                             dates=self.dates,
+                                             assets=self.assets)
 
         engine = SimplePipelineEngine(
             lambda column:

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -19,7 +19,6 @@ from zipline.pipeline.data.testing import TestingDataSet
 from zipline.pipeline.term import AssetExists, NotSpecified
 from zipline.pipeline.expression import NUMEXPR_MATH_FUNCS
 from zipline.utils.numpy_utils import (
-    bool_dtype,
     datetime64ns_dtype,
     float64_dtype,
 )

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -369,7 +369,7 @@ class ObjectIdentityTestCase(TestCase):
                 int_column = Column(dtype=int64_dtype, missing_value=3)
 
         self.assertTrue(
-            str(e.exception.message).startswith(
+            str(e.exception.args[0]).startswith(
                 "Failed to create Column with name 'bad_column'"
             )
         )

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -8,8 +8,9 @@ from unittest import TestCase
 from zipline.errors import (
     DTypeNotSpecified,
     InputTermNotAtomic,
-    InvalidDType,
+    NotDType,
     TermInputsNotSpecified,
+    UnsupportedDType,
     WindowLengthNotSpecified,
 )
 from zipline.pipeline import Factor, Filter, TermGraph
@@ -19,6 +20,7 @@ from zipline.pipeline.term import AssetExists, NotSpecified
 from zipline.pipeline.expression import NUMEXPR_MATH_FUNCS
 from zipline.utils.numpy_utils import (
     bool_dtype,
+    complex128_dtype,
     datetime64ns_dtype,
     float64_dtype,
     int64_dtype,
@@ -332,8 +334,14 @@ class ObjectIdentityTestCase(TestCase):
         with self.assertRaises(DTypeNotSpecified):
             SomeFactorNoDType()
 
-        with self.assertRaises(InvalidDType):
+        with self.assertRaises(NotDType):
             SomeFactor(dtype=1)
+
+        with self.assertRaises(NoDefaultMissingValue):
+            SomeFactor(dtype=int64_dtype)
+
+        with self.assertRaises(UnsupportedDType):
+            SomeFactor(dtype=complex128_dtype)
 
     def test_latest_on_different_dtypes(self):
         factor_dtypes = (int64_dtype, float64_dtype, datetime64ns_dtype)
@@ -350,11 +358,10 @@ class ObjectIdentityTestCase(TestCase):
             # property of correctly handling `NaN`.
             self.assertIs(column.missing_value, column.latest.missing_value)
 
-    def test_failure_timing_on_bad_missing_values(self):
+    def test_failure_timing_on_bad_dtypes(self):
 
         # Just constructing a bad column shouldn't fail.
         Column(dtype=int64_dtype)
-
         with self.assertRaises(NoDefaultMissingValue) as e:
             class BadDataSet(DataSet):
                 bad_column = Column(dtype=int64_dtype)
@@ -366,6 +373,13 @@ class ObjectIdentityTestCase(TestCase):
                 "Failed to create Column with name 'bad_column'"
             )
         )
+
+        Column(dtype=complex128_dtype)
+        with self.assertRaises(UnsupportedDType):
+            class BadDataSetComplex(DataSet):
+                bad_column = Column(dtype=complex128_dtype)
+                float_column = Column(dtype=float64_dtype)
+                int_column = Column(dtype=int64_dtype, missing_value=3)
 
 
 class SubDataSetTestCase(TestCase):

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -12,11 +12,12 @@ from zipline.errors import (
     TermInputsNotSpecified,
     WindowLengthNotSpecified,
 )
-from zipline.pipeline import Factor, TermGraph
+from zipline.pipeline import Factor, Filter, TermGraph
 from zipline.pipeline.data import Column, DataSet
 from zipline.pipeline.term import AssetExists, NotSpecified
 from zipline.pipeline.expression import NUMEXPR_MATH_FUNCS
 from zipline.utils.numpy_utils import (
+    bool_dtype,
     datetime64ns_dtype,
     float64_dtype,
 )
@@ -330,6 +331,17 @@ class ObjectIdentityTestCase(TestCase):
 
         with self.assertRaises(InvalidDType):
             SomeFactor(dtype=1)
+
+    def test_latest_on_different_dtypes(self):
+
+        class D(DataSet):
+            bool_col = Column(dtype=bool_dtype)
+            float_col = Column(dtype=float64_dtype)
+            datetime_col = Column(dtype=datetime64ns_dtype)
+
+        self.assertIsInstance(D.bool_col.latest, Filter)
+        self.assertIsInstance(D.float_col.latest, Factor)
+        self.assertIsInstance(D.datetime_col.latest, Factor)
 
 
 class SubDataSetTestCase(TestCase):

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -11,9 +11,11 @@ from zipline.errors import (
     InvalidDType,
     TermInputsNotSpecified,
     WindowLengthNotSpecified,
+    UnsupportedDataType,
 )
 from zipline.pipeline import Factor, Filter, TermGraph
 from zipline.pipeline.data import Column, DataSet
+from zipline.pipeline.data.testing import TestingDataSet
 from zipline.pipeline.term import AssetExists, NotSpecified
 from zipline.pipeline.expression import NUMEXPR_MATH_FUNCS
 from zipline.utils.numpy_utils import (
@@ -334,14 +336,14 @@ class ObjectIdentityTestCase(TestCase):
 
     def test_latest_on_different_dtypes(self):
 
-        class D(DataSet):
-            bool_col = Column(dtype=bool_dtype)
-            float_col = Column(dtype=float64_dtype)
-            datetime_col = Column(dtype=datetime64ns_dtype)
+        self.assertIsInstance(TestingDataSet.bool_col.latest, Filter)
+        self.assertIsInstance(TestingDataSet.float_col.latest, Factor)
+        self.assertIsInstance(TestingDataSet.datetime_col.latest, Factor)
 
-        self.assertIsInstance(D.bool_col.latest, Filter)
-        self.assertIsInstance(D.float_col.latest, Factor)
-        self.assertIsInstance(D.datetime_col.latest, Factor)
+        # TODO: Support this by allowing users to provide a missing value on
+        # columns.
+        with self.assertRaises(UnsupportedDataType):
+            self.assertIsInstance(TestingDataSet.int_col.latest, Factor)
 
 
 class SubDataSetTestCase(TestCase):

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,0 +1,31 @@
+"""
+Tests for our testing utilities.
+"""
+from itertools import product
+from unittest import TestCase
+from zipline.utils.test_utils import parameter_space
+
+
+class TestParameterSpace(TestCase):
+
+    x_args = [1, 2]
+    y_args = [3, 4]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.xy_invocations = []
+
+    @classmethod
+    def tearDownClass(cls):
+        # This is the only actual test here.
+        assert cls.xy_invocations == list(product(cls.x_args, cls.y_args))
+
+    @parameter_space(x=x_args, y=y_args)
+    def test_xy(self, x, y):
+        self.xy_invocations.append((x, y))
+
+    def test_nothing(self):
+        # Ensure that there's at least one "real" test in the class, or else
+        # our {setUp,tearDown}Class won't be called if, for example,
+        # `parameter_space` returns None.
+        pass

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -14,15 +14,23 @@ class TestParameterSpace(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.xy_invocations = []
+        cls.yx_invocations = []
 
     @classmethod
     def tearDownClass(cls):
         # This is the only actual test here.
         assert cls.xy_invocations == list(product(cls.x_args, cls.y_args))
+        assert cls.yx_invocations == list(product(cls.y_args, cls.x_args))
 
     @parameter_space(x=x_args, y=y_args)
     def test_xy(self, x, y):
         self.xy_invocations.append((x, y))
+
+    @parameter_space(x=x_args, y=y_args)
+    def test_yx(self, y, x):
+        # Ensure that product is called with args in the order that they appear
+        # in the function's parameter list.
+        self.yx_invocations.append((y, x))
 
     def test_nothing(self):
         # Ensure that there's at least one "real" test in the class, or else

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -396,7 +396,7 @@ class DTypeNotSpecified(ZiplineError):
     )
 
 
-class InvalidDType(ZiplineError):
+class NotDType(ZiplineError):
     """
     Raised when a pipeline Term is constructed with a dtype that isn't a numpy
     dtype object.
@@ -404,6 +404,17 @@ class InvalidDType(ZiplineError):
     msg = (
         "{termname} expected a numpy dtype "
         "object for a dtype, but got {dtype} instead."
+    )
+
+
+class UnsupportedDType(ZiplineError):
+    """
+    Raised when a pipeline Term is constructed with a dtype that's not
+    supported.
+    """
+    msg = (
+        "Failed to construct {termname}.\n"
+        "Pipeline terms of dtype {dtype} are not yet supported."
     )
 
 

--- a/zipline/lib/adjusted_array.py
+++ b/zipline/lib/adjusted_array.py
@@ -7,6 +7,8 @@ from numpy import (
     float64,
     int32,
     int64,
+    int16,
+    uint16,
     ndarray,
     uint32,
     uint8,
@@ -29,13 +31,33 @@ from ._int64window import AdjustedArrayWindow as Int64Window
 from ._uint8window import AdjustedArrayWindow as UInt8Window
 
 NOMASK = None
+BOOL_DTYPES = frozenset(
+    map(dtype, [bool_]),
+)
 FLOAT_DTYPES = frozenset(
-    map(dtype, [float32, float64, int32]),
+    map(dtype, [float32, float64]),
 )
 INT_DTYPES = frozenset(
     # NOTE: uint64 not supported because it can't be safely cast to int64.
-    map(dtype, [int32, int64, uint32]),
+    map(dtype, [int16, uint16, int32, int64, uint32]),
 )
+DATETIME_DTYPES = frozenset(
+    map(dtype, ['datetime64[ns]', 'datetime64[D]']),
+)
+REPRESENTABLE_DTYPES = BOOL_DTYPES.union(
+    FLOAT_DTYPES,
+    INT_DTYPES,
+    DATETIME_DTYPES
+)
+
+
+def can_represent_dtype(dtype):
+    """
+    Can we build an AdjustedArray for a baseline of dtype ``dtype``?
+    """
+    return dtype in REPRESENTABLE_DTYPES
+
+
 CONCRETE_WINDOW_TYPES = {
     float64_dtype: Float64Window,
     int64_dtype: Int64Window,

--- a/zipline/lib/rank.pyx
+++ b/zipline/lib/rank.pyx
@@ -58,6 +58,11 @@ def masked_rankdata_2d(ndarray data,
         # the extra work that apply_along_axis does.
         result = apply_along_axis(rankdata, 1, data, method=method)
 
+        # On SciPy >= 0.17, rankdata returns integers for any method except
+        # average.
+        if result.dtype.name != 'float64':
+            result = result.astype('float64')
+
     # rankdata will sort missing values into last place, but we want our nans
     # to propagate, so explicitly re-apply.
     result[missing_locations] = nan

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -9,6 +9,7 @@ from six import (
 
 from zipline.pipeline.term import Term, AssetExists
 from zipline.utils.input_validation import ensure_dtype
+from zipline.utils.numpy_utils import bool_dtype
 from zipline.utils.preprocess import preprocess
 
 
@@ -92,7 +93,10 @@ class BoundColumn(Term):
 
     @property
     def latest(self):
-        from zipline.pipeline.factors import Latest
+        if self.dtype == bool_dtype:
+            from zipline.pipeline.filters import Latest
+        else:
+            from zipline.pipeline.factors import Latest
         return Latest(inputs=(self,), dtype=self.dtype)
 
     def __repr__(self):

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -33,12 +33,21 @@ class _BoundColumnDescr(object):
     """
     Intermediate class that sits on `DataSet` objects and returns memoized
     `BoundColumn` objects when requested.
+
+    This exists so that subclasses of DataSets don't share columns with their
+    parent classes.
     """
     def __init__(self, dtype, name):
         self.dtype = dtype
         self.name = name
 
     def __get__(self, instance, owner):
+        """
+        Produce a concrete BoundColumn object when accessed.
+
+        We don't bind to datasets at class creation time so that subclasses of
+        DataSets produce different BoundColumns.
+        """
         return BoundColumn(
             dtype=self.dtype,
             dataset=owner,

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -15,7 +15,6 @@ from zipline.pipeline.term import (
 from zipline.utils.input_validation import ensure_dtype
 from zipline.utils.numpy_utils import (
     bool_dtype,
-    default_missing_value_for_dtype,
     NoDefaultMissingValue,
 )
 from zipline.utils.preprocess import preprocess

--- a/zipline/pipeline/data/testing.py
+++ b/zipline/pipeline/data/testing.py
@@ -1,0 +1,21 @@
+"""
+Datasets for testing use.
+
+Loaders for datasets in this file can be found in
+zipline.pipeline.data.testing.
+"""
+from .dataset import Column, DataSet
+from zipline.utils.numpy_utils import (
+    bool_dtype,
+    float64_dtype,
+    datetime64ns_dtype,
+    int64_dtype,
+)
+
+
+class TestingDataSet(DataSet):
+
+    bool_col = Column(dtype=bool_dtype)
+    float_col = Column(dtype=float64_dtype)
+    datetime_col = Column(dtype=datetime64ns_dtype)
+    int_col = Column(dtype=int64_dtype)

--- a/zipline/pipeline/data/testing.py
+++ b/zipline/pipeline/data/testing.py
@@ -14,8 +14,11 @@ from zipline.utils.numpy_utils import (
 
 
 class TestingDataSet(DataSet):
+    # Tell nose this isn't a test case.
+    __test__ = False
 
-    bool_col = Column(dtype=bool_dtype)
+    bool_col = Column(dtype=bool_dtype, missing_value=False)
+    bool_col_default_True = Column(dtype=bool_dtype, missing_value=True)
     float_col = Column(dtype=float64_dtype)
     datetime_col = Column(dtype=datetime64ns_dtype)
-    int_col = Column(dtype=int64_dtype)
+    int_col = Column(dtype=int64_dtype, missing_value=0)

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -92,13 +92,13 @@ class SimplePipelineEngine(object):
         An AssetFinder instance.  We depend on the AssetFinder to determine
         which assets are in the top-level universe at any point in time.
     """
-    __slots__ = [
+    __slots__ = (
         '_get_loader',
         '_calendar',
         '_finder',
         '_root_mask_term',
         '__weakref__',
-    ]
+    )
 
     def __init__(self, get_loader, calendar, asset_finder):
         self._get_loader = get_loader

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -38,6 +38,7 @@ from zipline.utils.numpy_utils import (
     bool_dtype,
     datetime64ns_dtype,
     float64_dtype,
+    int64_dtype,
 )
 from zipline.utils.preprocess import preprocess
 
@@ -303,7 +304,7 @@ def function_application(func):
     return mathfunc
 
 
-FACTOR_DTYPES = frozenset([datetime64ns_dtype, float64_dtype])
+FACTOR_DTYPES = frozenset([datetime64ns_dtype, float64_dtype, int64_dtype])
 
 
 class Factor(CompositeTerm):

--- a/zipline/pipeline/filters/__init__.py
+++ b/zipline/pipeline/filters/__init__.py
@@ -1,7 +1,9 @@
 from .filter import Filter, NumExprFilter, PercentileFilter
+from .latest import Latest
 
 __all__ = [
     'Filter',
+    'Latest',
     'NumExprFilter',
     'PercentileFilter',
 ]

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -252,6 +252,52 @@ class PercentileFilter(SingleInputMixin, Filter):
 
 class CustomFilter(PositiveWindowLengthMixin, CustomTermMixin, Filter):
     """
-    Filter analog to ``CustomFactor``.
+    Base class for user-defined Filters.
+
+    Parameters
+    ----------
+    inputs : iterable, optional
+        An iterable of `BoundColumn` instances (e.g. USEquityPricing.close),
+        describing the data to load and pass to `self.compute`.  If this
+        argument is passed to the CustomFilter constructor, we look for a
+        class-level attribute named `inputs`.
+    window_length : int, optional
+        Number of rows to pass for each input.  If this argument is not passed
+        to the CustomFilter constructor, we look for a class-level attribute
+        named `window_length`.
+
+    Notes
+    -----
+    Users implementing their own Filters should subclass CustomFilter and
+    implement a method named `compute` with the following signature:
+
+    .. code-block:: python
+
+        def compute(self, today, assets, out, *inputs):
+           ...
+
+    On each simulation date, ``compute`` will be called with the current date,
+    an array of sids, an output array, and an input array for each expression
+    passed as inputs to the CustomFilter constructor.
+
+    The specific types of the values passed to `compute` are as follows::
+
+        today : np.datetime64[ns]
+            Row label for the last row of all arrays passed as `inputs`.
+        assets : np.array[int64, ndim=1]
+            Column labels for `out` and`inputs`.
+        out : np.array[bool, ndim=1]
+            Output array of the same shape as `assets`.  `compute` should write
+            its desired return values into `out`.
+        *inputs : tuple of np.array
+            Raw data arrays corresponding to the values of `self.inputs`.
+
+    See the documentation for
+    :class:`~zipline.pipeline.factors.factor.CustomFactor` for more details on
+    implementing a custom ``compute`` method.
+
+    See Also
+    --------
+    zipline.pipeline.factors.factor.CustomFactor
     """
     ctx = nullctx()

--- a/zipline/pipeline/filters/latest.py
+++ b/zipline/pipeline/filters/latest.py
@@ -1,0 +1,29 @@
+"""
+Filter that produces the most most recently-known value of a boolean-valued
+Column.
+"""
+from zipline.utils.numpy_utils import bool_dtype
+
+from .filter import CustomFilter
+from ..mixins import SingleInputMixin
+
+
+class Latest(SingleInputMixin, CustomFilter):
+    """
+    Filter producing the most recently-known value of `inputs[0]` on each day.
+    """
+    window_length = 1
+
+    def compute(self, today, assets, out, data):
+        out[:] = data[-1]
+
+    def _validate(self):
+        if self.inputs[0].dtype != bool_dtype:
+            raise TypeError(
+                "{name} expected an input of dtype bool, "
+                "but got {not_bool} instead.".format(
+                    name=type(self).__name__,
+                    not_bool=self.inputs[0].dtype,
+                )
+            )
+        super(Latest, self)._validate()

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -165,6 +165,7 @@ from zipline.pipeline.loaders.utils import (
     normalize_data_query_bounds,
     normalize_timestamp_to_query_time,
 )
+from zipline.pipeline.term import NotSpecified
 from zipline.lib.adjusted_array import AdjustedArray
 from zipline.lib.adjustment import Float64Overwrite
 from zipline.utils.enum import enum
@@ -275,15 +276,21 @@ _new_names = ('BlazeDataSet_%d' % n for n in count())
 
 
 @memoize
-def new_dataset(expr, deltas):
-    """Creates or returns a dataset from a pair of blaze expressions.
+def new_dataset(expr, deltas, missing_values):
+    """
+    Creates or returns a dataset from a pair of blaze expressions.
 
     Parameters
     ----------
     expr : Expr
-       The blaze expression representing the first known values.
+        The blaze expression representing the first known values.
     deltas : Expr
-       The blaze expression representing the deltas to the data.
+        The blaze expression representing the deltas to the data.
+    missing_values : frozenset((name, value) pairs
+        Association pairs column name and missing_value for that column.
+
+        This needs to be a frozenset rather than a dict or tuple of tuples
+        because we want a collection that's unordered but still hashable.
 
     Returns
     -------
@@ -295,9 +302,16 @@ def new_dataset(expr, deltas):
     This function is memoized. repeated calls with the same inputs will return
     the same type.
     """
+    missing_values = dict(missing_values)
     columns = {}
     for name, type_ in expr.dshape.measure.fields:
+        # Don't generate a column for sid or timestamp, since they're
+        # implicitly the labels if the arrays that will be passed to pipeline
+        # Terms.
+        if name in (SID_FIELD_NAME, TS_FIELD_NAME):
+            continue
         try:
+            # TODO: This should support datetime and bool columns.
             if promote(type_, float64, promote_option=False) != float64:
                 raise NotPipelineCompatible()
             if isinstance(type_, Option):
@@ -307,7 +321,10 @@ def new_dataset(expr, deltas):
         except TypeError:
             col = NonNumpyField(name, type_)
         else:
-            col = Column(type_.to_numpy_dtype())
+            col = Column(
+                type_.to_numpy_dtype(),
+                missing_values.get(name, NotSpecified),
+            )
 
         columns[name] = col
 
@@ -473,6 +490,7 @@ def from_blaze(expr,
                loader=None,
                resources=None,
                odo_kwargs=None,
+               missing_values=None,
                no_deltas_rule=no_deltas_rules.warn):
     """Create a Pipeline API object from a blaze expression.
 
@@ -494,6 +512,9 @@ def from_blaze(expr,
         scope for ``bz.compute``.
     odo_kwargs : dict, optional
         The keyword arguments to pass to odo when evaluating the expressions.
+    missing_values : dict[str -> any], optional
+        A dict mapping column names to missing values for those columns.
+        Missing values are required for integral columns.
     no_deltas_rule : no_deltas_rule
         What should happen if ``deltas='auto'`` but no deltas can be found.
         'warn' says to raise a warning but continue.
@@ -583,7 +604,10 @@ def from_blaze(expr,
     _check_resources('deltas', deltas, resources)
 
     # Create or retrieve the Pipeline API dataset.
-    ds = new_dataset(dataset_expr, deltas)
+    if missing_values is None:
+        missing_values = {}
+    ds = new_dataset(dataset_expr, deltas, frozenset(missing_values.items()))
+
     # Register our new dataset with the loader.
     (loader if loader is not None else global_loader)[ds] = ExprData(
         bind_expression_to_resources(dataset_expr, resources),
@@ -1018,7 +1042,8 @@ class BlazeLoader(dict):
                     column_name,
                     asset_idx,
                     sparse_deltas,
-                )
+                ),
+                column.missing_value,
             )
 
 global_loader = BlazeLoader.global_instance()

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -81,12 +81,16 @@ class USEquityPricingLoader(PipelineLoader):
             dates,
             assets,
         )
-        adjusted_arrays = [
-            AdjustedArray(raw_array, mask, col_adjustments)
-            for raw_array, col_adjustments in zip(raw_arrays, adjustments)
-        ]
 
-        return dict(zip(columns, adjusted_arrays))
+        out = {}
+        for c, c_raw, c_adjs in zip(columns, raw_arrays, adjustments):
+            out[c] = AdjustedArray(
+                c_raw.astype(c.dtype),
+                mask,
+                c_adjs,
+                c.missing_value,
+            )
+        return out
 
 
 def _shift_dates(dates, start_date, end_date, shift):

--- a/zipline/pipeline/loaders/frame.py
+++ b/zipline/pipeline/loaders/frame.py
@@ -60,7 +60,7 @@ class DataFrameLoader(PipelineLoader):
 
     def __init__(self, column, baseline, adjustments=None):
         self.column = column
-        self.baseline = baseline.values
+        self.baseline = baseline.values.astype(self.column.dtype)
         self.dates = baseline.index
         self.assets = baseline.columns
 
@@ -171,5 +171,6 @@ class DataFrameLoader(PipelineLoader):
                 # Mask out requested columns/rows that didnt match.
                 mask=(good_assets & good_dates[:, None]) & mask,
                 adjustments=self.format_adjustments(dates, assets),
+                missing_value=column.missing_value,
             ),
         }

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -6,6 +6,7 @@ from bcolz import ctable
 from numpy import (
     arange,
     array,
+    eye,
     float64,
     full,
     iinfo,
@@ -84,6 +85,29 @@ class PrecomputedLoader(PipelineLoader):
                 loader.load_adjusted_array([col], dates, assets, mask)
             )
         return out
+
+
+class EyeLoader(PrecomputedLoader):
+    """
+    A PrecomputedLoader that emits arrays containing 1s on the diagonal and 0s
+    elsewhere.
+
+    Parameters
+    ----------
+    columns : list[BoundColumn]
+        Columns that this loader should know about.
+    dates : iterable[datetime-like]
+        Same as PrecomputedLoader.
+    sids : iterable[int-like]
+        Same as PrecomputedLoader
+    """
+    def __init__(self, columns, dates, sids):
+        shape = (len(dates), len(sids))
+        super(EyeLoader, self).__init__(
+            {column: eye(shape, dtype=column.dtype) for column in columns},
+            dates,
+            sids,
+        )
 
 
 class SyntheticDailyBarWriter(BcolzDailyBarWriter):

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -12,6 +12,7 @@ from numpy import (
     iinfo,
     uint32,
 )
+from numpy.random import RandomState
 from pandas import DataFrame, Timestamp
 from six import iteritems
 from sqlite3 import connect as sqlite3_connect
@@ -23,6 +24,12 @@ from zipline.data.us_equity_pricing import (
     SQLiteAdjustmentReader,
     SQLiteAdjustmentWriter,
     US_EQUITY_PRICING_BCOLZ_COLUMNS,
+)
+from zipline.utils.numpy_utils import (
+    bool_dtype,
+    datetime64ns_dtype,
+    float64_dtype,
+    int64_dtype,
 )
 
 
@@ -108,6 +115,83 @@ class EyeLoader(PrecomputedLoader):
             dates,
             sids,
         )
+
+
+class SeededRandomLoader(PrecomputedLoader):
+    """
+    A PrecomputedLoader that emits arrays randomly-generated with a given seed.
+
+    Parameters
+    ----------
+    seed : int
+        Seed for numpy.random.RandomState.
+    columns : list[BoundColumn]
+        Columns that this loader should know about.
+    dates : iterable[datetime-like]
+        Same as PrecomputedLoader.
+    sids : iterable[int-like]
+        Same as PrecomputedLoader
+    """
+
+    def __init__(self, seed, columns, dates, sids):
+        self._seed = seed
+        super(SeededRandomLoader, self).__init__(
+            {c: self.values(c.dtype, dates, sids) for c in columns},
+            dates,
+            sids,
+        )
+
+    def values(self, dtype, dates, sids):
+        """
+        Make a random array of shape (len(dates), len(sids)) with ``dtype``.
+        """
+        shape = (len(dates), len(sids))
+        return {
+            datetime64ns_dtype: self._datetime_values,
+            float64_dtype: self._float_values,
+            int64_dtype: self._int_values,
+            bool_dtype: self._bool_values,
+        }[dtype](shape)
+
+    @property
+    def state(self):
+        """
+        Make a new RandomState from our seed.
+
+        This ensures that every call to _*_values produces the same output
+        every time for a given SeededRandomLoader instance.
+        """
+        return RandomState(self._seed)
+
+    def _float_values(self, shape):
+        """
+        Return uniformly-distributed floats between -0.0 and 100.0.
+        """
+        return self.state.uniform(low=0.0, high=100.0, size=shape)
+
+    def _int_values(self, shape):
+        """
+        Return uniformly-distributed integers between 0 and 100.
+        """
+        return self.state.random_integers(low=0, high=100, size=shape)
+
+    def _datetime_values(self, shape):
+        """
+        Return uniformly-distributed dates in 2014.
+        """
+        start = Timestamp('2014', tz='UTC').asm8
+        offsets = self.state.random_integers(
+            low=0,
+            high=364,
+            size=shape,
+        ).astype('timedelta64[D]')
+        return start + offsets
+
+    def _bool_values(self, shape):
+        """
+        Return uniformly-distributed True/False values.
+        """
+        return self.state.randn(*shape) < 0
 
 
 class SyntheticDailyBarWriter(BcolzDailyBarWriter):

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -32,31 +32,34 @@ def nanos_to_seconds(nanos):
     return nanos / (1000 * 1000 * 1000)
 
 
-class ConstantLoader(PipelineLoader):
+class PrecomputedLoader(PipelineLoader):
     """
-    Synthetic PipelineLoader that returns a constant value for each column.
+    Synthetic PipelineLoader that uses a pre-computed array for each column.
 
     Parameters
     ----------
-    constants : dict
-        Map from column to value(s) to use for that column.
+    values : dict
+        Map from column to values to use for that column.
         Values can be anything that can be passed as the first positional
-        argument to a DataFrame of the same shape as `mask`.
-    mask : pandas.DataFrame
-        Mask indicating when assets existed.
-        Indices of this frame are used to align input queries.
+        argument to a DataFrame whose indices are ``dates`` and ``sids``
+    dates : iterable[datetime-like]
+        Row labels for input data.  Can be anything that pd.DataFrame will
+        coerce to a DatetimeIndex.
+    sids : iterable[int-like]
+        Column labels for input data.  Can be anything that pd.DataFrame will
+        coerce to an Int64Index.
 
     Notes
     -----
-    Adjustments are unsupported with ConstantLoader.
+    Adjustments are unsupported by this loader.
     """
-    def __init__(self, constants, dates, assets):
+    def __init__(self, constants, dates, sids):
         loaders = {}
         for column, const in iteritems(constants):
             frame = DataFrame(
                 const,
                 index=dates,
-                columns=assets,
+                columns=sids,
                 dtype=column.dtype,
             )
             loaders[column] = DataFrameLoader(

--- a/zipline/pipeline/loaders/testing.py
+++ b/zipline/pipeline/loaders/testing.py
@@ -1,0 +1,21 @@
+"""
+Loaders for zipline.pipeline.data.testing datasets.
+"""
+from .synthetic import EyeLoader, SeededRandomLoader
+from ..data.testing import TestingDataSet
+
+
+def make_eye_loader(dates, sids):
+    """
+    Make a PipelineLoader that emits np.eye arrays for the columns in
+    ``TestingDataSet``.
+    """
+    return EyeLoader(TestingDataSet.columns, dates, sids)
+
+
+def make_seeded_random_loader(seed, dates, sids):
+    """
+    Make a PipelineLoader that emits random arrays seeded with `seed` for the
+    columns in ``TestingDataSet``.
+    """
+    return SeededRandomLoader(seed, TestingDataSet.columns, dates, sids)

--- a/zipline/pipeline/mixins.py
+++ b/zipline/pipeline/mixins.py
@@ -47,6 +47,7 @@ class CustomTermMixin(object):
                 inputs=NotSpecified,
                 window_length=NotSpecified,
                 dtype=NotSpecified,
+                missing_value=NotSpecified,
                 **kwargs):
 
         unexpected_keys = set(kwargs) - set(cls.params)
@@ -64,6 +65,7 @@ class CustomTermMixin(object):
             inputs=inputs,
             window_length=window_length,
             dtype=dtype,
+            missing_value=missing_value,
             **kwargs
         )
 

--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -15,10 +15,13 @@ from toolz import flip
 
 uint8_dtype = dtype('uint8')
 bool_dtype = dtype('bool')
+
 int64_dtype = dtype('int64')
 
 float32_dtype = dtype('float32')
 float64_dtype = dtype('float64')
+
+complex128_dtype = dtype('complex128')
 
 datetime64D_dtype = dtype('datetime64[D]')
 datetime64ns_dtype = dtype('datetime64[ns]')

--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -16,7 +16,10 @@ from toolz import flip
 uint8_dtype = dtype('uint8')
 bool_dtype = dtype('bool')
 int64_dtype = dtype('int64')
+
+float32_dtype = dtype('float32')
 float64_dtype = dtype('float64')
+
 datetime64D_dtype = dtype('datetime64[D]')
 datetime64ns_dtype = dtype('datetime64[ns]')
 
@@ -33,16 +36,27 @@ NaTD = NaT_for_dtype(datetime64D_dtype)
 
 
 _FILLVALUE_DEFAULTS = {
+    bool_dtype: False,
+    float32_dtype: nan,
     float64_dtype: nan,
     datetime64ns_dtype: NaTns,
 }
 
 
-def default_fillvalue_for_dtype(dtype):
+class NoDefaultMissingValue(Exception):
+    pass
+
+
+def default_missing_value_for_dtype(dtype):
     """
     Get the default fill value for `dtype`.
     """
-    return _FILLVALUE_DEFAULTS[dtype]
+    try:
+        return _FILLVALUE_DEFAULTS[dtype]
+    except KeyError:
+        raise NoDefaultMissingValue(
+            "No default value registered for dtype %s." % dtype
+        )
 
 
 def repeat_first_axis(array, count):

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -567,13 +567,18 @@ class SubTestFailures(AssertionError):
 
 
 def subtest(iterator, *_names):
-    """Construct a subtest in a unittest.
+    """
+    Construct a subtest in a unittest.
 
-    This works by decorating a function as a subtest. The test will be run
-    by iterating over the ``iterator`` and *unpacking the values into the
-    function. If any of the runs fail, the result will be put into a set and
-    the rest of the tests will be run. Finally, if any failed, all of the
-    results will be dumped as one failure.
+    Consider using ``zipline.utils.test_utils.parameter_space`` when subtests
+    are constructed over a single input or over the cross-product of multiple
+    inputs.
+
+    ``subtest`` works by decorating a function as a subtest. The decorated
+    function will be run by iterating over the ``iterator`` and *unpacking the
+    values into the function. If any of the runs fail, the result will be put
+    into a set and the rest of the tests will be run. Finally, if any failed,
+    all of the results will be dumped as one failure.
 
     Parameters
     ----------
@@ -615,6 +620,10 @@ def subtest(iterator, *_names):
 
     We cannot use ``unittest2.TestCase.subTest`` because nose, pytest, and
     nose2 do not support ``addSubTest``.
+
+    See Also
+    --------
+    zipline.utils.test_utils.parameter_space
     """
     def dec(f):
         @wraps(f)
@@ -735,11 +744,16 @@ def parameter_space(**params):
 
     Usage
     -----
+    >>> from unittest import TestCase
     >>> class SomeTestCase(TestCase):
     ...     @parameter_space(x=[1, 2], y=[2, 3])
     ...     def test_some_func(self, x, y):
     ...         # Will be called with every possible combination of x and y.
     ...         self.assertEqual(somefunc(x, y), expected_result(x, y))
+
+    See Also
+    --------
+    zipline.utils.test_utils.subtest
     """
     def decorator(f):
 

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -324,7 +324,7 @@ def make_simple_equity_info(sids, start_date, end_date, symbols=None):
     sids : array-like of int
     start_date : pd.Timestamp
     end_date : pd.Timestamp
-    symbols : list, optionaln
+    symbols : list, optional
         Symbols to use for the assets.
         If not provided, symbols are generated from the sequence 'A', 'B', ...
 

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -18,7 +18,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 import pandas as pd
 from pandas.tseries.offsets import MonthBegin
 from six import iteritems, itervalues
-from six.moves import filter
+from six.moves import filter, map
 from sqlalchemy import create_engine
 from toolz import concat
 
@@ -260,10 +260,10 @@ def chrange(start, stop):
 
     Example
     -------
-    >>> list(chrange('A', 'C'))
+    >>> chrange('A', 'C')
     ['A', 'B', 'C']
     """
-    return map(chr, range(ord(start), ord(stop) + 1))
+    return list(map(chr, range(ord(start), ord(stop) + 1)))
 
 
 def make_rotating_equity_info(num_assets,


### PR DESCRIPTION
Adds support for specifying `missing_values` to pipeline `Term`s, and makes `BoundColumn.latest` return a Filter instead of a Factor for expressions of dtype `bool`.

This also removes all implicit coercion behavior from `AdjustedArray`.  PipelineLoaders are now responsible for ensuring that loaded values match the dtypes of requested columns.

@llllllllll tagging you on this since most of the changes here are actually in the `BlazeLoader` and its tests.