### PR TITLE
BUG: Fix OSError when creating sids that share dir

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -300,9 +300,13 @@ class BcolzMinuteBarWriter(object):
         path : string
             The path to rootdir of the new ctable.
         """
-        # Only create the subdir on container creation.
-        sid_dirname = os.path.dirname(path)
-        os.makedirs(sid_dirname)
+        # Only create the containing subdir on creation.
+        # This is not to be confused with the `.bcolz` directory, but is the
+        # directory up one level from the `.bcolz` directories.
+        sid_containing_dirname = os.path.dirname(path)
+        if not os.path.exists(sid_containing_dirname):
+            # Other sids may have already created the containing directory.
+            os.makedirs(sid_containing_dirname)
         initial_array = np.empty(0, np.uint32)
         table = ctable(
             rootdir=path,


### PR DESCRIPTION
Fix a bug where creating a sid bcolz file when the containing directory
was already occupied by a sid caused an OSError on attempt of creating
the directory because it already existed.

e.g. if there were two sids, `1` and `2`. The paths would be
`00/00/000001.bcolz` and `00/00/000002.bcolz` which share the same
directory `00/00`.

Fixed by checking for directory existence before calling `makedirs`.

Add test coverage which exercises writing of sids that are siblings in
the sid directory structure.