### PR TITLE
MAINT: Use metadata method for reader init.

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -454,7 +454,7 @@ class BcolzMinuteBarReader(object):
         """
         self._rootdir = rootdir
 
-        metadata = BcolzMinuteBarMetadata.read(self._rootdir)
+        metadata = self._get_metadata()
 
         self._first_trading_day = metadata.first_trading_day
         self._minute_index = metadata.minute_index


### PR DESCRIPTION
Use the preexisting metadata method when instantiating the minute bar
reader.

An internal sublcass uses the `_get_metadata` method to setup data for
directories that have not used the new writer/reader interface.
(i.e. allows for reader creation when the metadata.json file does not
exist.)