### PR TITLE
BUG: Don't accumulate 0-sized positions.

### DIFF
--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -350,7 +350,10 @@ class FinanceTestCase(TestCase):
             self.assertEqual(len(transactions), expected_txn_count)
 
             cumulative_pos = tracker.position_tracker.positions[sid]
-            self.assertEqual(total_volume, cumulative_pos.amount)
+            if total_volume == 0:
+                self.assertIsNone(cumulative_pos)
+            else:
+                self.assertEqual(total_volume, cumulative_pos.amount)
 
             # the open orders should not contain sid.
             oo = blotter.open_orders

--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -2153,32 +2153,8 @@ trade after cover"""
 
         self.assertEqual(
             len(pp.positions),
-            1,
-            "should be just one position"
-        )
-
-        self.assertEqual(
-            pp.positions[1].sid,
-            short_txn.sid,
-            "position should be in security from the transaction"
-        )
-
-        self.assertEqual(
-            pp.positions[1].amount,
             0,
-            "should have a position of -100 shares"
-        )
-
-        self.assertEqual(
-            pp.positions[1].cost_basis,
-            0,
-            "a covered position should have a cost basis of 0"
-        )
-
-        self.assertEqual(
-            pp.positions[1].last_sale_price,
-            trades[-1].price,
-            "last sale should be price of last trade"
+            "should be zero positions"
         )
 
         self.assertEqual(
@@ -2377,10 +2353,15 @@ shares in position"
                                     self.sim_params.data_frequency)
         pp.position_tracker = pt
 
-        for txn, cb in zip(transactions, cost_bases):
+        for idx, (txn, cb) in enumerate(zip(transactions, cost_bases)):
             pt.execute_transaction(txn)
             pp.handle_execution(txn)
-            self.assertEqual(pp.positions[1].cost_basis, cb)
+
+            if idx == 2:
+                # buy 200, sell 100, sell 100 = 0 shares = no position
+                self.assertNotIn(1, pp.positions)
+            else:
+                self.assertEqual(pp.positions[1].cost_basis, cb)
 
         pp.calculate_performance()
 

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -258,6 +258,19 @@ class PositionTracker(object):
             position = self.positions[sid]
 
         position.update(txn)
+
+        if position.amount == 0:
+            # if this position now has 0 shares, remove it from our internal
+            # bookkeeping.
+            del self.positions[sid]
+
+            try:
+                # if this position exists in our user-facing dictionary,
+                # remove it as well.
+                del self._positions_store[sid]
+            except KeyError:
+                pass
+
         self._update_asset(sid)
 
     def handle_commission(self, sid, cost):


### PR DESCRIPTION
We properly remove empty positions before the user calls `context.portfolio.positions`.

But until the user does that, the empty positions sit around.  And if other internal code needs a list of the positions, they get empty positions.