### PR TITLE
BUG: Allow more than 998 equities for dividends.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -40,12 +40,12 @@ from zipline.assets.asset_writer import (
     check_version_info,
     split_delimited_symbol,
     asset_db_table_names,
-    SQLITE_MAX_VARIABLE_NUMBER,
 )
 from zipline.assets.asset_db_schema import (
     ASSET_DB_VERSION
 )
 from zipline.utils.control_flow import invert
+from zipline.utils.sqlite_utils import group_into_chunks
 
 log = Logger('assets.py')
 
@@ -163,7 +163,7 @@ class AssetFinder(object):
 
         router_cols = self.asset_router.c
 
-        for assets in self._group_into_chunks(missing):
+        for assets in group_into_chunks(missing):
             query = sa.select((router_cols.sid, router_cols.asset_type)).where(
                 self.asset_router.c.sid.in_(map(int, assets))
             )
@@ -175,12 +175,6 @@ class AssetFinder(object):
                 found[sid] = self._asset_type_cache[sid] = None
 
         return found
-
-    @staticmethod
-    def _group_into_chunks(items, chunk_size=SQLITE_MAX_VARIABLE_NUMBER):
-        items = list(items)
-        return [items[x:x+chunk_size]
-                for x in range(0, len(items), chunk_size)]
 
     def group_by_type(self, sids):
         """
@@ -358,7 +352,7 @@ class AssetFinder(object):
         cache = self._asset_cache
         hits = {}
 
-        for assets in self._group_into_chunks(sids):
+        for assets in group_into_chunks(sids):
             # Load misses from the db.
             query = self._select_assets_by_sid(asset_tbl, assets)
 

--- a/zipline/utils/sqlite_utils.py
+++ b/zipline/utils/sqlite_utils.py
@@ -1,0 +1,24 @@
+# Copyright 2016 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from six.moves import range
+
+SQLITE_MAX_VARIABLE_NUMBER = 998
+
+
+def group_into_chunks(items, chunk_size=SQLITE_MAX_VARIABLE_NUMBER):
+    items = list(items)
+    return [items[x:x+chunk_size]
+            for x in range(0, len(items), chunk_size)]


### PR DESCRIPTION
Chunk queries into groups of 998, because of a SQLite limitation on
query size.

Also, point assets module at factored out value and function.