### PR TITLE
Tests for create_transaction using current_dt

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -174,6 +174,29 @@ class SlippageTestCase(TestCase):
             # TODO: Make expected_txn an Transaction object and ensure there
             # is a __eq__ for that class.
             self.assertEquals(expected_txn, txn.__dict__)
+
+            open_orders = [
+                Order(
+                    dt=datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
+                    amount=100,
+                    filled=0,
+                    sid=133
+                )
+            ]
+
+            # Set bar_data to be a minute ahead of last trade.
+            # Volume share slippage should not execute when there is no trade.
+            bar_data = BarData(data_portal,
+                               lambda: self.minutes[1],
+                               'minute')
+
+            orders_txns = list(slippage_model.simulate(
+                bar_data[133],
+                open_orders,
+            ))
+
+            self.assertEquals(len(orders_txns), 0)
+
         finally:
             tempdir.cleanup()
 


### PR DESCRIPTION
With the changes to create_transaction using the current_dt, the `test_perf_tracking` suite became incompatible, because of the change to using the `SidView` `current_dt` instead of the `Event`, the tests now need `BarData`.

Also, add test to `test_slippage` which checks for the case where a transaction would have been created on a bar with no trades (which was also fixed in a previous patch.)