### PR TITLE
condense the blaze query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ test.log
 
 # Packages
 *.egg
+.eggs/*
 *.egg-info
 dist
 build

--- a/etc/requirements_blaze.txt
+++ b/etc/requirements_blaze.txt
@@ -1,3 +1,4 @@
--e git://github.com/quantopian/blaze.git@831116adba808b89f42cef48c7d96cc44603d05a#egg=blaze-dev
--e git://github.com/quantopian/odo.git@4f7f45fb039d89ea101803b95da21fc055901d66#egg=odo-dev
 -e git://github.com/quantopian/datashape.git@9bd8fb970a0fc55e866a0b46b5101c9aa47e24ed#egg=datashape-dev
+-e git://github.com/quantopian/odo.git@4f7f45fb039d89ea101803b95da21fc055901d66#egg=odo-dev
+-e git://github.com/quantopian/blaze.git@0b6e76122a57c7115f18c6fdbd5fbab5501fd486#egg=blaze-dev
+


### PR DESCRIPTION
Make less calls to compute to reduce IO bottlenecks when the expression is bound to a remote data source.

The update to blaze makes `least` work correctly on `pd.Timestamp`: https://github.com/blaze/blaze/pull/1409