### PR TITLE
MAINT: Upgrade Logbook version

### DIFF
--- a/conda/logbook/meta.yaml
+++ b/conda/logbook/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: logbook
-  version: "0.10.0"
+  version: "0.12.5"
 
 source:
-  fn: Logbook-0.10.0.tar.gz
-  url: https://pypi.python.org/packages/source/L/Logbook/Logbook-0.10.0.tar.gz
-  md5: 92439ce6f71f3120d65d84c2a3ab5047
+  fn: Logbook-0.12.5.tar.gz
+  url: https://pypi.python.org/packages/source/L/Logbook/Logbook-0.12.5.tar.gz
+  md5: 1bf64289b9b4cada5a61817c63dd9e82
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -30,11 +30,9 @@ requirements:
   build:
     - python
     - setuptools
-    - six >=1.4.0
 
   run:
     - python
-    - six >=1.4.0
 
 test:
   # Python imports

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -2,7 +2,7 @@
 pip>=7.1.0
 
 # Logging
-Logbook==0.10.0
+Logbook==0.12.5
 
 # Scientific Libraries
 

--- a/zipline/examples/olmar.py
+++ b/zipline/examples/olmar.py
@@ -9,7 +9,7 @@ from zipline.utils.factory import load_from_yahoo
 from zipline.finance import commission
 
 zipline_logging = logbook.NestedSetup([
-    logbook.NullHandler(level=logbook.DEBUG, bubble=True),
+    logbook.NullHandler(),
     logbook.StreamHandler(sys.stdout, level=logbook.INFO),
     logbook.StreamHandler(sys.stderr, level=logbook.ERROR),
 ])


### PR DESCRIPTION
Upgrade Logbook to 0.12.5. This required changing a usage of
`logbook.NullHandler()` which passed `bubble=True`, since
`NullHandler` no longer supports the `bubble` argument.