### PR TITLE
BLD: Use separate travis pip cache subdirs per numpy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,16 @@ matrix:
   fast_finish: true
   include:
   - python: 2.7
-    env: PANDAS_VERSION=0.16.1 NUMPY_VERSION=1.9.2 SCIPY_VERSION=0.15.1
+    env: PANDAS_VERSION=0.16.1 NUMPY_VERSION=1.9.2 SCIPY_VERSION=0.15.1 CACHE_DIR=$HOME/.cache/.pip/pip_np19
   - python: 2.7
-    env: PANDAS_VERSION=0.17.1 NUMPY_VERSION=1.10.2 SCIPY_VERSION=0.16.1
+    env: PANDAS_VERSION=0.17.1 NUMPY_VERSION=1.10.2 SCIPY_VERSION=0.16.1 CACHE_DIR=$HOME/.cache/.pip/pip_np110
   - python: 3.4
-    env: PANDAS_VERSION=0.16.1 NUMPY_VERSION=1.9.2 SCIPY_VERSION=0.15.1
+    env: PANDAS_VERSION=0.16.1 NUMPY_VERSION=1.9.2 SCIPY_VERSION=0.15.1 CACHE_DIR=$HOME/.cache/.pip/pip_np19
   - python: 3.4
-    env: PANDAS_VERSION=0.17.1 NUMPY_VERSION=1.10.2 SCIPY_VERSION=0.16.1
+    env: PANDAS_VERSION=0.17.1 NUMPY_VERSION=1.10.2 SCIPY_VERSION=0.16.1 CACHE_DIR=$HOME/.cache/.pip/pip_np110
+cache:
+  directories:
+    - $HOME/.cache/.pip/
 
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget https://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh; fi
@@ -23,11 +26,11 @@ before_install:
 install:
   - conda create -n testenv --yes -c quantopian pip python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION ta-lib=0.4.8
   - source activate testenv
-  - pip install --upgrade pip coverage coveralls
-  - pip install -r etc/requirements.txt
-  - pip install -r etc/requirements_dev.txt
-  - pip install -r etc/requirements_blaze.txt  # this uses git requirements right now
-  - pip install -e .
+  - pip install --upgrade pip coverage coveralls --cache-dir=$CACHE_DIR
+  - pip install -r etc/requirements.txt --cache-dir=$CACHE_DIR
+  - pip install -r etc/requirements_dev.txt --cache-dir=$CACHE_DIR
+  - pip install -r etc/requirements_blaze.txt --cache-dir=$CACHE_DIR  # this uses git requirements right now
+  - pip install -e . --cache-dir=$CACHE_DIR
 before_script:
   - pip freeze | sort
 script:


### PR DESCRIPTION
Round 1: np 1.9 and np 1.10 jobs will all run with empty caches, each will populate a subdirectory and update the travis cache, last one wins - let's say 1.9.

Round 2: All jobs will run, but the cache will only have 1.9, which will speed up only those jobs. 1.10 will be slower, but will now add its data to the cache and become the last to upload it, now with both 1.9 and 1.10.

Round 3: All jobs can use the cache for a performance gain during installation.