### PR TITLE
Deprecate batch transform

### DIFF
--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -25,6 +25,9 @@ Highlights
 * Zipline now supports ``numpy`` 1.10, ``pandas`` 0.17, and ``scipy`` 0.16
   (:issue:`969`).
 
+* Batch transforms have been deprecated and will be removed in a future release.
+  Using ``history`` is recommended as an alternative.
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/zipline/transforms/batch_transform.py
+++ b/zipline/transforms/batch_transform.py
@@ -34,6 +34,7 @@ from six import (
 
 from zipline.utils.algo_instance import get_algo_instance
 from zipline.utils.data import MutableIndexRollingPanel
+from zipline.utils.deprecate import deprecated
 from zipline.protocol import Event
 
 log = logbook.Logger('BatchTransform')
@@ -151,6 +152,8 @@ class BatchTransform(object):
 
     """
 
+    @deprecated(msg="Batch transforms are deprecated and will be removed"
+                    " in a future release. Please use 'history' instead.")
     def __init__(self,
                  func=None,
                  refresh_period=0,
@@ -161,7 +164,6 @@ class BatchTransform(object):
                  compute_only_full=True,
                  bars='daily',
                  downsample=False):
-
         """Instantiate new batch_transform object.
 
         :Arguments:
@@ -488,9 +490,9 @@ class BatchTransform(object):
 
 def batch_transform(func):
     """Decorator function to use instead of inheriting from BatchTransform.
+
     For an example on how to use this, see the doc string of BatchTransform.
     """
-
     @functools.wraps(func)
     def create_window(*args, **kwargs):
         # passes the user defined function to BatchTransform which it

--- a/zipline/utils/deprecate.py
+++ b/zipline/utils/deprecate.py
@@ -1,0 +1,46 @@
+"""Utilities for marking deprecated functions."""
+# Copyright 2016 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from functools import wraps
+
+
+def deprecated(msg=None, stacklevel=2):
+    """
+    Used to mark a function as deprecated.
+
+    Parameters
+    ----------
+    msg : str
+        The message to display in the deprecation warning.
+    stacklevel : int
+        How far up the stack the warning needs to go, before
+        showing the relevant calling lines.
+    Usage
+    -----
+    @deprecated(msg='function_a is deprecated! Use function_b instead.')
+    def function_a(*args, **kwargs):
+    """
+    def deprecated_dec(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                msg or "Function %s is deprecated." % fn.__name__,
+                category=DeprecationWarning,
+                stacklevel=stacklevel
+            )
+            return fn(*args, **kwargs)
+        return wrapper
+    return deprecated_dec


### PR DESCRIPTION
Deprecating for now, before we rewrite the sample pairtrade algo to use history and then kill batch altogether.
