### PR TITLE
BUG: Ensure consistent ordering of amounts, prices & multipliers

### DIFF
--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -33,6 +33,7 @@ Position Tracking
 
 from __future__ import division
 from math import copysign
+from collections import OrderedDict
 
 from copy import copy
 
@@ -228,7 +229,7 @@ last_sale_price: {last_sale_price}"
         self.__dict__.update(state)
 
 
-class positiondict(dict):
+class positiondict(OrderedDict):
 
     def __missing__(self, key):
         pos = Position(key)


### PR DESCRIPTION
To calculate our position values / exposures, we multiply together the corresponding `amounts`, `last_sale_prices` and `multipliers`. This assumes that these three iterables are in the same order. In fact this is not necessarily the case, because while `multipliers` are stored as an `OrderedDict`, the `amounts` and `last_sale_prices` are lists which are populated by iterating over a regular `dict` (actually a subclass, called `positiondict`), and we cannot be sure of the order in which keys/values are stored within in this `dict`. In particular, the order of this `dict` may change in arbitrary ways when we call `.update()` on it, whereas the ordering of existing elements in the `OrderedDict`s will not change.

We have not previously seen this issue because in the case equities-only algorithms, all the `multipliers` are the same (== 1) and so the order in which they are stored does not matter. This *is* an issue when dealing with mixed equities and futures algorithms, since in the case of futures we would like to [set the positions values to zero](https://github.com/quantopian/zipline/blob/master/zipline/finance/performance/position_tracker.py#L153) (since, unlike equities, you can't sell your positions for cash.) It is also an issue with pure-futures algorithms, since different futures can have different multipliers leading to different exposures.

To resolve this issue, we change `positiondict` so that it subclasses `OrderedDict` rather than just `dict`. Since `self.positions` and `self_position_value_multipliers / self._position_exposure_multipliers` are populated in the same order, we ensure that values from `amounts`, `last_sale_prices` and `_position_value_multipliers` will all now be returned in the same order.

I still need to update our tests the cover the above.