### PR TITLE
PERF: Prefetch daily history windows.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1041,6 +1041,16 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
 
             np.testing.assert_array_equal(window1, [2])
 
+            window1_volume = self.data_portal.get_history_window(
+                [asset],
+                pd.Timestamp("2015-01-05", tz='UTC'),
+                1,
+                "1d",
+                "volume"
+            )[asset]
+
+            np.testing.assert_array_equal(window1_volume, [200])
+
             # straddling the first event
             window2 = self.data_portal.get_history_window(
                 [asset],
@@ -1053,6 +1063,16 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
             # first value should be halved, second value unadjusted
             np.testing.assert_array_equal([1, 3], window2)
 
+            window2_volume = self.data_portal.get_history_window(
+                [asset],
+                pd.Timestamp("2015-01-06", tz='UTC'),
+                2,
+                "1d",
+                "volume"
+            )[asset]
+
+            np.testing.assert_array_equal(window2_volume, [100, 300])
+
             # straddling both events
             window3 = self.data_portal.get_history_window(
                 [asset],
@@ -1063,6 +1083,16 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
             )[asset]
 
             np.testing.assert_array_equal([0.5, 1.5, 4], window3)
+
+            window3_volume = self.data_portal.get_history_window(
+                [asset],
+                pd.Timestamp("2015-01-07", tz='UTC'),
+                3,
+                "1d",
+                "volume"
+            )[asset]
+
+            np.testing.assert_array_equal(window3_volume, [50, 150, 400])
 
     def test_daily_dividends(self):
         # self.DIVIDEND_ASSET had dividends on 1/6 and 1/7

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -498,7 +498,8 @@ class TradingAlgorithm(object):
                 if equities:
                     from zipline.data.us_equity_pricing import \
                         PanelDailyBarReader
-                    equity_daily_reader = PanelDailyBarReader(copy_panel)
+                    equity_daily_reader = PanelDailyBarReader(
+                        self.trading_environment.trading_days, copy_panel)
                 else:
                     equity_daily_reader = None
                 self.data_portal = DataPortal(

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -25,7 +25,7 @@ from six.moves import reduce
 
 from zipline.assets import Asset, Future, Equity
 from zipline.data.us_equity_pricing import NoDataOnDate
-from zipline.pipeline.data.equity_pricing import USEquityPricing
+from zipline.data.us_equity_loader import USEquityHistoryLoader
 
 from zipline.utils import tradingcalendar
 from zipline.utils.memoize import remember_last
@@ -90,6 +90,11 @@ class DataPortal(object):
         self._extra_source_df = None
 
         self._equity_daily_reader = equity_daily_reader
+        if self._equity_daily_reader is not None:
+            self._equity_history_loader = USEquityHistoryLoader(
+                self._equity_daily_reader,
+                self._adjustment_reader
+            )
         self._equity_minute_reader = equity_minute_reader
         self._future_daily_reader = future_daily_reader
         self._future_minute_reader = future_minute_reader
@@ -1069,19 +1074,9 @@ class DataPortal(object):
         if self._equity_daily_reader_array_keys[field] == key:
             return self._equity_daily_reader_array_data[field]
         else:
-            col = getattr(USEquityPricing, field)
-            data = self._equity_daily_reader.load_raw_arrays(
-                [col],
-                dts[0],
-                dts[-1],
-                assets)[0]
-            for i, asset in enumerate(assets):
-                self._apply_all_adjustments(
-                    data[:, i],
-                    asset,
-                    dts,
-                    field,
-                )
+            data = self._equity_history_loader.history(assets,
+                                                       dts,
+                                                       field)
             self._equity_daily_reader_array_keys[field] = key
             self._equity_daily_reader_array_data[field] = data
             return data

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -1,0 +1,235 @@
+# Copyright 2016 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numpy import dtype, around
+
+from six import iteritems
+
+from zipline.pipeline.data.equity_pricing import USEquityPricing
+from zipline.lib._float64window import AdjustedArrayWindow as Float64Window
+from zipline.lib.adjustment import Float64Multiply
+from zipline.utils.cache import CachedObject, Expired
+
+
+class SlidingWindow(object):
+    """
+    Wrapper around an AdjustedArrayWindow which supports monotonically
+    increasing (by datetime) requests for a sized window of data.
+
+    Parameters
+    ----------
+    window : AdjustedArrayWindow
+       Window of pricing data with prefetched values beyond the current
+       simulation dt.
+    cal_start : int
+       Index in the overall calendar at which the window starts.
+    """
+
+    def __init__(self, window, cal_start):
+        self.window = window
+        self.cal_start = cal_start
+        self.current = around(next(window), 3)
+        self.most_recent_ix = self.cal_start
+
+    def get(self, end_ix):
+        """
+        Returns
+        -------
+        out : A np.ndarray of the equity pricing up to end_ix after adjustments
+              and rounding have been applied.
+        """
+        if self.most_recent_ix == end_ix:
+            return self.current
+
+        self.current = around(self.window.seek(end_ix - self.cal_start + 1), 3)
+
+        self.most_recent_ix = end_ix
+        return self.current
+
+
+class USEquityHistoryLoader(object):
+    """
+    Loader for sliding history windows of adjusted US Equity Pricing data.
+
+    Parameters
+    ----------
+    daily_reader : DailyBarReader
+        Reader for daily bars.
+    adjustment_reader : SQLiteAdjustmentReader
+        Reader for adjustment data.
+    """
+
+    def __init__(self, daily_reader, adjustment_reader):
+        self._daily_reader = daily_reader
+        self._calendar = daily_reader._calendar
+        self._adjustments_reader = adjustment_reader
+        self._daily_window_blocks = {}
+
+        self._prefetch_length = 40
+
+    def _get_adjustments_in_range(self, assets, days, field):
+        """
+        Get the Float64Multiply objects to pass to an AdjustedArrayWindow.
+
+        For the use of AdjustedArrayWindow in the loader, which looks back
+        from current simulation time back to a window of data the dictionary is
+        structured with:
+        - the key into the dictionary for adjustments is the location of the
+        day from which the window is being viewed.
+        - the start of all multiply objects is always 0 (in each window all
+          adjustments are overlapping)
+        - the end of the multiply object is the location before the calendar
+          location of the adjustment action, making all days before the event
+          adjusted.
+
+        Parameters
+        ----------
+        assets : iterable of Asset
+            The assets for which to get adjustments.
+
+        days : iterable of datetime64-like
+            The days for which adjustment data is needed.
+        field : str
+            OHLCV field for which to get the adjustments.
+
+        Returns
+        -------
+        out : The adjustments as a dict of loc -> Float64Multiply
+        """
+        sids = {int(asset): i for i, asset in enumerate(assets)}
+        start = days[0]
+        end = days[-1]
+        adjs = {}
+        for sid, i in iteritems(sids):
+            if field != 'volume':
+                mergers = self._adjustments_reader.get_adjustments_for_sid(
+                    'mergers', sid)
+                for m in mergers:
+                    dt = m[0]
+                    if start < dt <= end:
+                        end_loc = days.get_loc(dt)
+                        mult = Float64Multiply(0,
+                                               end_loc - 1,
+                                               i,
+                                               i,
+                                               m[1])
+                        try:
+                            adjs[end_loc].append(mult)
+                        except KeyError:
+                            adjs[end_loc] = [mult]
+                divs = self._adjustments_reader.get_adjustments_for_sid(
+                    'dividends', sid)
+                for d in divs:
+                    dt = d[0]
+                    if start < dt <= end:
+                        end_loc = days.get_loc(dt)
+                        mult = Float64Multiply(0,
+                                               end_loc - 1,
+                                               i,
+                                               i,
+                                               d[1])
+                        try:
+                            adjs[end_loc].append(mult)
+                        except KeyError:
+                            adjs[end_loc] = [mult]
+            splits = self._adjustments_reader.get_adjustments_for_sid(
+                'splits', sid)
+            for s in splits:
+                dt = s[0]
+                if field == 'volume':
+                    ratio = 1.0 / s[1]
+                else:
+                    ratio = s[1]
+                if start < dt <= end:
+                    end_loc = days.get_loc(dt)
+                    mult = Float64Multiply(0,
+                                           end_loc - 1,
+                                           i,
+                                           i,
+                                           ratio)
+                    try:
+                        adjs[end_loc].append(mult)
+                    except KeyError:
+                        adjs[end_loc] = [mult]
+        return adjs
+
+    def _ensure_sliding_window(
+            self, assets, start, end, size, field):
+        assets_key = frozenset(assets)
+        try:
+            block_cache = self._daily_window_blocks[(assets_key, field, size)]
+            try:
+                return block_cache.unwrap(end)
+            except Expired:
+                pass
+        except KeyError:
+            pass
+
+        start_ix = self._calendar.get_loc(start)
+        end_ix = self._calendar.get_loc(end)
+
+        col = getattr(USEquityPricing, field)
+        cal = self._calendar
+        prefetch_end_ix = min(end_ix + self._prefetch_length, len(cal) - 1)
+        prefetch_end = cal[prefetch_end_ix]
+        array = self._daily_reader.load_raw_arrays(
+            [col], start, prefetch_end, assets)[0]
+        days = cal[start_ix:prefetch_end_ix]
+        if self._adjustments_reader:
+            adjs = self._get_adjustments_in_range(assets, days, col)
+        else:
+            adjs = {}
+        if field == 'volume':
+            array = array.astype('float64')
+        dtype_ = dtype('float64')
+
+        window = Float64Window(
+            array,
+            dtype_,
+            adjs,
+            0,
+            size
+        )
+        block = SlidingWindow(window, start_ix)
+        self._daily_window_blocks[(assets_key, field, size)] = CachedObject(
+            block, prefetch_end)
+        return block
+
+    def history(self, assets, dts, field):
+        """
+        A window of pricing data with adjustments applied assuming that the
+        end of the window is the day before the current simulation time.
+
+        Parameters
+        ----------
+        assets : iterable of Assets
+            The assets in the window.
+        dts : iterable of datetime64-like
+            The datetimes for which to fetch data.
+            Makes an assumption that all dts are present and contiguous,
+            in the calendar.
+        field : str
+            The OHLCV field for which to retrieve data.
+
+
+        Returns
+        -------
+        out : np.ndarray with shape(len(days between start, end), len(assets))
+        """
+        start = dts[0]
+        end = dts[-1]
+        size = len(dts)
+        block = self._ensure_sliding_window(assets, start, end, size, field)
+        end_ix = self._calendar.get_loc(end)
+        return block.get(end_ix)

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -619,23 +619,23 @@ class PanelDailyBarReader(DailyBarReader):
     first_trading_day : pd.Timestamp
         The first trading day in the dataset.
     """
-    def __init__(self, panel):
+    def __init__(self, calendar, panel):
         panel = panel.copy()
         if 'volume' not in panel.items:
             # Fake volume if it does not exist.
             panel.loc[:, :, 'volume'] = int(1e9)
 
         self.first_trading_day = panel.major_axis[0]
-        self._calendar = panel.major_axis
+        self._calendar = calendar
 
         self.panel = panel
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
         col_names = [col.name for col in columns]
-        data = self.panel[assets, start_date:end_date, col_names].values
-        if len(data.shape) == 2:
-            data = [data]
-        return data
+        cal = self._calendar
+        index = cal[cal.slice_indexer(start_date, end_date)]
+        result = self.panel.loc[assets, start_date:end_date, col_names]
+        return result.reindex_axis(index, 1).values
 
     def spot_price(self, sid, day, colname):
         """


### PR DESCRIPTION
Use AdjustedArrayWindow to prefetch daily history windows, advancing the
window forward on each call for a new end date of the window.

Locally, on an algorithm with 6 daily windows this speeds up the daily
1d history from 300ms -> 200ms per day, saving about 33%.

The main bottlenecks this addresses is:
- Re-reading the data from the daily bar bcolz files every simulation
day.
- Remove need to do all adjustments and rounding every day.

Also, changed the `load_raw_arrays` in the Panel daily bar reader to
provide nans for missing days, to match the behavior of the bcolz
loader. (Discovered when running test_examples.)

# Other Notes

- The repeated calculation of `size` based on the passed `dts` to history makes me think the interface is not 100% correct here. Perhaps we should be using last_dt and size as the parameter instead? Which would match the actual history calls parameters of `(assets, bar_count, '1d', fields)` more closely.

- This is on the path of speeding up history calls on the lazy-mainline branch, after this the next steps are most likely:
-- addressing `get_minute_window_for_equities` when called in minute mode and with `1d` 
-- Doing a prefetch on minute data.