### PR TITLE
MAINT: rename variables to simplify.

### DIFF
--- a/docs/source/whatsnew/0.8.5.txt
+++ b/docs/source/whatsnew/0.8.5.txt
@@ -16,8 +16,22 @@ None
 
 Enhancements
 ~~~~~~~~~~~~
+* Added new datasets 
+  :class:`~zipline.pipeline.data.buyback_auth.CashBuybackAuthorizations` 
+  and :class:`~zipline.pipeline.data.buyback_auth.ShareBuybackAuthorizations`
+  for use in the Pipeline API.  These datasets provide an abstract interface for
+  adding cash and share buyback authorizations data, respectively, to a new 
+  algorithm. pandas-based reference implementations for these datasets can be found in
+  :mod:`zipline.pipeline.loaders.buyback_auth`, and experimental blaze-based
+  implementations can be found in
+  :mod:`zipline.pipeline.loaders.blaze.buyback_auth`. (:issue:`1022`).
 
-None
+* Added new built-in factors,
+  :class:`zipline.pipeline.factors.BusinessDaysSinceCashBuybackAuth` and
+  :class:`zipline.pipeline.factors.BusinessDaysSinceShareBuybackAuth`.  These
+  factors use the new ``CashBuybackAuthorizations`` and 
+  ``ShareBuybackAuthorizations`` datasets, respectively. (:issue:`1022`).
+
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tests/pipeline/test_buyback_auth.py
+++ b/tests/pipeline/test_buyback_auth.py
@@ -23,8 +23,8 @@ from zipline.pipeline.common import(
 from zipline.pipeline.data import (CashBuybackAuthorizations,
                                    ShareBuybackAuthorizations)
 from zipline.pipeline.factors.events import (
-    BusinessDaysSincePreviousCashBuybackAuth,
-    BusinessDaysSincePreviousShareBuybackAuth
+    BusinessDaysSinceCashBuybackAuth,
+    BusinessDaysSinceShareBuybackAuth
 )
 from zipline.pipeline.loaders.buyback_auth import \
     CashBuybackAuthorizationsLoader, ShareBuybackAuthorizationsLoader
@@ -88,11 +88,11 @@ class CashBuybackAuthLoaderTestCase(TestCase, EventLoaderCommonMixin):
     """
     pipeline_columns = {
         PREVIOUS_BUYBACK_CASH:
-            CashBuybackAuthorizations.previous_value.latest,
+            CashBuybackAuthorizations.cash_amount.latest,
         PREVIOUS_BUYBACK_ANNOUNCEMENT:
-            CashBuybackAuthorizations.previous_announcement_date.latest,
+            CashBuybackAuthorizations.announcement_date.latest,
         DAYS_SINCE_PREV:
-            BusinessDaysSincePreviousCashBuybackAuth(),
+            BusinessDaysSinceCashBuybackAuth(),
     }
 
     @classmethod
@@ -150,11 +150,11 @@ class ShareBuybackAuthLoaderTestCase(TestCase, EventLoaderCommonMixin):
     """
     pipeline_columns = {
         PREVIOUS_BUYBACK_SHARE_COUNT:
-            ShareBuybackAuthorizations.previous_share_count.latest,
+            ShareBuybackAuthorizations.share_count.latest,
         PREVIOUS_BUYBACK_ANNOUNCEMENT:
-            ShareBuybackAuthorizations.previous_announcement_date.latest,
+            ShareBuybackAuthorizations.announcement_date.latest,
         DAYS_SINCE_PREV:
-            BusinessDaysSincePreviousShareBuybackAuth(),
+            BusinessDaysSinceShareBuybackAuth(),
     }
 
     @classmethod

--- a/zipline/pipeline/data/buyback_auth.py
+++ b/zipline/pipeline/data/buyback_auth.py
@@ -11,8 +11,8 @@ class CashBuybackAuthorizations(DataSet):
     Dataset representing dates of recently announced cash buyback
     authorizations.
     """
-    previous_value = Column(float64_dtype)
-    previous_announcement_date = Column(datetime64ns_dtype)
+    cash_amount = Column(float64_dtype)
+    announcement_date = Column(datetime64ns_dtype)
 
 
 class ShareBuybackAuthorizations(DataSet):
@@ -20,5 +20,5 @@ class ShareBuybackAuthorizations(DataSet):
     Dataset representing dates of recently announced share buyback
     authorizations.
     """
-    previous_share_count = Column(float64_dtype)
-    previous_announcement_date = Column(datetime64ns_dtype)
+    share_count = Column(float64_dtype)
+    announcement_date = Column(datetime64ns_dtype)

--- a/zipline/pipeline/factors/events.py
+++ b/zipline/pipeline/factors/events.py
@@ -129,7 +129,7 @@ class BusinessDaysSincePreviousEarnings(BusinessDaysSincePreviousEvents):
     inputs = [EarningsCalendar.previous_announcement]
 
 
-class BusinessDaysSincePreviousCashBuybackAuth(
+class BusinessDaysSinceCashBuybackAuth(
     BusinessDaysSincePreviousEvents
 ):
     """
@@ -138,12 +138,12 @@ class BusinessDaysSincePreviousCashBuybackAuth(
 
     See Also
     --------
-    BusinessDaysSincePreviousCashBuybackAuth
+    zipline.pipeline.factors.BusinessDaysSinceCashBuybackAuth
     """
-    inputs = [CashBuybackAuthorizations.previous_announcement_date]
+    inputs = [CashBuybackAuthorizations.announcement_date]
 
 
-class BusinessDaysSincePreviousShareBuybackAuth(
+class BusinessDaysSinceShareBuybackAuth(
     BusinessDaysSincePreviousEvents
 ):
     """
@@ -153,6 +153,6 @@ class BusinessDaysSincePreviousShareBuybackAuth(
 
     See Also
     --------
-    BusinessDaysSincePreviousShareBuybackAuth
+    zipline.pipeline.factors.BusinessDaysSinceShareBuybackAuth
     """
-    inputs = [ShareBuybackAuthorizations.previous_announcement_date]
+    inputs = [ShareBuybackAuthorizations.announcement_date]

--- a/zipline/pipeline/loaders/buyback_auth.py
+++ b/zipline/pipeline/loaders/buyback_auth.py
@@ -40,17 +40,17 @@ class CashBuybackAuthorizationsLoader(EventsLoader):
         )
 
     @lazyval
-    def previous_value_loader(self):
+    def cash_amount_loader(self):
         return self._previous_event_value_loader(
-            self.dataset.previous_value,
+            self.dataset.cash_amount,
             BUYBACK_ANNOUNCEMENT_FIELD_NAME,
             CASH_FIELD_NAME
         )
 
     @lazyval
-    def previous_announcement_date_loader(self):
+    def announcement_date_loader(self):
         return self._previous_event_date_loader(
-            self.dataset.previous_announcement_date,
+            self.dataset.announcement_date,
             BUYBACK_ANNOUNCEMENT_FIELD_NAME,
         )
 
@@ -83,16 +83,16 @@ class ShareBuybackAuthorizationsLoader(EventsLoader):
         )
 
     @lazyval
-    def previous_share_count_loader(self):
+    def share_count_loader(self):
         return self._previous_event_value_loader(
-            self.dataset.previous_share_count,
+            self.dataset.share_count,
             BUYBACK_ANNOUNCEMENT_FIELD_NAME,
             SHARE_COUNT_FIELD_NAME
         )
 
     @lazyval
-    def previous_announcement_date_loader(self):
+    def announcement_date_loader(self):
         return self._previous_event_date_loader(
-            self.dataset.previous_announcement_date,
+            self.dataset.announcement_date,
             BUYBACK_ANNOUNCEMENT_FIELD_NAME,
         )


### PR DESCRIPTION
Some of the variables related to buyback auth are unnecessarily long; this PR simplifies them.