### PR TITLE
BUG: Fix history crash at data start.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1219,3 +1219,19 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
         # should be two NaNs and two values
         np.testing.assert_almost_equal(
             [0, 0, 200, 300], window)
+
+        # Use a minute to force minute mode.
+        first_minute = self.env.open_and_closes.market_open[
+            self.TRADING_START_DT]
+
+        window = self.data_portal.get_history_window(
+            [self.ASSET2],
+            first_minute,
+            4,
+            "1d",
+            "close"
+        )[self.ASSET2]
+
+        # should be all nans since ASSET2 does not start on first day.
+        np.testing.assert_almost_equal(
+            [np.nan, np.nan, np.nan, np.nan], window)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1207,3 +1207,15 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
         # should be two NaNs and two values
         np.testing.assert_almost_equal(
             [np.nan, np.nan, 2, 3], window)
+
+        window = self.data_portal.get_history_window(
+            [self.ASSET1],
+            second_day,
+            4,
+            "1d",
+            "volume"
+        )[self.ASSET1]
+
+        # should be two NaNs and two values
+        np.testing.assert_almost_equal(
+            [0, 0, 200, 300], window)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1189,3 +1189,21 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
                     last_val = sum(np.array(range(782, 782 + idx + 1)) * 100)
 
                 self.assertEqual(window[-1], last_val)
+
+    def test_history_window_before_first_trading_day(self):
+        # trading_start is 2/3/2014
+        # get a history window that starts before that, and ends after that
+
+        second_day = self.env.next_trading_day(self.TRADING_START_DT)
+
+        window = self.data_portal.get_history_window(
+            [self.ASSET1],
+            second_day,
+            4,
+            "1d",
+            "price"
+        )[self.ASSET1]
+
+        # should be two NaNs and two values
+        np.testing.assert_almost_equal(
+            [np.nan, np.nan, 2, 3], window)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -92,6 +92,7 @@ class DataPortal(object):
         self._equity_daily_reader = equity_daily_reader
         if self._equity_daily_reader is not None:
             self._equity_history_loader = USEquityHistoryLoader(
+                self.env,
                 self._equity_daily_reader,
                 self._adjustment_reader
             )

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -188,11 +188,12 @@ class USEquityHistoryLoader(object):
             td = self.env.trading_days
             offset = td.get_loc(start) - td.get_loc(
                 self._daily_reader.first_trading_day)
-            if end < self._daily_reader.first_trading_day:
-                array = full((size, 1), nan)
+            pre_slice = self._calendar.slice_indexer(start, end)
+            fill_size = pre_slice.stop - pre_slice.start
+            if field != 'volume':
+                pre_array = full((fill_size, 1), nan)
             else:
-                pre_slice = self._calendar.slice_indexer(start, end)
-                pre_array = full((pre_slice.stop - pre_slice.start, 1), nan)
+                pre_array = full((fill_size, 1), 0)
         else:
             offset = 0
             start_ix = self._calendar.get_loc(start)

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numpy import dtype, around
+from numpy import dtype, around, full, nan, concatenate
 
 from six import iteritems
 
@@ -36,10 +36,11 @@ class SlidingWindow(object):
        Index in the overall calendar at which the window starts.
     """
 
-    def __init__(self, window, cal_start):
+    def __init__(self, window, cal_start, offset):
         self.window = window
         self.cal_start = cal_start
         self.current = around(next(window), 3)
+        self.offset = offset
         self.most_recent_ix = self.cal_start
 
     def get(self, end_ix):
@@ -52,7 +53,8 @@ class SlidingWindow(object):
         if self.most_recent_ix == end_ix:
             return self.current
 
-        self.current = around(self.window.seek(end_ix - self.cal_start + 1), 3)
+        target = end_ix - self.cal_start - self.offset + 1
+        self.current = around(self.window.seek(target), 3)
 
         self.most_recent_ix = end_ix
         return self.current
@@ -70,7 +72,8 @@ class USEquityHistoryLoader(object):
         Reader for adjustment data.
     """
 
-    def __init__(self, daily_reader, adjustment_reader):
+    def __init__(self, env, daily_reader, adjustment_reader):
+        self.env = env
         self._daily_reader = daily_reader
         self._calendar = daily_reader._calendar
         self._adjustments_reader = adjustment_reader
@@ -176,16 +179,34 @@ class USEquityHistoryLoader(object):
         except KeyError:
             pass
 
-        start_ix = self._calendar.get_loc(start)
+        # Handle case where data is request before the start of data available
+        # in the daily_reader. In that case, prepend nans until the start
+        # of data.
+        pre_array = None
+        if start < self._daily_reader.first_trading_day:
+            start_ix = 0
+            td = self.env.trading_days
+            offset = td.get_loc(start) - td.get_loc(
+                self._daily_reader.first_trading_day)
+            if end < self._daily_reader.first_trading_day:
+                array = full((size, 1), nan)
+            else:
+                pre_slice = self._calendar.slice_indexer(start, end)
+                pre_array = full((pre_slice.stop - pre_slice.start, 1), nan)
+        else:
+            offset = 0
+            start_ix = self._calendar.get_loc(start)
+
         end_ix = self._calendar.get_loc(end)
 
         col = getattr(USEquityPricing, field)
         cal = self._calendar
         prefetch_end_ix = min(end_ix + self._prefetch_length, len(cal) - 1)
         prefetch_end = cal[prefetch_end_ix]
-        array = self._daily_reader.load_raw_arrays(
-            [col], start, prefetch_end, assets)[0]
+
         days = cal[start_ix:prefetch_end_ix]
+        array = self._daily_reader.load_raw_arrays(
+            [col], days[0], prefetch_end, assets)[0]
         if self._adjustments_reader:
             adjs = self._get_adjustments_in_range(assets, days, col)
         else:
@@ -194,6 +215,9 @@ class USEquityHistoryLoader(object):
             array = array.astype('float64')
         dtype_ = dtype('float64')
 
+        if pre_array is not None:
+            array = concatenate([pre_array, array])
+
         window = Float64Window(
             array,
             dtype_,
@@ -201,7 +225,7 @@ class USEquityHistoryLoader(object):
             0,
             size
         )
-        block = SlidingWindow(window, start_ix)
+        block = SlidingWindow(window, start_ix, offset)
         self._daily_window_blocks[(assets_key, field, size)] = CachedObject(
             block, prefetch_end)
         return block


### PR DESCRIPTION
Fix a bug when history is called in a backtest with a start date near
the first trading day of the daily bars file, where load_raw_arrays
would hit a key error because data was requested which preceded dates
stored in the daily bar reader's calendar.

In the case where the first day is before the daily bar start, truncate
the query to days in the daily bar readers range, and then prepend nans.