### PR TITLE
Ignore missing deltas in pipeline

### DIFF
--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -37,8 +37,11 @@ from zipline.utils.numpy_utils import (
     int64_dtype,
     repeat_last_axis,
 )
-from zipline.utils.test_utils import tmp_asset_finder, make_simple_equity_info
-
+from zipline.utils.test_utils import (
+    tmp_asset_finder,
+    make_simple_equity_info,
+    make_test_handler
+)
 
 nameof = op.attrgetter('name')
 dtypeof = op.attrgetter('dtype')
@@ -1128,3 +1131,82 @@ class BlazeToPipelineTestCase(TestCase):
                 window_length=3,
                 compute_fn=op.itemgetter(-1),
             )
+
+    def test_ignore_nonexistent_delta(self):
+        missing_sid = ord('E')
+        handler = make_test_handler(self)
+        asset_info = asset_infos[0][0]
+        base_dates = pd.DatetimeIndex([
+            pd.Timestamp('2014-01-01'),
+            pd.Timestamp('2014-01-04')
+        ])
+        repeated_dates = base_dates.repeat(4)
+        baseline = pd.DataFrame({
+            'sid': (self.sids + (missing_sid,)) * 2,
+            'value': (0., 1., 2., 3., 1., 2., 3., 4.),
+            'int_value': (0, 1, 2, 3, 1, 2, 3, 4.),
+            'asof_date': repeated_dates,
+            'timestamp': repeated_dates
+        })
+        expr = bz.Data(baseline, name='expr', dshape=self.dshape)
+        deltas = bz.Data(
+            odo(
+                bz.transform(
+                    expr,
+                    value=expr.value + 10,
+                    timestamp=expr.timestamp + timedelta(days=1),
+                ),
+                pd.DataFrame,
+            ),
+            name='delta',
+            dshape=self.dshape,
+        )
+        expected_views = keymap(pd.Timestamp, {
+            '2014-01-03': np.array([[10.0, 11.0, 12.0],
+                                    [10.0, 11.0, 12.0],
+                                    [10.0, 11.0, 12.0]]),
+            '2014-01-06': np.array([[10.0, 11.0, 12.0],
+                                    [10.0, 11.0, 12.0],
+                                    [11.0, 12.0, 13.0]]),
+        })
+        if len(asset_info) == 4:
+            expected_views = valmap(
+                lambda view: np.c_[view, [np.nan, np.nan, np.nan]],
+                expected_views,
+            )
+            expected_output_buffer = [10, 11, 12, np.nan, 11, 12, 13, np.nan]
+        else:
+            expected_output_buffer = [10, 11, 12, 11, 12, 13]
+
+        cal = pd.DatetimeIndex([
+            pd.Timestamp('2014-01-01'),
+            pd.Timestamp('2014-01-02'),
+            pd.Timestamp('2014-01-03'),
+            # omitting the 4th and 5th to simulate a weekend
+            pd.Timestamp('2014-01-06'),
+        ])
+        with handler.applicationbound():
+            with tmp_asset_finder(equities=asset_info) as finder:
+                expected_output = pd.DataFrame(
+                    expected_output_buffer,
+                    index=pd.MultiIndex.from_product((
+                        sorted(expected_views.keys()),
+                        finder.retrieve_all(asset_info.index),
+                    )),
+                    columns=('value',),
+                )
+                self._run_pipeline(
+                    expr,
+                    deltas,
+                    expected_views,
+                    expected_output,
+                    finder,
+                    calendar=cal,
+                    start=cal[2],
+                    end=cal[-1],
+                    window_length=3,
+                    compute_fn=op.itemgetter(-1),
+                )
+            message = handler.records[0].message
+            exp_msg = "Didn't find the following sids in asset index: {}"
+            self.assertIn(exp_msg.format(set([missing_sid])), message)

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -129,7 +129,6 @@ from collections import namedtuple, defaultdict
 from copy import copy
 from functools import partial, reduce
 from itertools import count
-import logbook
 import warnings
 from weakref import WeakKeyDictionary
 
@@ -195,7 +194,6 @@ traversable_nodes = (
 )
 is_invalid_deltas_node = complement(flip(isinstance, valid_deltas_node_types))
 get__name__ = op.attrgetter('__name__')
-log = logbook.Logger('BlazeLoader')
 
 
 class ExprData(namedtuple('ExprData', 'expr deltas odo_kwargs')):
@@ -954,14 +952,10 @@ class BlazeLoader(dict):
                 columns=added_query_fields + list(map(getname, columns)),
             )
         )
+
+        # It's not guaranteed that assets returned by the engine will contain
+        # all sids from the deltas table; filter out such mismatches here.
         if not materialized_deltas.empty and have_sids:
-            missing_sids = materialized_deltas[
-                ~materialized_deltas.sid.isin(assets)
-            ]
-            log.debug(
-                "Didn't find the following sids in asset index: {}".format(
-                    set(missing_sids.sid))
-            )
             materialized_deltas = materialized_deltas[
                 materialized_deltas.sid.isin(assets)
             ]

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -957,7 +957,7 @@ class BlazeLoader(dict):
         # all sids from the deltas table; filter out such mismatches here.
         if not materialized_deltas.empty and have_sids:
             materialized_deltas = materialized_deltas[
-                materialized_deltas.sid.isin(assets)
+                materialized_deltas[SID_FIELD_NAME].isin(assets)
             ]
 
         if data_query_time is not None:

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -197,6 +197,7 @@ is_invalid_deltas_node = complement(flip(isinstance, valid_deltas_node_types))
 get__name__ = op.attrgetter('__name__')
 log = logbook.Logger('BlazeLoader')
 
+
 class ExprData(namedtuple('ExprData', 'expr deltas odo_kwargs')):
     """A pair of expressions and data resources. The expresions will be
     computed using the resources as the starting scope.

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -884,6 +884,13 @@ def parameter_space(**params):
 
 
 def make_test_handler(testcase, *args, **kwargs):
+    """
+    Returns a TestHandler which will be used by the given testcase. This
+    handler can be used to test log messages.
+
+    testcase: unittest.TestCase
+        The test class in which the log handler will be used.
+    """
     handler = TestHandler(*args, **kwargs)
     testcase.addCleanup(handler.close)
     return handler

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -888,8 +888,17 @@ def make_test_handler(testcase, *args, **kwargs):
     Returns a TestHandler which will be used by the given testcase. This
     handler can be used to test log messages.
 
+    Parameters
+    ----------
     testcase: unittest.TestCase
         The test class in which the log handler will be used.
+    *args, **kwargs
+        Forwarded to the new TestHandler object.
+
+    Returns
+    -------
+    handler: logbook.TestHandler
+        The handler to use for the test case.
     """
     handler = TestHandler(*args, **kwargs)
     testcase.addCleanup(handler.close)

--- a/zipline/utils/test_utils.py
+++ b/zipline/utils/test_utils.py
@@ -12,7 +12,7 @@ import shutil
 from string import ascii_uppercase
 import tempfile
 
-from logbook import FileHandler
+from logbook import FileHandler, TestHandler
 from mock import patch
 from numpy.testing import assert_allclose, assert_array_equal
 import numpy as np
@@ -881,3 +881,9 @@ def parameter_space(**params):
         param_sets = product(*(params[name] for name in argnames))
         return subtest(param_sets, *argnames)(f)
     return decorator
+
+
+def make_test_handler(testcase, *args, **kwargs):
+    handler = TestHandler(*args, **kwargs)
+    testcase.addCleanup(handler.close)
+    return handler


### PR DESCRIPTION
This branch addresses an [issue](https://github.com/quantopian/qexec/issues/9196) in which running Pipeline for certain premium datasets for certain date ranges results in a KeyError because there are sids that exist in the databazaar deltas table but that are not returned by the pipeline engine. This fix filters out those sids and logs a message that keeps track of which sids are not found.