### PR TITLE
BUG: Fixes incorrect behaviour in market open and close

### DIFF
--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -191,7 +191,7 @@ class TestEventRule(TestCase):
             super(Always, Always()).should_trigger('a', env=None)
 
 
-def minutes_for_days():
+def minutes_for_days(ordered_days=False):
     """
     500 randomly selected days.
     This is used to make sure our test coverage is unbaised towards any rules.
@@ -204,19 +204,44 @@ def minutes_for_days():
     true.
 
     This returns a generator of tuples each wrapping a single generator.
-    Iterating over this yeilds a single day, iterating over the day yields
+    Iterating over this yields a single day, iterating over the day yields
     the minutes for that day.
     """
     env = TradingEnvironment()
     random.seed('deterministic')
-    return ((env.market_minutes_for_day(random.choice(env.trading_days[:-1])),)
-            for _ in range(500))
+    if ordered_days:
+        # Get a list of 500 trading days, in order. As a performance
+        # optimization in AfterOpen and BeforeClose, we rely on the fact that
+        # the clock only ever moves forward in a simulation. For those cases,
+        # we guarantee that the list of trading days we test is ordered.
+        ordered_day_list = random.sample(list(env.trading_days), 500)
+        ordered_day_list.sort()
+
+        def day_picker(day):
+            return ordered_day_list[day]
+    else:
+        # Other than AfterOpen and BeforeClose, we don't rely on the the nature
+        # of the clock, so we don't care.
+        def day_picker(day):
+            return random.choice(env.trading_days[:-1])
+
+    return ((env.market_minutes_for_day(day_picker(cnt)),)
+            for cnt in range(500))
 
 
 class RuleTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.env = TradingEnvironment()
+        # On the AfterOpen and BeforeClose tests, we want ensure that the
+        # functions are pure, and that running them with the same input will
+        # provide the same output, regardless of whether the function is run 1
+        # or N times. (For performance reasons, we cache some internal state
+        # in AfterOpen and BeforeClose, but we don't want it to affect
+        # purity). Hence, we use the same before_close and after_open across
+        # subtests.
+        cls.before_close = BeforeClose(hours=1, minutes=5)
+        cls.after_open = AfterOpen(hours=1, minutes=5)
         cls.class_ = None  # Mark that this is the base class.
 
     @classmethod
@@ -275,10 +300,10 @@ class TestStatelessRules(RuleTestCase):
         should_trigger = partial(Never().should_trigger, env=self.env)
         self.assertFalse(any(map(should_trigger, ms)))
 
-    @subtest(minutes_for_days(), 'ms')
+    @subtest(minutes_for_days(ordered_days=True), 'ms')
     def test_AfterOpen(self, ms):
         should_trigger = partial(
-            AfterOpen(minutes=5, hours=1).should_trigger,
+            self.after_open.should_trigger,
             env=self.env,
         )
         for m in islice(ms, 64):
@@ -292,11 +317,11 @@ class TestStatelessRules(RuleTestCase):
             # Check the rest of the day.
             self.assertTrue(should_trigger(m))
 
-    @subtest(minutes_for_days(), 'ms')
+    @subtest(minutes_for_days(ordered_days=True), 'ms')
     def test_BeforeClose(self, ms):
         ms = list(ms)
         should_trigger = partial(
-            BeforeClose(hours=1, minutes=5).should_trigger,
+            self.before_close.should_trigger,
             env=self.env
         )
         for m in ms[0:-66]:


### PR DESCRIPTION
Fixes schedule_function's handling of after_open and before_close dates. 
We now look at *this* period start and period end, instead of the next period start and period end. The next period start and period end are implicitly creating state(when we call a rule for the first time, when its `_next_period_start` is None, and then again when its `_next_period_start `has a value). 

As a result we were seeing the following impure behaviour:
```python
In [33]: bc.should_trigger(test_close_time2, env)
Out[33]: True

In [34]: bc.should_trigger(test_close_time2, env)
Out[34]: False

In [35]: bc.should_trigger(test_close_time2, env)
Out[35]: False
```
because of the messed up state, we weren't correctly keeping track of where we were, which led to messed up behaviour with `schedule_function`. We avoid that here by simply keeping track of this period start and end, and updating the period if the date we're on is not the same as the cached date. In tests, we now only create one before_close and one after_open object, so that we can catch any regressions that affect their internal state, instead of creating fresh objects in each subtest that have a good internal state.

There is some performance impact, but we're still doing OK. Here's the code I used to test perf:
**this branch**
```python
In [11]: tdays = env.trading_days[2000:3000]

In [12]: ao = time_rules.market_open(minutes=30)

In [13]: def test_trigger(tdays, rule):
   ....:     for tday in tdays:
   ....:         mins = env.market_minutes_for_day(tday)
   ....:         for min in mins:
   ....:             rule.should_trigger(min, env)
   ....:             

In [14]: %timeit test_trigger(tdays, ao)
1 loops, best of 3: 1.13 s per loop

In [15]: bc = time_rules.market_close(minutes=30)

In [16]: %timeit test_trigger(tdays, ao)
1 loops, best of 3: 1.13 s per loop

In [17]: %timeit test_trigger(tdays, bc)
1 loops, best of 3: 1.07 s per loop
```

**lazy-mainline**
```python
In [1]: def test_trigger(tdays, rule):
    for tday in tdays:
        mins = env.market_minutes_for_day(tday)
        for min in mins:
            rule.should_trigger(min, env)
   ...:             

In [2]: ao = time_rules.market_open(minutes=30)

In [3]: tdays = env.trading_days[2000:3000]

In [4]: %timeit test_trigger(tdays, ao)
1 loops, best of 3: 838 ms per loop

In [5]: bc = time_rules.market_close(minutes=30)

In [6]: %timeit test_trigger(tdays, bc)
1 loops, best of 3: 730 ms per loop
```

**master**
```python
In [1]: def test_trigger(tdays, rule):
    for tday in tdays:
        mins = env.market_minutes_for_day(tday)
        for min in mins:
            rule.should_trigger(min, env)
   ...:             

In [2]: ao = time_rules.market_open(minutes=30)

In [4]: tdays = env.trading_days[2000:3000]

In [5]: %timeit test_trigger(tdays, ao)
1 loops, best of 3: 2.55 s per loop

In [6]: bc = time_rules.market_close(minutes=30)

In [7]: %timeit test_trigger(tdays, bc)
1 loops, best of 3: 2.51 s per loop
```