### PR TITLE
MAINT: Remove notion of "atomic" pipeline terms.

### DIFF
--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from zipline.errors import (
     DTypeNotSpecified,
-    InputTermNotAtomic,
+    WindowedInputToWindowedTerm,
     NotDType,
     TermInputsNotSpecified,
     UnsupportedDType,
@@ -157,7 +157,7 @@ class DependencyResolutionTestCase(TestCase):
         self.assertEqual(graph.extra_rows[bar], 4)
         self.assertEqual(graph.extra_rows[buzz], 4)
 
-    def test_reuse_atomic_terms(self):
+    def test_reuse_loadable_terms(self):
         """
         Test that raw inputs only show up in the dependency graph once.
         """
@@ -174,7 +174,7 @@ class DependencyResolutionTestCase(TestCase):
 
     def test_disallow_recursive_lookback(self):
 
-        with self.assertRaises(InputTermNotAtomic):
+        with self.assertRaises(WindowedInputToWindowedTerm):
             SomeFactor(inputs=[SomeFactor(), SomeDataSet.foo])
 
 

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -347,13 +347,17 @@ class WindowLengthNotPositive(ZiplineError):
     ).strip()
 
 
-class InputTermNotAtomic(ZiplineError):
+class WindowedInputToWindowedTerm(ZiplineError):
     """
-    Raised when a non-atomic term is specified as an input to a Pipeline API
-    term with a lookback window.
+    Raised when a windowed Pipeline API term is specified as an input to
+    another windowed term.
+
+    This is an error because it's generally not safe to compose windowed
+    functions on split/dividend adjusted data.
     """
     msg = (
-        "Can't compute {parent} with non-atomic input {child}."
+        "Can't compute windowed expression {parent} with "
+        "windowed input {child}."
     )
 
 

--- a/zipline/pipeline/classifier.py
+++ b/zipline/pipeline/classifier.py
@@ -2,8 +2,8 @@
 classifier.py
 """
 
-from zipline.pipeline.term import CompositeTerm
+from zipline.pipeline.term import ComputableTerm
 
 
-class Classifier(CompositeTerm):
+class Classifier(ComputableTerm):
     pass

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -8,9 +8,10 @@ from six import (
 )
 
 from zipline.pipeline.term import (
-    Term,
     AssetExists,
+    LoadableTerm,
     NotSpecified,
+    Term,
 )
 from zipline.utils.input_validation import ensure_dtype
 from zipline.utils.numpy_utils import (
@@ -87,7 +88,7 @@ class _BoundColumnDescr(object):
         )
 
 
-class BoundColumn(Term):
+class BoundColumn(LoadableTerm):
     """
     A column of data that's been concretely bound to a particular dataset.
 

--- a/zipline/pipeline/expression.py
+++ b/zipline/pipeline/expression.py
@@ -12,7 +12,7 @@ from numpy import (
     inf,
 )
 
-from zipline.pipeline.term import Term, CompositeTerm
+from zipline.pipeline.term import Term, ComputableTerm
 
 
 _VARIABLE_NAME_RE = re.compile("^(x_)([0-9]+)$")
@@ -164,7 +164,7 @@ def is_comparison(op):
     return op in COMPARISONS
 
 
-class NumericalExpression(CompositeTerm):
+class NumericalExpression(ComputableTerm):
     """
     Term binding to a numexpr expression.
 

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -18,7 +18,7 @@ from zipline.pipeline.mixins import (
     PositiveWindowLengthMixin,
     SingleInputMixin,
 )
-from zipline.pipeline.term import CompositeTerm, NotSpecified
+from zipline.pipeline.term import ComputableTerm, NotSpecified
 from zipline.pipeline.expression import (
     BadBinaryOperator,
     COMPARISONS,
@@ -343,7 +343,7 @@ def if_not_float64_tell_caller_to_use_isnull(f):
 FACTOR_DTYPES = frozenset([datetime64ns_dtype, float64_dtype, int64_dtype])
 
 
-class Factor(CompositeTerm):
+class Factor(ComputableTerm):
     """
     Pipeline API expression producing numerically-valued outputs.
     """

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -19,7 +19,7 @@ from zipline.pipeline.mixins import (
     PositiveWindowLengthMixin,
     SingleInputMixin,
 )
-from zipline.pipeline.term import CompositeTerm
+from zipline.pipeline.term import ComputableTerm
 from zipline.pipeline.expression import (
     BadBinaryOperator,
     FILTER_BINOPS,
@@ -112,7 +112,7 @@ def unary_operator(op):
     return unary_operator
 
 
-class Filter(CompositeTerm):
+class Filter(ComputableTerm):
     """
     Pipeline API expression producing boolean-valued outputs.
     """

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -9,6 +9,8 @@ from six import itervalues, iteritems
 from zipline.utils.memoize import lazyval
 from zipline.pipeline.visualize import display_graph
 
+from .term import LoadableTerm
+
 
 class CyclicDependency(Exception):
     pass
@@ -163,8 +165,8 @@ class TermGraph(DiGraph):
         return iter(self._ordered)
 
     @lazyval
-    def atomic_terms(self):
-        return tuple(term for term in self if term.atomic)
+    def loadable_terms(self):
+        return tuple(term for term in self if isinstance(term, LoadableTerm))
 
     def _add_to_graph(self, term, parents, extra_rows):
         """

--- a/zipline/pipeline/loaders/blaze/buyback_auth.py
+++ b/zipline/pipeline/loaders/blaze/buyback_auth.py
@@ -25,7 +25,7 @@ class BlazeCashBuybackAuthorizationsLoader(BlazeEventsLoader):
     expr : Expr
         The expression representing the data to load.
     resources : dict, optional
-        Mapping from the atomic terms of ``expr`` to actual data resources.
+        Mapping from the loadable terms of ``expr`` to actual data resources.
     odo_kwargs : dict, optional
         Extra keyword arguments to pass to odo when executing the expression.
     data_query_time : time, optional
@@ -97,7 +97,7 @@ class BlazeShareBuybackAuthorizationsLoader(BlazeEventsLoader):
     expr : Expr
         The expression representing the data to load.
     resources : dict, optional
-        Mapping from the atomic terms of ``expr`` to actual data resources.
+        Mapping from the loadable terms of ``expr`` to actual data resources.
     odo_kwargs : dict, optional
         Extra keyword arguments to pass to odo when executing the expression.
     data_query_time : time, optional

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -1059,7 +1059,7 @@ def bind_expression_to_resources(expr, resources):
     expr : bz.Expr
         The expression to which we want to bind resources.
     resources : dict[bz.Symbol -> any]
-        Mapping from the atomic terms of ``expr`` to actual data resources.
+        Mapping from the loadable terms of ``expr`` to actual data resources.
 
     Returns
     -------

--- a/zipline/pipeline/loaders/blaze/earnings.py
+++ b/zipline/pipeline/loaders/blaze/earnings.py
@@ -17,7 +17,7 @@ class BlazeEarningsCalendarLoader(BlazeEventsLoader):
     expr : Expr
         The expression representing the data to load.
     resources : dict, optional
-        Mapping from the atomic terms of ``expr`` to actual data resources.
+        Mapping from the loadable terms of ``expr`` to actual data resources.
     odo_kwargs : dict, optional
         Extra keyword arguments to pass to odo when executing the expression.
     data_query_time : time, optional

--- a/zipline/pipeline/loaders/blaze/events.py
+++ b/zipline/pipeline/loaders/blaze/events.py
@@ -29,7 +29,7 @@ class BlazeEventsLoader(PipelineLoader):
     expr : Expr
         The expression representing the data to load.
     resources : dict, optional
-        Mapping from the atomic terms of ``expr`` to actual data resources.
+        Mapping from the loadable terms of ``expr`` to actual data resources.
     odo_kwargs : dict, optional
         Extra keyword arguments to pass to odo when executing the expression.
     data_query_time : time, optional

--- a/zipline/pipeline/visualize.py
+++ b/zipline/pipeline/visualize.py
@@ -98,7 +98,7 @@ def _render(g, out, format_, include_asset_exists=False):
     graph_attrs = {'rankdir': 'TB', 'splines': 'ortho'}
     cluster_attrs = {'style': 'filled', 'color': 'lightgoldenrod1'}
 
-    in_nodes = g.atomic_terms
+    in_nodes = g.loadable_terms
     out_nodes = list(g.outputs.values())
 
     f = BytesIO()


### PR DESCRIPTION
Replace it by distinguishing between "Loadable" and "Computable".

This is useful because it's now  possible to write computable terms that
don't require  any inputs  (e.g. an `Always`  filter or  an `Everything`
classifier).