### PR TITLE
BUG: proper accounting of leftover_cash for multiple concurrent splits

### DIFF
--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -224,8 +224,11 @@ class PositionTracker(object):
 
         Returns
         -------
-        None
+        int: The leftover cash from fractional sahres after modifying each
+            position.
         """
+        total_leftover_cash = 0
+
         for split in splits:
             sid = split[0]
             if sid in self.positions:
@@ -234,7 +237,9 @@ class PositionTracker(object):
                 position = self.positions[sid]
                 leftover_cash = position.handle_split(sid, split[1])
                 self._update_asset(split[0])
-                return leftover_cash
+                total_leftover_cash += leftover_cash
+
+        return total_leftover_cash
 
     def earn_dividends(self, dividends, stock_dividends):
         """


### PR DESCRIPTION
If there were multiple splits that affected our holdings at the same
time, the leftover cash wasn’t properly being summed.

for https://github.com/quantopian/qexec/issues/9353