### PR TITLE
TST: Update tests to use new data API

### DIFF
--- a/tests/resources/fetcher_inputs/fetcher_test_data.py
+++ b/tests/resources/fetcher_inputs/fetcher_test_data.py
@@ -140,30 +140,6 @@ ibm,4/1/07,0
 ibm,5/1/07,1
 """.strip()
 
-NOMATCH_CSV_DATA = """
-symbol,date,signal
-nomatch,1/1/06,1
-nomatch,2/1/06,0
-nomatch,3/1/06,0
-nomatch,4/1/06,0
-nomatch,5/1/06,1
-nomatch,6/1/06,1
-nomatch,7/1/06,1
-nomatch,8/1/06,1
-nomatch,9/1/06,0
-nomatch,10/1/06,1
-nomatch,11/1/06,1
-nomatch,12/1/06,5
-nomatch,1/1/07,1
-nomatch,2/1/07,0
-nomatch,3/1/07,1
-nomatch,4/1/07,0
-nomatch,5/1/07,1
-PIRS,1/1/06,1
-PIRS,2/1/06,0
-PIRS,3/1/06,0
-""".strip()
-
 CPIAUCSL_DATA = """
 Date,Value
 2007-12-01,211.445

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -284,24 +284,6 @@ def handle_data(algo, data):
             with ZiplineAPI(algo):
                 self.assertIs(sentinel, getattr(zipline.api, name)())
 
-    def test_get_sid(self):
-        algo_text = """
-from zipline.api import sid
-
-def initialize(context):
-    pass
-
-def handle_data(context, data):
-    aapl = data[sid(3)]
-    assert aapl.sid == 3
-"""
-
-        algo = TradingAlgorithm(script=algo_text,
-                                sim_params=self.sim_params,
-                                env=self.env)
-
-        algo.run(self.data_portal)
-
     def test_sid_datetime(self):
         algo_text = """
 from zipline.api import sid, get_datetime
@@ -310,8 +292,8 @@ def initialize(context):
     pass
 
 def handle_data(context, data):
-    aapl = data[sid(1)]
-    assert aapl.datetime == get_datetime()
+    aapl_dt = data.current(sid(1), "last_traded")
+    assert aapl_dt == get_datetime()
 """
 
         algo = TradingAlgorithm(script=algo_text,
@@ -1094,7 +1076,7 @@ def initialize(context):
 def handle_data(context, data):
     if context.incr < context.count:
         order(sid(0), -1000)
-    record(price=data[0].price)
+    record(price=data.current(sid(0), "price"))
 
     context.incr += 1""",
             sim_params=self.sim_params,
@@ -1156,8 +1138,8 @@ def handle_data(context, data):
         # order small lots to be sure the
         # order will fill in a single transaction
         order(sid(0), 5000)
-    record(price=data[0].price)
-    record(volume=data[0].volume)
+    record(price=data.current(sid(0), "price"))
+    record(volume=data.current(sid(0), "volume"))
     record(incr=context.incr)
     context.incr += 1
     """.format(commission_line),

--- a/tests/test_api_shim.py
+++ b/tests/test_api_shim.py
@@ -155,14 +155,20 @@ class TestAPIShim(TestCase):
         """
         Test that the new and old data APIs hit the same code paths.
 
-        We want to ensure that the old data API(data[sid(N)].field)
-        and the new data API(data.current(sid(N), field) hit the same
-        code paths on the DataPortal.
+        We want to ensure that the old data API(data[sid(N)].field and
+        similar)  and the new data API(data.current(sid(N), field) and
+        similar) hit the same code paths on the DataPortal.
         """
-        test_minute = self.env.market_minutes_for_day(
+        test_start_minute = self.env.market_minutes_for_day(
             self.trading_days[0]
         )[1]
-        bar_data = BarData(self.data_portal, lambda: test_minute, "minute")
+        test_end_minute = self.env.market_minutes_for_day(
+            self.trading_days[0]
+        )[-1]
+        bar_data = BarData(
+            self.data_portal,
+            lambda: test_end_minute, "minute"
+        )
         ohlcvp_fields = [
             "open",
             "high",
@@ -171,34 +177,89 @@ class TestAPIShim(TestCase):
             "volume",
             "price",
         ]
-        patch_meth = 'zipline.data.data_portal.DataPortal.get_spot_value'
+        spot_value_meth = 'zipline.data.data_portal.DataPortal.get_spot_value'
 
-        def assert_spot_value_called(fun, field, ts):
+        def assert_get_spot_value_called(fun, field):
             """
-            Assert that spot_value was called during the execution of fun.
+            Assert that get_spot_value was called during the execution of fun.
 
-            Takes in a function fun, a timestamp ts, and a string field.
+            Takes in a function fun and a string field.
             """
-            with patch(patch_meth) as gsv:
+            with patch(spot_value_meth) as gsv:
                 fun()
                 gsv.assert_called_with(
                     self.asset1,
                     field,
-                    test_minute,
+                    test_end_minute,
                     'minute'
                 )
-
+        # Ensure that data.current(sid(n), field) has the same behaviour as
+        # data[sid(n)].field.
         for field in ohlcvp_fields:
-            assert_spot_value_called(
+            assert_get_spot_value_called(
                 lambda: getattr(bar_data[self.asset1], field),
                 field,
-                test_minute,
             )
-            assert_spot_value_called(
+            assert_get_spot_value_called(
                 lambda: bar_data.current(self.asset1, field),
                 field,
-                test_minute,
             )
+
+        history_meth = 'zipline.data.data_portal.DataPortal.get_history_window'
+
+        def assert_get_history_window_called(fun, is_legacy):
+            """
+            Assert that get_history_window was called during fun().
+
+            Takes in a function fun and a boolean is_legacy.
+            """
+            with patch(history_meth) as ghw:
+                fun()
+                # Slightly hacky, but done to get around the fact that
+                # history( explicitly passes an ffill param as the last arg,
+                # while data.history doesn't.
+                if is_legacy:
+                    ghw.assert_called_with(
+                        [self.asset1, self.asset2],
+                        test_end_minute,
+                        5,
+                        "1m",
+                        "volume",
+                        True
+                    )
+                else:
+                    ghw.assert_called_with(
+                        [self.asset1, self.asset2],
+                        test_end_minute,
+                        5,
+                        "1m",
+                        "volume",
+                    )
+
+        test_sim_params = SimulationParameters(
+            period_start=test_start_minute,
+            period_end=test_end_minute,
+            data_frequency="minute",
+            env=self.env
+        )
+
+        history_algorithm = self.create_algo(
+            history_algo,
+            sim_params=test_sim_params
+        )
+        assert_get_history_window_called(
+            lambda: history_algorithm.run(self.data_portal),
+            is_legacy=True
+        )
+        assert_get_history_window_called(
+            lambda: bar_data.history(
+                [self.asset1, self.asset2],
+                "volume",
+                5,
+                "1m"
+            ),
+            is_legacy=False
+        )
 
     def test_iterate_data(self):
         with warnings.catch_warnings(record=True) as w:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -35,7 +35,6 @@ from .resources.fetcher_inputs.fetcher_test_data import (
     IBM_CSV_DATA,
     ANNUAL_AAPL_CSV_DATA,
     AAPL_IBM_CSV_DATA,
-    NOMATCH_CSV_DATA,
     CPIAUCSL_DATA,
     PALLADIUM_DATA,
     FETCHER_UNIVERSE_DATA,
@@ -56,9 +55,6 @@ class FetcherTestCase(TestCase):
         responses.add(responses.GET,
                       'https://fake.urls.com/multi_signal_csv_data.csv',
                       body=MULTI_SIGNAL_CSV_DATA, content_type='text/csv')
-        responses.add(responses.GET,
-                      'https://fake.urls.com/nomatch_csv_data.csv',
-                      body=NOMATCH_CSV_DATA, content_type='text/csv')
         responses.add(responses.GET,
                       'https://fake.urls.com/cpiaucsl_data.csv',
                       body=CPIAUCSL_DATA, content_type='text/csv')

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -139,7 +139,8 @@ cdef class BarData:
         assets : Asset or iterable of Assets
 
         fields : string or iterable of strings.  Valid values are: "price",
-            "last_traded", "open", "high", "low", "close", "volume"
+            "last_traded", "open", "high", "low", "close", "volume", or column
+            names in files read by fetch_csv.
 
         Returns
         -------

--- a/zipline/finance/controls.py
+++ b/zipline/finance/controls.py
@@ -190,7 +190,7 @@ class MaxOrderSize(TradingControl):
         if self.max_shares is not None and abs(amount) > self.max_shares:
             self.fail(asset, amount, _algo_datetime)
 
-        current_asset_price = algo_current_data[asset].price
+        current_asset_price = algo_current_data.current(asset, "price")
         order_value = amount * current_asset_price
 
         too_much_value = (self.max_notional is not None and
@@ -252,7 +252,7 @@ class MaxPositionSize(TradingControl):
         if too_many_shares:
             self.fail(asset, amount, algo_datetime)
 
-        current_price = algo_current_data[asset].price
+        current_price = algo_current_data.current(asset, "price")
         value_post_order = shares_post_order * current_price
 
         too_much_value = (self.max_notional is not None and

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -393,7 +393,8 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
             new_shares = (.001 * self.portfolio.portfolio_value) / price
         elif isinstance(self.sid(0), Future):
             new_shares = (.001 * self.portfolio.portfolio_value) / \
-                (data.current(sid(0), "price") * self.sid(0).contract_multiplier)
+                (data.current(sid(0), "price") *
+                    self.sid(0).contract_multiplier)
 
         new_shares = int(round_if_near_integer(new_shares))
         self.target_shares += new_shares

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -264,7 +264,8 @@ class TestOrderAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['amount'] == \
                 self.incr, "Orders not filled immediately."
             assert self.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
         self.incr += 1
         self.order(self.sid(0), 1)
 
@@ -283,8 +284,8 @@ class TestOrderInstantAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['last_sale_price'] == \
                 self.last_price, "Orders was not filled at last price."
         self.incr += 1
-        self.order_value(self.sid(0), data[0].price)
-        self.last_price = data[0].price
+        self.order_value(self.sid(0), data.current(sid(0), "price"))
+        self.last_price = data.current(sid(0), "price")
 
 
 class TestOrderStyleForwardingAlgorithm(TradingAlgorithm):
@@ -309,7 +310,7 @@ class TestOrderStyleForwardingAlgorithm(TradingAlgorithm):
 
             method_to_check = getattr(self, self.method_name)
             method_to_check(self.sid(133),
-                            data[0].price,
+                            data.current(sid(0), "price"),
                             style=StopLimitOrder(10, 10))
 
             assert len(self.blotter.open_orders[self.sid(133)]) == 1
@@ -332,14 +333,18 @@ class TestOrderValueAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['amount'] == \
                 self.incr, "Orders not filled immediately."
             assert self.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
         self.incr += 2
 
         multiplier = 2.
         if isinstance(self.sid(0), Future):
             multiplier *= self.sid(0).multiplier
 
-        self.order_value(self.sid(0), data[0].price * multiplier)
+        self.order_value(
+            self.sid(0),
+            data.current(sid(0), "price") * multiplier
+        )
 
 
 class TestTargetAlgorithm(TradingAlgorithm):
@@ -355,7 +360,8 @@ class TestTargetAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['amount'] == \
                 self.target_shares, "Orders not filled immediately."
             assert self.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
         self.target_shares = 10
         self.order_target(self.sid(0), self.target_shares)
 
@@ -377,16 +383,17 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['amount'] == \
                 self.target_shares, "Orders not filled immediately."
             assert self.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
 
         self.order_percent(self.sid(0), .001)
 
         if isinstance(self.sid(0), Equity):
-            price = data[0].price
+            price = data.current(sid(0), "price")
             new_shares = (.001 * self.portfolio.portfolio_value) / price
         elif isinstance(self.sid(0), Future):
             new_shares = (.001 * self.portfolio.portfolio_value) / \
-                (data[0].price * self.sid(0).contract_multiplier)
+                (data.current(sid(0), "price") * self.sid(0).contract_multiplier)
 
         new_shares = int(round_if_near_integer(new_shares))
         self.target_shares += new_shares
@@ -417,9 +424,10 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
                 "Orders not filled correctly"
 
             assert self.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
 
-        self.sale_price = data[0].price
+        self.sale_price = data.current(sid(0), "price")
         self.order_target_percent(self.sid(0), .002)
         self.ordered = True
 
@@ -440,16 +448,17 @@ class TestTargetValueAlgorithm(TradingAlgorithm):
             assert self.portfolio.positions[0]['amount'] == \
                 self.target_shares, "Orders not filled immediately."
             assert self.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
 
         self.order_target_value(self.sid(0), 20)
-        self.target_shares = np.round(20 / data[0].price)
+        self.target_shares = np.round(20 / data.current(sid(0), "price"))
 
         if isinstance(self.sid(0), Equity):
-            self.target_shares = np.round(20 / data[0].price)
+            self.target_shares = np.round(20 / data.current(sid(0), "price"))
         if isinstance(self.sid(0), Future):
             self.target_shares = np.round(
-                20 / (data[0].price * self.sid(0).multiplier))
+                20 / (data.current(sid(0), "price") * self.sid(0).multiplier))
 
 
 class FutureFlipAlgo(TestAlgorithm):
@@ -756,7 +765,8 @@ def handle_data_api(context, data):
         assert context.portfolio.positions[0]['amount'] == \
             context.incr, "Orders not filled immediately."
         assert context.portfolio.positions[0]['last_sale_price'] == \
-            data[0].price, "Orders not filled at current price."
+            data.current(sid(0), "price"), \
+            "Orders not filled at current price."
     context.incr += 1
     order(sid(0), 1)
 
@@ -792,7 +802,8 @@ def handle_data(context, data):
         assert context.portfolio.positions[0]['amount'] == \
                 context.incr, "Orders not filled immediately."
         assert context.portfolio.positions[0]['last_sale_price'] == \
-                data[0].price, "Orders not filled at current price."
+                data.current(sid(0), "price"), \
+                "Orders not filled at current price."
     context.incr += 1
     order(sid(0), 1)
 


### PR DESCRIPTION
Updated the tests that were using the old data API. After discussion with @jbredeche a couple of the tests that have use cases we don't really support anymore(`test_get_sid`, for example), have been killed. 

The PR itself is still WIP because I'm adding another commit that tests that the old and new data APIs return identical results for OHLCVP, but this commit itself is ready to be looked at.

UPDATE: Added a test that verifies old and new data APIs both hit the same code path.