### PR TITLE
PERF: Use precalc market minutes.

### DIFF
--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -593,3 +593,11 @@ class AssetDBImpossibleDowngrade(ZiplineError):
         "The existing Asset database is version: {db_version} which is lower "
         "than the desired downgrade version: {desired_version}."
     )
+
+
+class HistoryWindowStartsBeforeData(ZiplineError):
+    msg = (
+        "History window extends beyond environment first date, "
+        "{first_trading_day}. To use history with bar count, {bar_count}, "
+        "start simulation on or after, {suggested_start_day}."
+        )


### PR DESCRIPTION
Also, limit history to dates in trading enviroment.

The main goal of this patch is to speed up repeated history calls by
indexing into a pre-calculated market minute window for all minutes in
the TradingEnvironment's range, instead of calculating the market minute
window every minute.

However after that change, history windows which went before the 'first
trading day' known to the environment would attempt to reach back into
'unknown' territory/dates (i.e. the market minutes for the prepending of
pre-data set days would not be calculated when the TradingEnvironment's
date range is limited to trading days.)

Instead of handling that case, and to simplify the behavior of history
windows, (and not report a window with 'nans', when there were real
world trades.), when the history window goes before the first dataset
day, raise an exception which suggests a date which is far enough past
the first dataset day for the desired history window to retrieve data.