### PR TITLE
FIX: Rollback granularity on fetcher sources to daily

### DIFF
--- a/tests/resources/fetcher_inputs/fetcher_test_data.py
+++ b/tests/resources/fetcher_inputs/fetcher_test_data.py
@@ -60,12 +60,13 @@ aapl,5/1/07,1
 # times are expected in UTC
 AAPL_MINUTE_CSV_DATA = """
 symbol,date,signal
-aapl,1/4/06 4:01PM,-1
-aapl,1/5/06 4:00PM,5
-aapl,1/6/06 9:30AM,6
-aapl,1/9/06 12:01PM,9
+aapl,1/4/06 5:31AM, 1
+aapl,1/4/06 11:30AM, 2
+aapl,1/5/06 5:31AM, 1
+aapl,1/5/06 11:30AM, 3
+aapl,1/9/06 5:31AM, 1
+aapl,1/9/06 11:30AM, 4
 """.strip()
-
 
 IBM_CSV_DATA = """
 symbol,date,signal

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -483,9 +483,7 @@ cdef class BarData:
 
     @property
     def fetcher_assets(self):
-        return self.data_portal.get_fetcher_assets(
-            normalize_date(self.simulation_dt_func())
-        )
+        return self.data_portal.get_fetcher_assets(self.simulation_dt_func())
 
     property _handle_non_market_minutes:
         def __set__(self, val):


### PR DESCRIPTION
For every fetcher source, take the last signal on a given day for
a given asset or data source as the signal for the entire day