### PR TITLE
DEV: Make all the data.* methods work for non-market-minutes by using the last market close

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -17,6 +17,7 @@ from copy import copy
 
 import pytz
 import pandas as pd
+from contextlib2 import ExitStack
 from pandas.tseries.tools import normalize_date
 import numpy as np
 
@@ -30,7 +31,7 @@ from six import (
     string_types,
 )
 
-
+from zipline._protocol import handle_non_market_minutes
 from zipline.data.data_portal import DataPortal
 from zipline.errors import (
     AttachPipelineAfterInitialize,
@@ -347,7 +348,9 @@ class TradingAlgorithm(object):
         if self._before_trading_start is None:
             return
 
-        self._before_trading_start(self, data)
+        with handle_non_market_minutes(data) if \
+                self.data_frequency == "minute" else ExitStack():
+            self._before_trading_start(self, data)
 
     def handle_data(self, data):
         self._handle_data(self, data)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -139,6 +139,8 @@ class DataPortal(object):
         }
         self._equity_daily_reader_array_data = {}
 
+        self._in_bts = False
+
     def handle_extra_source(self, source_df, sim_params):
         """
         Extra sources always have a sid column.
@@ -471,8 +473,9 @@ class DataPortal(object):
         if column == "volume":
             if result == 0:
                 return 0
-        elif not ffill and np.isnan(result):
-            return np.nan
+        elif not ffill or not np.isnan(result):
+            # if we're not forward filling, or we found a result, return it
+            return result
 
         # we are looking for price, and didn't find one. have to go hunting.
         last_traded_dt = \
@@ -497,8 +500,10 @@ class DataPortal(object):
 
         # the value we found came from a different day, so we have to adjust
         # the data if there are any adjustments on that day barrier
-        return self._get_adjusted_value(asset, column, last_traded_dt, dt,
-                                        "minute", spot_value=result)
+        return self._get_adjusted_value(
+            asset, column, last_traded_dt,
+            dt, "minute", spot_value=result
+        )
 
     def _get_daily_data(self, asset, column, dt):
         if column == "last_traded":

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -32,7 +32,7 @@ from zipline.assets.asset_writer import (
 from zipline.errors import (
     NoFurtherDataError
 )
-
+from zipline.utils.memoize import remember_last
 
 log = logbook.Logger('Trading')
 
@@ -375,6 +375,7 @@ class TradingEnvironment(object):
         # then return the open of the *next* trading day.
         return self.next_open_and_close(start)[0]
 
+    @remember_last
     def previous_market_minute(self, start):
         """
         Get the next market minute before @start. This is either the immediate

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -57,9 +57,8 @@ class AlgorithmSimulator(object):
         # Snapshot Setup
         # ==============
 
-        # The algorithm's data as of our most recent event.
-        # We want an object that will have empty objects as default
-        # values on missing keys.
+        # This object is the way that user algorithms interact with OHLCV data,
+        # fetcher data, and some API methods like `data.can_trade`.
         self.current_data = self._create_bar_data(universe_func)
 
         # We don't have a datetime for the current snapshot until we


### PR DESCRIPTION
Give responsibility of altering datetimes on the fly to `BarData`, so that `DataPortal` is unsullied.

