### PR TITLE
ENH: Speedups by moving computation-heavy things to Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,10 @@ ext_modules = [
     Extension('zipline.data._adjustments', ['zipline/data/_adjustments.pyx']),
     Extension('zipline._protocol', ['zipline/_protocol.pyx']),
     Extension('zipline.gens.sim_engine', ['zipline/gens/sim_engine.pyx']),
+    Extension(
+        'zipline.data._minute_bar_internal',
+        ['zipline/data/_minute_bar_internal.pyx']
+    )
 ]
 
 

--- a/zipline/data/_minute_bar_internal.pyx
+++ b/zipline/data/_minute_bar_internal.pyx
@@ -1,0 +1,123 @@
+from numpy cimport ndarray, long_t
+from numpy import searchsorted
+cimport cython
+
+from bcolz.carray_ext cimport carray
+
+cdef inline int int_min(int a, int b): return a if a <= b else b
+
+@cython.cdivision(True)
+def minute_value(ndarray[long_t, ndim=1] market_opens,
+                 Py_ssize_t pos,
+                 short minutes_per_day):
+    """
+    Finds the value of the minute represented by `pos` in the given array of
+    market opens.
+
+    Parameters
+    ----------
+    market_opens: numpy array of ints
+        Market opens, in minute epoch values.
+
+    pos: int
+        The index of the desired minute.
+
+    minutes_per_day: int
+        The number of minutes per day (e.g. 390 for NYSE).
+
+    Returns
+    -------
+    int: The minute epoch value of the desired minute.
+    """
+    cdef short q, r
+
+    q = cython.cdiv(pos, minutes_per_day)
+    r = cython.cmod(pos, minutes_per_day)
+
+    return market_opens[q] + r
+
+def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
+                            long_t minute_val,
+                            short minutes_per_day):
+    """
+    Finds the position of a given minute in the given array of market opens.
+
+    Parameters
+    ----------
+    market_opens: numpy array of ints
+        Market opens, in minute epoch values.
+
+    minute_val: int
+        The desired minute, as a minute epoch.
+
+    minutes_per_day: int
+        The number of minutes per day (e.g. 390 for NYSE).
+
+    Returns
+    -------
+    int: The position of the given minute in the market opens array.
+    """
+    cdef Py_ssize_t market_open_loc, market_open, delta
+
+    market_open_loc = \
+        searchsorted(market_opens, minute_val, side='right') - 1
+    market_open = market_opens[market_open_loc]
+    delta = minute_val - market_open
+
+    return (market_open_loc * minutes_per_day) + delta
+
+def find_last_traded_position_internal(
+        ndarray[long_t, ndim=1] market_opens,
+        long_t end_minute,
+        long_t start_minute,
+        carray volumes,
+        short minutes_per_day):
+
+    """
+    Finds the position of the last traded minute for the given volumes array.
+
+    Parameters
+    ----------
+    market_opens: numpy array of ints
+        Market opens, in minute epoch values.
+
+    end_minute: int
+        The minute from which to start looking backwards, as a minute epoch.
+
+    start_minute: int
+        The asset's start date, as a minute epoch.  Acts as the bottom limit of
+        how far we can look backwards.
+
+    volumes: bcolz carray
+        The volume history for the given asset.
+
+    minutes_per_day: int
+        The number of minutes per day (e.g. 390 for NYSE).
+
+    Returns
+    -------
+    int: The position of the last traded minute, starting from `minute_val`
+    """
+    cdef Py_ssize_t minute_pos, current_minute
+
+    minute_pos = int_min(
+        find_position_of_minute(market_opens, end_minute, minutes_per_day),
+        len(volumes) - 1
+    )
+
+    while minute_pos >= 0:
+        current_minute = minute_value(
+            market_opens, minute_pos, minutes_per_day
+        )
+
+        if current_minute < start_minute:
+            return -1
+
+        if volumes[minute_pos] != 0:
+            return minute_pos
+
+        minute_pos -= 1
+
+    # we've gone to the beginning of this asset's range, and still haven't
+    # found a trade event
+    return -1

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -20,8 +20,13 @@ from os.path import join
 import json
 import os
 import pandas as pd
+from zipline.gens.sim_engine import NANOS_IN_MINUTE
 
-from zipline.utils.memoize import remember_last
+from zipline.data._minute_bar_internal import (
+    minute_value,
+    find_position_of_minute,
+    find_last_traded_position_internal
+)
 
 US_EQUITIES_MINUTES_PER_DAY = 390
 
@@ -519,7 +524,11 @@ class BcolzMinuteBarReader(object):
         metadata = self._get_metadata()
 
         self._first_trading_day = metadata.first_trading_day
-        self._minute_index = metadata.minute_index
+
+        # store a list of "minute epoch" values
+        self._minute_value_index = \
+            metadata.minute_index.astype('datetime64[m]').astype(int)
+
         self._ohlc_inverse = 1.0 / metadata.ohlc_ratio
 
         self._carrays = {
@@ -601,32 +610,29 @@ class BcolzMinuteBarReader(object):
 
     def _find_last_traded_position(self, asset, dt):
         volumes = self._open_minute_file('volume', asset)
-        start_date = asset.start_date
+        start_date_minutes = asset.start_date.value / NANOS_IN_MINUTE
+        dt_minutes = dt.value / NANOS_IN_MINUTE
 
-        if dt < start_date:
+        if dt_minutes < start_date_minutes:
             return -1
 
-        minute_pos = min(self._find_position_of_minute(dt), len(volumes) - 1)
-
-        while minute_pos >= 0:
-            dt = self._pos_to_minute(minute_pos)
-            if dt < start_date:
-                return -1
-            if volumes[minute_pos] != 0:
-                return minute_pos
-            minute_pos -= 1
-
-        # we've gone to the beginning of this asset's range, and still haven't
-        # found a trade event
-        return -1
+        return find_last_traded_position_internal(
+            self._minute_value_index,
+            dt_minutes,
+            start_date_minutes,
+            volumes,
+            US_EQUITIES_MINUTES_PER_DAY
+        )
 
     def _pos_to_minute(self, pos):
-        # TODO: Make configurable.
-        q, r = divmod(pos, 390)
-        minute = self._minute_index[q] + np.timedelta64(int(r), 'm')
-        return pd.Timestamp(minute, tz='UTC')
+        minute_epoch = minute_value(
+            self._minute_value_index,
+            pos,
+            US_EQUITIES_MINUTES_PER_DAY
+        )
 
-    @remember_last
+        return pd.Timestamp(minute_epoch, tz='UTC', unit="m")
+
     def _find_position_of_minute(self, minute_dt):
         """
         Internal method that returns the position of the given minute in the
@@ -643,18 +649,14 @@ class BcolzMinuteBarReader(object):
 
         Returns
         -------
-        out : int
-
-        The position of the given minute in the list of all trading minutes
-        since market open on the first trading day.
+        int: The position of the given minute in the list of all trading
+        minutes since market open on the first trading day.
         """
 
-        # This method will return an inaccurate value when the minute_dt is
-        # not a trading minute (midnight, for example)
-        minute = minute_dt.asm8.astype('datetime64[m]')
-        # TODO: Get better structure for this.
-        mo_loc = np.searchsorted(self._minute_index, minute,
-                                 side='right') - 1
-        mo = self._minute_index[mo_loc]
-        delta = minute - mo
-        return mo_loc * 390 + delta.astype('int')
+        # NOTE: This method will return an inaccurate value when the minute_dt
+        # is not a trading minute (midnight, for example)
+        return find_position_of_minute(
+            self._minute_value_index,
+            minute_dt.value / NANOS_IN_MINUTE,
+            US_EQUITIES_MINUTES_PER_DAY
+        )


### PR DESCRIPTION
Moving a bunch of arithmetic-heavy work to Cython takes this algorithm, on my machine (in qprof) from ~46 seconds to ~29 seconds:

```
def initialize(context):
    pass

def before_trading_start(context, data):
	data.current(sid(24), "high")

def handle_data(context, data):
	data.current(sid(24), "price")
```

(2012-01-04 to 2014-01-03, 1M, minutely)

the difference is much more pronounced with even more illiquid securities.  I'll have more data tomorrow.