### PR TITLE
BUG: Fix '1d' history for last day in slot.

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -59,6 +59,362 @@ OHLCVP_FIELDS = frozenset([
 HISTORY_FREQUENCIES = set(["1m", "1d"])
 
 
+class DailyHistoryAggregator(object):
+    """
+    Converts minute pricing data into a daily summary, to be used for the
+    last slot in a call to history with a frequency of `1d`.
+
+    This summary is the same as a daily bar rollup of minute data, with the
+    distinction that the summary is truncated to the `dt` requested.
+    i.e. the aggregation slides forward during a the course of simulation day.
+
+    Provides aggregation for `open`, `high`, `low`, `close`, and `volume`.
+    The aggregation rules for each price type is documented in their respective
+
+    """
+
+    def __init__(self, market_opens, minute_reader):
+        self._market_opens = market_opens
+        self._minute_reader = minute_reader
+
+        # The caches are structured as (date, market_open, entries), where
+        # entries is a dict of asset -> (last_visited_dt, value)
+        #
+        # Whenever an aggregation method determines the current value,
+        # the entry for the respective asset should be overwritten with a new
+        # entry for the current dt.value (int) and aggregation value.
+        #
+        # When the requested dt's date is different from date the cache is
+        # flushed, so that the cache entries do not grow unbounded.
+        #
+        # Example cache:
+        # cache = (date(2016, 3, 17),
+        #          pd.Timestamp('2016-03-17 13:31', tz='UTC'),
+        #          {
+        #              1: (1458221460000000000, np.nan),
+        #              2: (1458221460000000000, 42.0),
+        #         })
+        self._opens_cache = None
+        self._highs_cache = None
+        self._lows_cache = None
+        self._closes_cache = None
+        self._volumes_cache = None
+
+        # The int value is used for deltas to avoid extra computation from
+        # creating new Timestamps.
+        self._one_min = pd.Timedelta('1 min').value
+
+    def opens(self, assets, dt):
+        """
+        The open field's aggregation returns the first value that occurs
+        for the day, if there has been no data on or before the `dt` the open
+        is `nan`.
+
+        Once the first non-nan open is seen, that value remains constannt per
+        asset for the remainder of the day.
+
+        Returns
+        -------
+        np.array with dtype=float64, in order of assets parameter.
+        """
+        date = dt.date()
+        dt_value = dt.value
+        if self._opens_cache is None or self._opens_cache[0] != date:
+            market_open = self._market_opens.loc[date]
+            self._opens_cache = (dt.date(), market_open, {})
+
+        _, market_open, entries = self._opens_cache
+        opens = []
+        if dt != market_open:
+            prev_dt = dt_value - self._one_min
+        else:
+            prev_dt = None
+
+        for asset in assets:
+            if prev_dt is None:
+                val = self._minute_reader.get_value(asset, dt, 'open')
+                entries[asset] = (dt_value, val)
+                opens.append(val)
+                continue
+            else:
+                try:
+                    last_visited_dt, first_open = entries[asset]
+                    if not pd.isnull(first_open):
+                        opens.append(first_open)
+                        entries[asset] = (dt_value, first_open)
+                        continue
+                    else:
+                        after_last = pd.Timestamp(
+                            last_visited_dt + self._one_min, tz='UTC')
+                        window = self._minute_reader.unadjusted_window(
+                            ['open'], after_last, dt, [asset])[0]
+                        nonnan = window[~pd.isnull(window)]
+                        if len(nonnan):
+                            val = nonnan[0]
+                        else:
+                            val = np.nan
+                        entries[asset] = (dt_value, val)
+                        opens.append(val)
+                        continue
+                except KeyError:
+                    window = self._minute_reader.unadjusted_window(
+                        ['open'], market_open, dt, [asset])[0]
+                    nonnan = window[~pd.isnull(window)]
+                    if len(nonnan):
+                        val = nonnan[0]
+                    else:
+                        val = np.nan
+                    entries[asset] = (dt_value, val)
+                    opens.append(val)
+                    continue
+        return np.array(opens)
+
+    def highs(self, assets, dt):
+        """
+        The high field's aggregation returns the largest high seen between
+        the market open and the current dt.
+        If there has been no data on or before the `dt` the high is `nan`.
+
+        Returns
+        -------
+        np.array with dtype=float64, in order of assets parameter.
+        """
+        date = dt.date()
+        dt_value = dt.value
+        if self._highs_cache is None or self._highs_cache[0] != date:
+            market_open = self._market_opens.loc[date]
+            self._highs_cache = (dt.date(), market_open, {})
+
+        _, market_open, entries = self._highs_cache
+        highs = []
+        if dt != market_open:
+            prev_dt = dt_value - self._one_min
+        else:
+            prev_dt = None
+
+        for asset in assets:
+            if prev_dt is None:
+                val = self._minute_reader.get_value(asset, dt, 'high')
+                entries[asset] = (dt_value, val)
+                highs.append(val)
+                continue
+            else:
+                try:
+                    last_visited_dt, last_max = entries[asset]
+                    if last_visited_dt == prev_dt:
+                        curr_val = self._minute_reader.get_value(
+                            asset, dt, 'high')
+                        if pd.isnull(curr_val):
+                            val = last_max
+                        elif pd.isnull(last_max):
+                            val = curr_val
+                        else:
+                            val = max(last_max, curr_val)
+                        entries[asset] = (dt_value, val)
+                        highs.append(val)
+                        continue
+                    else:
+                        after_last = pd.Timestamp(
+                            last_visited_dt + self._one_min, tz='UTC')
+                        window = self._minute_reader.unadjusted_window(
+                            ['high'], after_last, dt, [asset])
+                        val = max(last_max, np.nanmax(window))
+                        entries[asset] = (dt_value, val)
+                        highs.append(val)
+                        continue
+                except KeyError:
+                    window = self._minute_reader.unadjusted_window(
+                        ['high'], market_open, dt, [asset])
+                    val = np.nanmax(window)
+                    entries[asset] = (dt_value, val)
+                    highs.append(val)
+                    continue
+        return np.array(highs)
+
+    def lows(self, assets, dt):
+        """
+        The low field's aggregation returns the smallest low seen between
+        the market open and the current dt.
+        If there has been no data on or before the `dt` the low is `nan`.
+
+        Returns
+        -------
+        np.array with dtype=float64, in order of assets parameter.
+        """
+        date = dt.date()
+        dt_value = dt.value
+        if self._lows_cache is None or self._lows_cache[0] != date:
+            market_open = self._market_opens.loc[date]
+            self._lows_cache = (dt.date(), market_open, {})
+
+        _, market_open, entries = self._lows_cache
+        lows = []
+        if dt != market_open:
+            prev_dt = dt_value - self._one_min
+        else:
+            prev_dt = None
+
+        # What if called on same dt?
+
+        for asset in assets:
+            if prev_dt is None:
+                val = self._minute_reader.get_value(asset, dt, 'low')
+                entries[asset] = (dt_value, val)
+                lows.append(val)
+                continue
+            else:
+                try:
+                    last_visited_dt, last_min = entries[asset]
+                    if last_visited_dt == prev_dt:
+                        curr_val = self._minute_reader.get_value(
+                            asset, dt, 'low')
+                        val = np.nanmin([last_min, curr_val])
+                        entries[asset] = (dt_value, val)
+                        lows.append(val)
+                        continue
+                    else:
+                        after_last = pd.Timestamp(
+                            last_visited_dt + self._one_min, tz='UTC')
+                        window = self._minute_reader.unadjusted_window(
+                            ['low'], after_last, dt, [asset])
+                        window_min = np.nanmin(window)
+                        if pd.isnull(window_min):
+                            val = last_min
+                        else:
+                            val = min(last_min, window_min)
+                        entries[asset] = (dt_value, val)
+                        lows.append(val)
+                        continue
+                except KeyError:
+                    window = self._minute_reader.unadjusted_window(
+                        ['low'], market_open, dt, [asset])
+                    val = np.nanmin(window)
+                    entries[asset] = (dt_value, val)
+                    lows.append(val)
+                    continue
+        return np.array(lows)
+
+    def closes(self, assets, dt):
+        """
+        The close field's aggregation returns the latest close at the given
+        dt.
+        If the close for the given dt is `nan`, the most recent non-nan
+        `close` is used.
+        If there has been no data on or before the `dt` the close is `nan`.
+
+        Returns
+        -------
+        np.array with dtype=float64, in order of assets parameter.
+        """
+        date = dt.date()
+        dt_value = dt.value
+        if self._closes_cache is None or self._closes_cache[0] != date:
+            market_open = self._market_opens.loc[date]
+            self._closes_cache = (dt.date(), market_open, {})
+
+        _, market_open, entries = self._closes_cache
+        closes = []
+        if dt != market_open:
+            prev_dt = dt_value - self._one_min
+        else:
+            prev_dt = None
+
+        for asset in assets:
+            if prev_dt is None:
+                val = self._minute_reader.get_value(asset, dt, 'close')
+                entries[asset] = (dt_value, val)
+                closes.append(val)
+                continue
+            else:
+                try:
+                    last_visited_dt, last_close = entries[asset]
+                    if last_visited_dt == prev_dt:
+                        val = self._minute_reader.get_value(
+                            asset, dt, 'close')
+                        if pd.isnull(val):
+                            val = last_close
+                        entries[asset] = (dt_value, val)
+                        closes.append(val)
+                        continue
+                    else:
+                        val = self._minute_reader.get_value(
+                            asset, dt, 'close')
+                        if pd.isnull(val):
+                            val = self.closes(
+                                [asset],
+                                pd.Timestamp(prev_dt, tz='UTC'))
+                        entries[asset] = (dt_value, val)
+                        closes.append(val)
+                        continue
+                except KeyError:
+                    val = self._minute_reader.get_value(
+                        asset, dt, 'close')
+                    if pd.isnull(val):
+                        val = self.closes([asset],
+                                          pd.Timestamp(prev_dt, tz='UTC'))
+                    entries[asset] = (dt_value, val)
+                    closes.append(val)
+                    continue
+        return np.array(closes)
+
+    def volumes(self, assets, dt):
+        """
+        The volume field's aggregation returns the sum of all volumes
+        between the market open and the `dt`
+        If there has been no data on or before the `dt` the volume is 0.
+
+        Returns
+        -------
+        np.array with dtype=int64, in order of assets parameter.
+        """
+        date = dt.date()
+        dt_value = dt.value
+        if self._volumes_cache is None or self._volumes_cache[0] != date:
+            market_open = self._market_opens.loc[date]
+            self._volumes_cache = (dt.date(), market_open, {})
+
+        _, market_open, entries = self._volumes_cache
+        volumes = []
+        if dt != market_open:
+            prev_dt = dt_value - self._one_min
+        else:
+            prev_dt = None
+
+        for asset in assets:
+            if prev_dt is None:
+                val = self._minute_reader.get_value(asset, dt, 'volume')
+                entries[asset] = (dt_value, val)
+                volumes.append(val)
+                continue
+            else:
+                try:
+                    last_visited_dt, last_total = entries[asset]
+                    if last_visited_dt == prev_dt:
+                        val = self._minute_reader.get_value(
+                            asset, dt, 'volume')
+                        val += last_total
+                        entries[asset] = (dt_value, val)
+                        volumes.append(val)
+                        continue
+                    else:
+                        after_last = pd.Timestamp(
+                            last_visited_dt + self._one_min, tz='UTC')
+                        window = self._minute_reader.unadjusted_window(
+                            ['volume'], after_last, dt, [asset])
+                        val = np.nansum(window) + last_total
+                        entries[asset] = (dt_value, val)
+                        volumes.append(val)
+                        continue
+                except KeyError:
+                    window = self._minute_reader.unadjusted_window(
+                        ['volume'], market_open, dt, [asset])
+                    val = np.nansum(window)
+                    entries[asset] = (dt_value, val)
+                    volumes.append(val)
+                    continue
+        return np.array(volumes)
+
+
 class DataPortal(object):
     def __init__(self,
                  env,
@@ -111,6 +467,9 @@ class DataPortal(object):
         self._first_trading_day = None
 
         if self._equity_minute_reader is not None:
+            self._equity_daily_aggregator = DailyHistoryAggregator(
+                self.env.open_and_closes.market_open,
+                self._equity_minute_reader)
             self.MINUTE_PRICE_ADJUSTMENT_FACTOR = \
                 self._equity_minute_reader._ohlc_inverse
 
@@ -689,38 +1048,28 @@ class DataPortal(object):
                 extra_slot=False
             )
         else:
-            all_minutes_for_day = self._get_market_minutes_for_day(
-                end_dt.date())
-            # for the last day of the desired window, use minute
-            # data and aggregate it.
-            last_minute_idx = all_minutes_for_day.searchsorted(end_dt)
-
-            # these are the minutes for the partial day
-            minutes_for_partial_day =\
-                all_minutes_for_day[0:(last_minute_idx + 1)]
-
+            # minute mode, requesting '1d'
             daily_data = self._get_daily_window_for_sids(
                 assets,
                 field_to_use,
                 days_for_window[0:-1]
             )
 
-            minute_data = self._get_minute_window_for_equities(
-                assets,
-                field_to_use,
-                minutes_for_partial_day
-            )
-
-            if field_to_use == 'volume':
-                minute_value = np.sum(minute_data)
-            elif field_to_use == 'open':
-                minute_value = minute_data[0]
-            elif field_to_use == 'close':
-                minute_value = minute_data[-1]
+            if field_to_use == 'open':
+                minute_value = self._equity_daily_aggregator.opens(
+                    assets, end_dt)
             elif field_to_use == 'high':
-                minute_value = np.amax(minute_data)
+                minute_value = self._equity_daily_aggregator.highs(
+                    assets, end_dt)
             elif field_to_use == 'low':
-                minute_value = np.amin(minute_data)
+                minute_value = self._equity_daily_aggregator.lows(
+                    assets, end_dt)
+            elif field_to_use == 'close':
+                minute_value = self._equity_daily_aggregator.closes(
+                    assets, end_dt)
+            elif field_to_use == 'volume':
+                minute_value = self._equity_daily_aggregator.volumes(
+                    assets, end_dt)
 
             # append the partial day.
             daily_data[-1] = minute_value
@@ -1127,14 +1476,15 @@ class DataPortal(object):
             # volumes default to 0, so we don't need to put NaNs in the array
             return_array[:] = np.NAN
 
-        data = self._equity_daily_reader_arrays(field,
-                                                days_in_window,
-                                                assets)
+        if bar_count != 0:
+            data = self._equity_daily_reader_arrays(field,
+                                                    days_in_window,
+                                                    assets)
 
-        if extra_slot:
-            return_array[:len(return_array) - 1, :] = data
-        else:
-            return_array[:len(data)] = data
+            if extra_slot:
+                return_array[:len(return_array) - 1, :] = data
+            else:
+                return_array[:len(data)] = data
         return return_array
 
     @staticmethod

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -815,7 +815,8 @@ def write_bcolz_minute_data(env, days, path, df_dict):
 
 
 def write_minute_data_for_asset(env, writer, start_dt, end_dt, sid,
-                                interval=1, start_val=1):
+                                interval=1, start_val=1,
+                                minute_blacklist=None):
 
     asset_minutes = env.minutes_for_days_in_range(start_dt, end_dt)
     minutes_count = len(asset_minutes)
@@ -835,6 +836,10 @@ def write_minute_data_for_asset(env, writer, start_dt, end_dt, sid,
         while counter < len(minutes_arr):
             df[counter:(counter + interval - 1)] = 0
             counter += interval
+
+    if minute_blacklist is not None:
+        for minute in minute_blacklist:
+            df.loc[minute] = 0
 
     writer.write(sid, df)
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -3,9 +3,15 @@ from unittest import TestCase
 from contextlib2 import ExitStack
 from logbook import NullHandler
 import pandas as pd
-from six import with_metaclass
+from six import with_metaclass, iteritems
+from testfixtures import TempDirectory
 
 from .core import tmp_asset_finder
+from ..data.minute_bars import (
+    BcolzMinuteBarReader,
+    BcolzMinuteBarWriter,
+    US_EQUITIES_MINUTES_PER_DAY
+)
 from ..finance.trading import TradingEnvironment
 from ..utils import tradingcalendar, factory
 from ..utils.final import FinalMeta, final
@@ -208,6 +214,10 @@ class WithTradingEnvironment(WithAssetFinder):
     This behavior can be altered by overriding `make_trading_environment` as a
     class method.
     """
+    TRADING_ENV_MIN_DATE = None
+    TRADING_ENV_MAX_DATE = None
+    TRADING_ENV_TRADING_CALENDAR = tradingcalendar
+
     @classmethod
     def make_load_function(cls):
         return None
@@ -217,6 +227,9 @@ class WithTradingEnvironment(WithAssetFinder):
         return TradingEnvironment(
             load=cls.make_load_function(),
             asset_db_path=cls.asset_finder.engine,
+            min_date=cls.TRADING_ENV_MIN_DATE,
+            max_date=cls.TRADING_ENV_MAX_DATE,
+            env_trading_calendar=cls.TRADING_ENV_TRADING_CALENDAR,
         )
 
     @classmethod
@@ -280,3 +293,70 @@ class WithNYSETradingDays(object):
         start_loc = end_loc - cls.TRADING_DAY_COUNT
 
         cls.trading_days = all_days[start_loc:end_loc + 1]
+
+
+class WithTempdir(object):
+    """
+    ZiplineTestCase mixin providing cls.tempdir as a class-level fixture.
+
+    After init_class_fixtures has been called, `cls.tempdir` is populated
+    with a TempDirectory object.
+
+    The default value of TEMPDIR_PATH is None.
+    Inheritors can override TEMPDIR_PATH to path argument to `TempDirectory`
+    """
+
+    TEMPDIR_PATH = None
+
+    @classmethod
+    def init_class_fixtures(cls):
+        super(WithTempdir, cls).init_class_fixtures()
+
+        cls.tempdir = TempDirectory(path=cls.TEMPDIR_PATH)
+
+        cls.add_class_callback(cls.tempdir.cleanup)
+
+
+class WithBcolzMinutes(WithTempdir,
+                       WithTradingEnvironment):
+    """
+    ZiplineTestCase mixin providing cls.boclz_minute_bar_reader as a
+    class-level fixture.
+
+    After init_class_fixtures has been called, `cls.bcolz_minute_bar_reader`
+    is populated with `BcolzMinuteBarReader` with data defined by
+    `make_bcolz_minute_bar_data`
+
+    The default value of BCOLZ_MINUTES_PER_DAY is US_EQUITIES_MINUTES_PER_DAY.
+    Inheritors can override BCOLZ_MINUTES_PER_DAY to write data for assets
+    that trade over a different period length.
+    """
+
+    BCOLZ_MINUTES_PER_DAY = US_EQUITIES_MINUTES_PER_DAY
+
+    @classmethod
+    def init_class_fixtures(cls):
+        super(WithBcolzMinutes, cls).init_class_fixtures()
+
+        writer = BcolzMinuteBarWriter(
+            cls.env.first_trading_day,
+            cls.tempdir.path,
+            cls.env.open_and_closes.market_open,
+            cls.BCOLZ_MINUTES_PER_DAY,
+        )
+        for sid, data in iteritems(cls.make_bcolz_minute_bar_data()):
+            writer.write(sid, data)
+        cls.bcolz_minute_bar_reader = BcolzMinuteBarReader(cls.tempdir.path)
+
+    @classmethod
+    def make_bcolz_minute_bar_data(cls):
+        """
+        Returns
+        -------
+        A dict of sid -> DataFrame with columns ('open', 'high', 'low',
+        'close', 'volume') and an index of the minutes on which the prices
+        occurred.
+
+        See, zipline.data.minute_bars.BcolzMinuteBarWriter
+        """
+        return {}


### PR DESCRIPTION
Fix the following behavior for the last slot in history with a '1d'
freq.

- open 
 - old
    Always used the open on the first minute, (9:31)
 - fix
    Uses first non-nan open.
- high
 - old
    The existence of any nan from market open to dt would propagate and
    make the result nan.
 - fix
    nans no longer affect high, unless there are only nans between
    market open and given dt
- low
 - old
    The existence of any nan from market open to dt would propagate and
    make the result nan.
 - fix
    nans no longer affect low, unless there are only nans between
    market open and given dt
- close
 - old
    The close at the given dt was always used. If the close was a nan at
    that dt, a nan would be returned.
 - fix
    The close at the given dt, unless that a value is a nan; in that
    case the most recent non-nan value is returned.

This patch's main intent is to fix the bug affecting results, however with
this fix there is a decent sized performance gain from cutting out the
calls to `all_minutes_for_day`, as well as cutting the retrieval of the
minute window from market_window -> current dt, which is order ~n^2 with
respect to how many minute values are accessed.

This implementation leaves some performance considerations on the table.
Particularly:
- The minute window access in each of the aggregation methods could be
fetched and stored in memory instead of going back to the bcolz tape on
every query.
- The minute windows could be structured so that they are accessed in
groups of assets. This implementation incurs the cost of getting the
minute position from the cache (and/or calculating) the number of bars
times the number of assets, when that retrieval could only be done once
per minute.

Also, adds test fixtures for bcolz minute data and the tempdir
dependency for the bcolz data, for use by the new test suite.