### PR TITLE
Lazy prevent history before trading start

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -19,7 +19,10 @@ from zipline.data.us_equity_pricing import (
     SQLiteAdjustmentWriter,
     SQLiteAdjustmentReader,
     BcolzDailyBarReader)
-from zipline.errors import HistoryInInitialize
+from zipline.errors import (
+    HistoryInInitialize,
+    HistoryWindowStartsBeforeData,
+)
 from zipline.finance.trading import (
     TradingEnvironment,
     SimulationParameters
@@ -66,12 +69,13 @@ class HistoryTestCaseBase(TestCase):
     # - merger on 2015-01-05 and 2015-01-06
     @classmethod
     def setUpClass(cls):
-        cls.env = TradingEnvironment()
         cls.tempdir = TempDirectory()
 
         # trading_start (when bcolz files start) = 2014-02-01
         cls.TRADING_START_DT = pd.Timestamp("2014-02-03", tz='UTC')
         cls.TRADING_END_DT = pd.Timestamp("2016-01-30", tz='UTC')
+
+        cls.env = TradingEnvironment(min_date=cls.TRADING_START_DT)
 
         cls.trading_days = cls.env.days_in_range(
             start=cls.TRADING_START_DT,
@@ -511,8 +515,8 @@ class MinuteEquityHistoryTestCase(HistoryTestCaseBase):
             """
         )
 
-        start = pd.Timestamp('2007-04-05', tz='UTC')
-        end = pd.Timestamp('2007-04-10', tz='UTC')
+        start = pd.Timestamp('2014-04-05', tz='UTC')
+        end = pd.Timestamp('2014-04-10', tz='UTC')
 
         sim_params = SimulationParameters(
             period_start=start,
@@ -864,27 +868,20 @@ class MinuteEquityHistoryTestCase(HistoryTestCaseBase):
     def test_history_window_before_first_trading_day(self):
         # trading_start is 2/3/2014
         # get a history window that starts before that, and ends after that
-
         first_day_minutes = self.env.market_minutes_for_day(
             self.TRADING_START_DT
         )
-
+        exp_msg = (
+            "History window extends beyond environment first date, "
+            "2014-02-03. To use history with bar count, 15, start simulation "
+            "on or after, 2014-02-04."
+        )
         for field in OHLCP:
-            window = self.data_portal.get_history_window(
-                [self.ASSET1], first_day_minutes[5], 15, "1m", "price"
-            )[self.ASSET1]
-
-            # should be 9 Nans and 6 values
-            np.testing.assert_array_equal(np.full(9, np.nan), window[0:9])
-            np.testing.assert_array_equal(range(7802, 7808), window[9:])
-
-        # volume should be prefilled with zeros
-        window = self.data_portal.get_history_window(
-            [self.ASSET1], first_day_minutes[5], 15, "1m", "volume"
-        )[self.ASSET1]
-
-        np.testing.assert_array_equal(np.zeros(9), window[0:9])
-        np.testing.assert_array_equal(range(780200, 780800, 100), window[9:])
+            with self.assertRaisesRegexp(
+                    HistoryWindowStartsBeforeData, exp_msg):
+                self.data_portal.get_history_window(
+                    [self.ASSET1], first_day_minutes[5], 15, "1m", "price"
+                )[self.ASSET1]
 
 
 class DailyEquityHistoryTestCase(HistoryTestCaseBase):
@@ -1242,42 +1239,39 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
 
         second_day = self.env.next_trading_day(self.TRADING_START_DT)
 
-        window = self.data_portal.get_history_window(
-            [self.ASSET1],
-            second_day,
-            4,
-            "1d",
-            "price"
-        )[self.ASSET1]
+        exp_msg = (
+            "History window extends beyond environment first date, "
+            "2014-02-03. To use history with bar count, 4, start simulation "
+            "on or after, 2014-02-07."
+        )
 
-        # should be two NaNs and two values
-        np.testing.assert_almost_equal(
-            [np.nan, np.nan, 2, 3], window)
+        with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
+            self.data_portal.get_history_window(
+                [self.ASSET1],
+                second_day,
+                4,
+                "1d",
+                "price"
+            )[self.ASSET1]
 
-        window = self.data_portal.get_history_window(
-            [self.ASSET1],
-            second_day,
-            4,
-            "1d",
-            "volume"
-        )[self.ASSET1]
-
-        # should be two NaNs and two values
-        np.testing.assert_almost_equal(
-            [0, 0, 200, 300], window)
+        with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
+            self.data_portal.get_history_window(
+                [self.ASSET1],
+                second_day,
+                4,
+                "1d",
+                "volume"
+            )[self.ASSET1]
 
         # Use a minute to force minute mode.
         first_minute = self.env.open_and_closes.market_open[
             self.TRADING_START_DT]
 
-        window = self.data_portal.get_history_window(
-            [self.ASSET2],
-            first_minute,
-            4,
-            "1d",
-            "close"
-        )[self.ASSET2]
-
-        # should be all nans since ASSET2 does not start on first day.
-        np.testing.assert_almost_equal(
-            [np.nan, np.nan, np.nan, np.nan], window)
+        with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
+            self.data_portal.get_history_window(
+                [self.ASSET2],
+                first_minute,
+                4,
+                "1d",
+                "close"
+            )[self.ASSET2]

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -25,7 +25,9 @@ from six.moves import reduce
 
 from zipline.assets import Asset, Future, Equity
 from zipline.data.us_equity_pricing import NoDataOnDate
-from zipline.data.us_equity_loader import USEquityHistoryLoader
+from zipline.data.us_equity_loader import (
+    USEquityHistoryLoader,
+)
 
 from zipline.utils import tradingcalendar
 from zipline.utils.math_utils import (
@@ -36,7 +38,8 @@ from zipline.utils.math_utils import (
 from zipline.utils.memoize import remember_last
 from zipline.errors import (
     NoTradeDataAvailableTooEarly,
-    NoTradeDataAvailableTooLate
+    NoTradeDataAvailableTooLate,
+    HistoryWindowStartsBeforeData,
 )
 
 log = Logger('DataPortal')
@@ -561,9 +564,16 @@ class DataPortal(object):
 
     @remember_last
     def _get_days_for_window(self, end_date, bar_count):
-        day_idx = tradingcalendar.trading_days.searchsorted(end_date)
-        return tradingcalendar.trading_days[
-            (day_idx - bar_count + 1):(day_idx + 1)]
+        tds = self.env.trading_days
+        end_loc = self.env.trading_days.get_loc(end_date)
+        start_loc = end_loc - bar_count + 1
+        if start_loc < 0:
+            raise HistoryWindowStartsBeforeData(
+                first_trading_day=self.env.first_trading_day.date(),
+                bar_count=bar_count,
+                suggested_start_day=tds[bar_count].date(),
+            )
+        return tds[start_loc:end_loc + 1]
 
     def _get_history_daily_window(self, assets, end_dt, bar_count,
                                   field_to_use):
@@ -724,59 +734,23 @@ class DataPortal(object):
         of minute frequency for the given sids.
         """
         # get all the minutes for this window
-        minutes_for_window = self.env.market_minute_window(
-            end_dt, bar_count, step=-1)[::-1]
-
-        first_trading_day = self._equity_minute_reader.first_trading_day
-
-        if minutes_for_window[0] < first_trading_day:
-
-            # but then cut it down to only the minutes after
-            # the first trading day.
-            modified_minutes_for_window = minutes_for_window[
-                minutes_for_window.slice_indexer(first_trading_day)]
-
-            modified_minutes_length = len(modified_minutes_for_window)
-
-            if modified_minutes_length == 0:
-                raise ValueError("Cannot calculate history window that ends "
-                                 "before the first trading day!")
-
-            bars_to_prepend = 0
-            nans_to_prepend = None
-
-            if modified_minutes_length < bar_count:
-                first_trading_date = first_trading_day.date()
-                if modified_minutes_for_window[0].date() == first_trading_date:
-                    # the beginning of the window goes before our global
-                    # trading start date
-                    bars_to_prepend = bar_count - modified_minutes_length
-                    nans_to_prepend = np.repeat(np.nan, bars_to_prepend)
-
-            if len(assets) == 0:
-                return pd.DataFrame(
-                    None,
-                    index=modified_minutes_for_window,
-                    columns=None
-                )
-            query_minutes = modified_minutes_for_window
-        else:
-            query_minutes = minutes_for_window
-            bars_to_prepend = 0
+        mm = self.env.market_minutes
+        end_loc = mm.get_loc(end_dt)
+        start_loc = end_loc - bar_count + 1
+        if start_loc < 0:
+            suggested_start_day = (mm[bar_count] + self.env.trading_day).date()
+            raise HistoryWindowStartsBeforeData(
+                first_trading_day=self.env.first_trading_day.date(),
+                bar_count=bar_count,
+                suggested_start_day=suggested_start_day,
+            )
+        minutes_for_window = mm[start_loc:end_loc + 1]
 
         asset_minute_data = self._get_minute_window_for_assets(
             assets,
             field_to_use,
-            query_minutes,
+            minutes_for_window,
         )
-
-        if bars_to_prepend != 0:
-            if field_to_use == "volume":
-                filler = np.zeros((len(nans_to_prepend), len(assets)))
-            else:
-                filler = np.full((len(nans_to_prepend), len(assets)), np.nan)
-
-            asset_minute_data = np.concatenate([filler, asset_minute_data])
 
         return pd.DataFrame(
             asset_minute_data,

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -593,3 +593,11 @@ class AssetDBImpossibleDowngrade(ZiplineError):
         "The existing Asset database is version: {db_version} which is lower "
         "than the desired downgrade version: {desired_version}."
     )
+
+
+class HistoryWindowStartsBeforeData(ZiplineError):
+    msg = (
+        "History window extends beyond environment first date, "
+        "{first_trading_day}. To use history with bar count, {bar_count}, "
+        "start simulation on or after, {suggested_start_day}."
+        )

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -597,7 +597,6 @@ class AssetDBImpossibleDowngrade(ZiplineError):
 
 class HistoryWindowStartsBeforeData(ZiplineError):
     msg = (
-        "History window extends beyond environment first date, "
-        "{first_trading_day}. To use history with bar count, {bar_count}, "
-        "start simulation on or after, {suggested_start_day}."
+        "History window extends before {first_trading_day}. To use this "
+        "history window, start the backtest on or after {suggested_start_day}."
         )

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -32,7 +32,7 @@ from zipline.assets.asset_writer import (
 from zipline.errors import (
     NoFurtherDataError
 )
-from zipline.utils.memoize import remember_last
+from zipline.utils.memoize import remember_last, lazyval
 
 log = logbook.Logger('Trading')
 
@@ -94,10 +94,6 @@ class TradingEnvironment(object):
         self.open_and_closes = env_trading_calendar.open_and_closes.loc[
             self.trading_days]
 
-        self.market_minutes = self.minutes_for_days_in_range(
-            self.first_trading_day,
-            self.last_trading_day)
-
         self.bm_symbol = bm_symbol
         if not load:
             load = load_market_data
@@ -126,6 +122,11 @@ class TradingEnvironment(object):
             self.asset_finder = AssetFinder(engine)
         else:
             self.asset_finder = None
+
+    @lazyval
+    def market_minutes(self):
+        return self.minutes_for_days_in_range(self.first_trading_day,
+                                              self.last_trading_day)
 
     def write_data(self,
                    engine=None,


### PR DESCRIPTION
Unreverts #1040 

Also, make env.market_minutes lazy so that the memory and CPU cost is not hit in contexts that do not use the minutes.