### PR TITLE
DEV: Clean up slippage API.

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -144,7 +144,7 @@ class SlippageTestCase(TestCase):
                     dt=datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                     amount=100,
                     filled=0,
-                    sid=133
+                    sid=self.ASSET133
                 )
             ]
 
@@ -183,7 +183,7 @@ class SlippageTestCase(TestCase):
                     dt=datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                     amount=100,
                     filled=0,
-                    sid=133
+                    sid=self.ASSET133
                 )
             ]
 
@@ -214,7 +214,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': 100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'limit': 3.5})
         ]
 
@@ -236,7 +236,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': 100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'limit': 3.5})
         ]
 
@@ -258,7 +258,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': 100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'limit': 3.6})
         ]
 
@@ -297,7 +297,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': -100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'limit': 3.5})
         ]
 
@@ -319,7 +319,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': -100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'limit': 3.5})
         ]
 
@@ -341,7 +341,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': -100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'limit': 3.4})
         ]
 
@@ -504,7 +504,10 @@ class SlippageTestCase(TestCase):
     def test_orders_stop(self, name, order_data, event_data, expected):
         tempdir = TempDirectory()
         try:
-            order = Order(**order_data)
+            data = order_data
+            data['sid'] = self.ASSET133
+
+            order = Order(**data)
 
             assets = {
                 133: pd.DataFrame({
@@ -569,7 +572,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': 100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'stop': 4.0,
                 'limit': 3.0})
         ]
@@ -604,7 +607,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': 100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'stop': 4.0,
                 'limit': 3.5})
         ]
@@ -639,7 +642,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': 100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'stop': 4.0,
                 'limit': 3.6})
         ]
@@ -687,7 +690,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': -100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'stop': 3.0,
                 'limit': 4.0})
         ]
@@ -722,7 +725,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': -100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'stop': 3.0,
                 'limit': 3.5})
         ]
@@ -757,7 +760,7 @@ class SlippageTestCase(TestCase):
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
                 'amount': -100,
                 'filled': 0,
-                'sid': 133,
+                'sid': self.ASSET133,
                 'stop': 3.0,
                 'limit': 3.4})
         ]

--- a/zipline/finance/order.py
+++ b/zipline/finance/order.py
@@ -19,6 +19,7 @@ import uuid
 from six import text_type
 
 import zipline.protocol as zp
+from zipline.assets import Asset
 from zipline.utils.enum import enum
 
 ORDER_STATUS = enum(
@@ -46,6 +47,8 @@ class Order(object):
                   a negative sign indicates a sell
         @filled - how many shares of the order have been filled so far
         """
+        assert isinstance(sid, Asset)
+
         # get a string representation of the uuid.
         self.id = id or self.make_id()
         self.dt = dt
@@ -198,6 +201,14 @@ class Order(object):
     @property
     def open(self):
         return self.status in [ORDER_STATUS.OPEN, ORDER_STATUS.HELD]
+
+    @property
+    def asset(self):
+        """
+        Convenience accessor to hide away a historical API that we'd like to
+        change at some point.
+        """
+        return self.sid
 
     @property
     def triggered(self):

--- a/zipline/finance/transaction.py
+++ b/zipline/finance/transaction.py
@@ -15,12 +15,16 @@
 from __future__ import division
 
 from copy import copy
+
+from zipline.assets import Asset
 from zipline.protocol import DATASOURCE_TYPE
 
 
 class Transaction(object):
 
     def __init__(self, sid, amount, dt, price, order_id, commission=None):
+        assert isinstance(sid, Asset)
+
         self.sid = sid
         self.amount = amount
         self.dt = dt


### PR DESCRIPTION
`process_order` now takes BarData and the Order object and
returns a tuple of (execution_price, execution_volume).  Our
internal code is now responsible for creating the transaction.

Also, enforce that Orders and Transactions use Assets, not ints.