### PR TITLE
FIX: Allow order_target_percent, order_target_value, etc on an asset's last day

### DIFF
--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -309,6 +309,16 @@ class TestMinuteBarData(TestBarDataBase):
                             self.assertEqual(last_traded_minute - 1,
                                              asset2_value)
 
+    def test_minute_of_last_day(self):
+        minutes = self.env.market_minutes_for_day(self.days[-1])
+
+        # this is the last day the assets exist
+        for idx, minute in enumerate(minutes):
+            bar_data = BarData(self.data_portal, lambda: minute, "minute")
+
+            self.assertTrue(bar_data.can_trade(self.ASSET1))
+            self.assertTrue(bar_data.can_trade(self.ASSET2))
+
     def test_minute_after_assets_stopped(self):
         minutes = self.env.market_minutes_for_day(
             self.env.next_trading_day(self.days[-1])

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -303,7 +303,7 @@ cdef class BarData:
             })
 
     cdef bool _can_trade_for_asset(self, asset, dt, adjusted_dt, data_portal):
-        if asset.start_date <= dt <= asset.end_date:
+        if asset.start_date <= normalize_date(dt) <= asset.end_date:
             # is there a last price?
             return not np.isnan(
                 data_portal.get_spot_value(

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -972,7 +972,10 @@ class FakeDataPortal(DataPortal):
         super(FakeDataPortal, self).__init__(env)
 
     def get_spot_value(self, asset, field, dt, data_frequency):
-        return 1.0
+        if field == "volume":
+            return 100
+        else:
+            return 1.0
 
 
 class FetcherDataPortal(DataPortal):


### PR DESCRIPTION
There was an off-by-one bug that was erroneously preventing you from
ordering an asset on its last trading day.

There’s a bunch we still need to do to solidy this - these date checks
don’t apply to the simple `order` method, etc.  I wanted to get this fix in first.