### PR TITLE
TST: Fix fetcher tests to stop and reset responses in teardown

### DIFF
--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -121,6 +121,11 @@ class FetcherTestCase(TestCase):
 
         )
 
+    @classmethod
+    def tearDownClass(cls):
+        responses.stop()
+        responses.reset()
+
     def run_algo(self, code, sim_params=None, data_frequency="daily"):
         if sim_params is None:
             sim_params = self.sim_params


### PR DESCRIPTION
So we don't have the issues with `nose_gevented_multiprocess`.