### PR TITLE
MAINT: Provide prefetch history loader for 1m.

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1545,9 +1545,18 @@ def handle_data(context, data):
             self.trades_by_sid
         )
 
+        sim_params = SimulationParameters(
+            period_start=pd.Timestamp('2006-02-01', tz='UTC'),
+            period_end=pd.Timestamp('2006-03-01', tz='UTC'),
+            capital_base=self.sim_params.capital_base,
+            data_frequency=self.sim_params.data_frequency,
+            emission_rate=self.sim_params.emission_rate,
+            env=self.env,
+        )
+
         test_algo = TradingAlgorithm(
             script=call_without_kwargs,
-            sim_params=self.sim_params,
+            sim_params=sim_params,
             env=self.env,
         )
         test_algo.run(data_portal)
@@ -1564,9 +1573,18 @@ def handle_data(context, data):
             self.trades_by_sid
         )
 
+        sim_params = SimulationParameters(
+            period_start=pd.Timestamp('2006-02-01', tz='UTC'),
+            period_end=pd.Timestamp('2006-03-01', tz='UTC'),
+            capital_base=self.sim_params.capital_base,
+            data_frequency=self.sim_params.data_frequency,
+            emission_rate=self.sim_params.emission_rate,
+            env=self.env,
+        )
+
         test_algo = TradingAlgorithm(
             script=call_with_kwargs,
-            sim_params=self.sim_params,
+            sim_params=sim_params,
             env=self.env,
         )
         test_algo.run(data_portal)

--- a/tests/test_api_shim.py
+++ b/tests/test_api_shim.py
@@ -158,7 +158,7 @@ class TestAPIShim(TestCase):
         cls.adj_reader = cls.create_adjustments_reader()
 
         cls.sim_params = SimulationParameters(
-            period_start=cls.trading_days[0],
+            period_start=cls.trading_days[3],
             period_end=cls.trading_days[-1],
             data_frequency="minute",
             env=cls.env

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -107,7 +107,9 @@ class HistoryTestCaseBase(TestCase):
         cls.adj_reader = cls.create_adjustments_reader()
 
         cls.create_data()
-        cls.create_data_portal()
+
+    def setUp(self):
+        self.create_data_portal()
 
     @classmethod
     def create_data_portal(cls):
@@ -655,6 +657,9 @@ class MinuteEquityHistoryTestCase(HistoryTestCaseBase):
             check_internal_consistency(
                 bar_data, self.SHORT_ASSET, ALL_FIELDS, 30, "1m"
             )
+
+        # Reset data portal because it has advanced past next test date.
+        self.create_data_portal()
 
         # choose a window that contains the last minute of the asset
         bar_data = BarData(self.data_portal, lambda: minutes[15], "minute")
@@ -1263,7 +1268,7 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
                 "close"
             )[asset]
 
-            # first value should be halved, second value unadjusted
+            # first value should be doubled, second value unadjusted
             np.testing.assert_array_equal([1, 3], window2)
 
             window2_volume = self.data_portal.get_history_window(
@@ -1274,7 +1279,10 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
                 "volume"
             )[asset]
 
-            np.testing.assert_array_equal(window2_volume, [100, 300])
+            if asset == self.SPLIT_ASSET:
+                np.testing.assert_array_equal(window2_volume, [400, 300])
+            elif asset == self.MERGER_ASSET:
+                np.testing.assert_array_equal(window2_volume, [200, 300])
 
             # straddling both events
             window3 = self.data_portal.get_history_window(
@@ -1295,7 +1303,10 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
                 "volume"
             )[asset]
 
-            np.testing.assert_array_equal(window3_volume, [50, 150, 400])
+            if asset == self.SPLIT_ASSET:
+                np.testing.assert_array_equal(window3_volume, [800, 600, 400])
+            elif asset == self.MERGER_ASSET:
+                np.testing.assert_array_equal(window3_volume, [200, 300, 400])
 
     def test_daily_dividends(self):
         # self.DIVIDEND_ASSET had dividends on 1/6 and 1/7

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -26,7 +26,8 @@ from six.moves import reduce
 from zipline.assets import Asset, Future, Equity
 from zipline.data.us_equity_pricing import NoDataOnDate
 from zipline.data.us_equity_loader import (
-    USEquityHistoryLoader,
+    USEquityDailyHistoryLoader,
+    USEquityMinuteHistoryLoader,
 )
 
 from zipline.utils import tradingcalendar
@@ -451,7 +452,7 @@ class DataPortal(object):
 
         self._equity_daily_reader = equity_daily_reader
         if self._equity_daily_reader is not None:
-            self._equity_history_loader = USEquityHistoryLoader(
+            self._equity_history_loader = USEquityDailyHistoryLoader(
                 self.env,
                 self._equity_daily_reader,
                 self._adjustment_reader
@@ -466,6 +467,11 @@ class DataPortal(object):
             self._equity_daily_aggregator = DailyHistoryAggregator(
                 self.env.open_and_closes.market_open,
                 self._equity_minute_reader)
+            self._equity_minute_history_loader = USEquityMinuteHistoryLoader(
+                self.env,
+                self._equity_minute_reader,
+                self._adjustment_reader
+            )
             self.MINUTE_PRICE_ADJUSTMENT_FACTOR = \
                 self._equity_minute_reader._ohlc_inverse
 
@@ -496,6 +502,15 @@ class DataPortal(object):
             'price': None
         }
         self._equity_daily_reader_array_data = {}
+        self._equity_minute_loader_array_keys = {
+            'open': None,
+            'high': None,
+            'low': None,
+            'close': None,
+            'volume': None,
+            'price': None
+        }
+        self._equity_minute_loader_array_data = {}
 
         self._in_bts = False
 
@@ -1283,101 +1298,10 @@ class DataPortal(object):
 
     def _get_minute_window_for_equities(
             self, assets, field, minutes_for_window):
-        # each sid's minutes are stored in a bcolz file
-        # the bcolz file has 390 bars per day, regardless
-        # of when the asset started trading and regardless of half days.
-        # for a half day, the second half is filled with zeroes.
-        # all the minutely bcolz files start on the same day.
-
-        try:
-            start_idx = self._equity_minute_reader._find_position_of_minute(
-                minutes_for_window[0])
-        except KeyError:
-            start_idx = 0
-
-        try:
-            end_idx = self._equity_minute_reader._find_position_of_minute(
-                minutes_for_window[-1]) + 1
-        except KeyError:
-            end_idx = 0
-
-        if end_idx == 0:
-            # No data to return for minute window.
-            return np.full((len(minutes_for_window), len(assets), np.nan))
-
-        num_minutes = len(minutes_for_window)
-        start_date = normalize_date(minutes_for_window[0])
-        end_date = normalize_date(minutes_for_window[-1])
-
-        return_data = np.zeros((len(minutes_for_window), len(assets)),
-                               dtype=np.float64)
-
-        for i, asset in enumerate(assets):
-            # find the position of start_dt in the entire timeline, go back
-            # bar_count bars, and that's the unadjusted data
-            raw_data = self._equity_minute_reader._open_minute_file(
-                field, asset)
-
-            data_to_copy = raw_data[start_idx:end_idx]
-
-            # data_to_copy contains all the zeros (from 1pm to 4pm of an early
-            # close).  num_minutes is the number of actual trading minutes.  if
-            # these two have different lengths, that means that we need to trim
-            # away data due to early closes.
-            if len(data_to_copy) != num_minutes:
-                # get a copy of the minutes in Eastern time, since we depend on
-                # an early close being at 1pm Eastern.
-                eastern_minutes = minutes_for_window.tz_convert("US/Eastern")
-
-                # accumulate a list of indices of the last minute of an early
-                # close day.  For example, if data_to_copy starts at 12:55 pm,
-                # and there are five minutes of real data before 180 zeroes,
-                # we would put 5 into last_minute_idx_of_early_close_day,
-                # because the fifth minute is the last "real" minute of
-                # the day.
-                last_minute_idx_of_early_close_day = []
-                for minute_idx, minute_dt in enumerate(eastern_minutes):
-                    if minute_idx == (num_minutes - 1):
-                        break
-
-                    if minute_dt.hour == 13 and minute_dt.minute == 0:
-                        next_minute = eastern_minutes[minute_idx + 1]
-                        if next_minute.hour != 13:
-                            # minute_dt is the last minute of an early close
-                            # day
-                            last_minute_idx_of_early_close_day.append(
-                                minute_idx)
-
-                # spin through the list of early close markers, and use them to
-                # chop off 180 minutes at a time from data_to_copy.
-                for idx, early_close_minute_idx in enumerate(
-                        last_minute_idx_of_early_close_day):
-                    early_close_minute_idx -= (180 * idx)
-                    data_to_copy = np.delete(
-                        data_to_copy,
-                        range(
-                            early_close_minute_idx + 1,
-                            early_close_minute_idx + 181
-                        )
-                    )
-
-            return_data[0:len(data_to_copy), i] = data_to_copy
-            if start_date != end_date:
-                self._apply_all_adjustments(
-                    return_data[:, i],
-                    asset,
-                    minutes_for_window,
-                    field,
-                    self.MINUTE_PRICE_ADJUSTMENT_FACTOR
-                )
-
-        if start_date == end_date:
-            if field != 'volume':
-                # TODO: Use reader for this value.
-                return_data[return_data == 0] = np.nan
-                return_data *= self.MINUTE_PRICE_ADJUSTMENT_FACTOR
-
-        return return_data
+        window = self._equity_minute_loader_arrays(field,
+                                                   minutes_for_window,
+                                                   assets)
+        return window
 
     def _apply_all_adjustments(self, data, asset, dts, field,
                                price_adj_factor=1.0):
@@ -1442,17 +1366,11 @@ class DataPortal(object):
                 True
             )
 
-            data *= price_adj_factor
-
-            # if anything is zero, it's a missing bar, so replace it with NaN.
-            # we only want to do this for non-volume fields, because a missing
-            # volume should be 0.
-            data[data == 0] = np.NaN
-
-        np.around(data, 3, out=data)
+            if price_adj_factor is not None:
+                data *= price_adj_factor
+                np.around(data, 3, out=data)
 
     def _equity_daily_reader_arrays(self, field, dts, assets):
-        # Temporary cache shim before loader is pulled in.
         # Custom memoization, because of unhashable types.
         assets_key = frozenset(assets)
         key = (field, dts[0], dts[-1], assets_key)
@@ -1464,6 +1382,20 @@ class DataPortal(object):
                                                        field)
             self._equity_daily_reader_array_keys[field] = key
             self._equity_daily_reader_array_data[field] = data
+            return data
+
+    def _equity_minute_loader_arrays(self, field, dts, assets):
+        # Custom memoization, because of unhashable types.
+        assets_key = frozenset(assets)
+        key = (field, dts[0], dts[-1], assets_key)
+        if self._equity_minute_loader_array_keys[field] == key:
+            return self._equity_minute_loader_array_data[field]
+        else:
+            data = self._equity_minute_history_loader.history(assets,
+                                                              dts,
+                                                              field)
+            self._equity_minute_loader_array_keys[field] = key
+            self._equity_minute_loader_array_data[field] = data
             return data
 
     def _get_daily_window_for_sids(

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -581,6 +581,10 @@ class BcolzMinuteBarReader(object):
     def _get_metadata(self):
         return BcolzMinuteBarMetadata.read(self._rootdir)
 
+    @lazyval
+    def last_available_dt(self):
+        return self._market_closes[-1]
+
     @property
     def first_trading_day(self):
         return self._first_trading_day

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -14,6 +14,7 @@
 from abc import (
     ABCMeta,
     abstractmethod,
+    abstractproperty,
 )
 from errno import ENOENT
 from os import remove
@@ -339,6 +340,10 @@ class DailyBarReader(with_metaclass(ABCMeta)):
     def spot_price(self, sid, day, colname):
         pass
 
+    @abstractproperty
+    def last_available_dt(self):
+        pass
+
 
 class BcolzDailyBarReader(DailyBarReader):
     """
@@ -491,6 +496,10 @@ class BcolzDailyBarReader(DailyBarReader):
     def first_trading_day(self):
         return self._first_trading_day
 
+    @property
+    def last_available_dt(self):
+        return self._calendar[-1]
+
     def _spot_col(self, colname):
         """
         Get the colname from daily_bar_table and read all of it into memory,
@@ -630,6 +639,10 @@ class PanelDailyBarReader(DailyBarReader):
         self._calendar = calendar
 
         self.panel = panel
+
+    @property
+    def last_available_dt(self):
+        return self._calendar[-1]
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
         col_names = [col.name for col in columns]


### PR DESCRIPTION
Factor out USEquityHistoryLoader into a base class which can be
overridden to support daily or minute history.

In support of reading the minute bars for a range of market minute by
the loader from the reader, put the entire minute index for the minute
bar reader into memory so that the two indexes can be readily compared.
(Though we may want to consider a better way to store just the half day
 information, since the half day only accounts for ~1% of trading days.)

Change some test case sim params so that the tests are started far
enough from the dataset start so that history calls can be made.