### PR TITLE
BUG: Fix accidental array during recursion.

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -341,7 +341,7 @@ class DailyHistoryAggregator(object):
                         if pd.isnull(val):
                             val = self.closes(
                                 [asset],
-                                pd.Timestamp(prev_dt, tz='UTC'))
+                                pd.Timestamp(prev_dt, tz='UTC'))[0]
                         entries[asset] = (dt_value, val)
                         closes.append(val)
                         continue
@@ -350,7 +350,7 @@ class DailyHistoryAggregator(object):
                         asset, dt, 'close')
                     if pd.isnull(val):
                         val = self.closes([asset],
-                                          pd.Timestamp(prev_dt, tz='UTC'))
+                                          pd.Timestamp(prev_dt, tz='UTC'))[0]
                     entries[asset] = (dt_value, val)
                     closes.append(val)
                     continue


### PR DESCRIPTION
The recursion on finding the last close was incorrectly using the array
returned by the close method instead of demoting it to scalar. When this
value was appended to the full close results return arrays with bizarre
shapes, e.g. `(2, 1, 1, 1, 1, 1)`, because a list built of scalars and
lists was passed to the array constructor.

Change daily aggregrator test suite to test the DailyHistoryAggregator
directly instead of routing through data portal, since the assignment of
the values when using a bar count of 1 was papering over the unexpected
shape.

Add a check on returned values in tests that the return is a `Real` to
prevent regression on the assignment of an array when a

Credit to @aliang for identifying root cause.