### PR TITLE
BUG: Prevent writing int max instead of nan.

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -16,6 +16,7 @@ from textwrap import dedent
 import bcolz
 from bcolz import ctable
 import numpy as np
+from numpy import nan_to_num
 from os.path import join
 import json
 import os
@@ -526,11 +527,14 @@ class BcolzMinuteBarWriter(object):
                                  dts.astype('datetime64[ns]'))
 
         ohlc_ratio = self._ohlc_ratio
-        open_col[dt_ixs] = (cols['open'] * ohlc_ratio).astype(np.uint32)
-        high_col[dt_ixs] = (cols['high'] * ohlc_ratio).astype(np.uint32)
-        low_col[dt_ixs] = (cols['low'] * ohlc_ratio).astype(np.uint32)
-        close_col[dt_ixs] = (cols['close'] * ohlc_ratio).astype(
-            np.uint32)
+        open_col[dt_ixs] = (nan_to_num(cols['open']) * ohlc_ratio).\
+            astype(np.uint32)
+        high_col[dt_ixs] = (nan_to_num(cols['high']) * ohlc_ratio).\
+            astype(np.uint32)
+        low_col[dt_ixs] = (nan_to_num(cols['low']) * ohlc_ratio).\
+            astype(np.uint32)
+        close_col[dt_ixs] = (nan_to_num(cols['close']) * ohlc_ratio).\
+            astype(np.uint32)
         vol_col[dt_ixs] = cols['volume'].astype(np.uint32)
 
         table.append([


### PR DESCRIPTION
np.array.astype can not be relied upon to convert nan's reliably to 0

Fix by calling nan_to_num on the float arrays before converting to
uint32.