### PR TITLE
MAINT: Provide prefetch history loader for 1m.

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1545,9 +1545,18 @@ def handle_data(context, data):
             self.trades_by_sid
         )
 
+        sim_params = SimulationParameters(
+            period_start=pd.Timestamp('2006-02-01', tz='UTC'),
+            period_end=pd.Timestamp('2006-03-01', tz='UTC'),
+            capital_base=self.sim_params.capital_base,
+            data_frequency=self.sim_params.data_frequency,
+            emission_rate=self.sim_params.emission_rate,
+            env=self.env,
+        )
+
         test_algo = TradingAlgorithm(
             script=call_without_kwargs,
-            sim_params=self.sim_params,
+            sim_params=sim_params,
             env=self.env,
         )
         test_algo.run(data_portal)
@@ -1564,9 +1573,18 @@ def handle_data(context, data):
             self.trades_by_sid
         )
 
+        sim_params = SimulationParameters(
+            period_start=pd.Timestamp('2006-02-01', tz='UTC'),
+            period_end=pd.Timestamp('2006-03-01', tz='UTC'),
+            capital_base=self.sim_params.capital_base,
+            data_frequency=self.sim_params.data_frequency,
+            emission_rate=self.sim_params.emission_rate,
+            env=self.env,
+        )
+
         test_algo = TradingAlgorithm(
             script=call_with_kwargs,
-            sim_params=self.sim_params,
+            sim_params=sim_params,
             env=self.env,
         )
         test_algo.run(data_portal)

--- a/tests/test_api_shim.py
+++ b/tests/test_api_shim.py
@@ -445,7 +445,17 @@ class TestAPIShim(TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
-            algo = self.create_algo(history_algo)
+            sim_params = SimulationParameters(
+                period_start=self.trading_days[1],
+                period_end=self.sim_params.period_end,
+                capital_base=self.sim_params.capital_base,
+                data_frequency=self.sim_params.data_frequency,
+                emission_rate=self.sim_params.emission_rate,
+                env=self.env,
+            )
+
+            algo = self.create_algo(history_algo,
+                                    sim_params=sim_params)
             algo.run(self.data_portal)
 
             self.assertEqual(1, len(w))

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -581,6 +581,10 @@ class BcolzMinuteBarReader(object):
     def _get_metadata(self):
         return BcolzMinuteBarMetadata.read(self._rootdir)
 
+    @lazyval
+    def last_available_dt(self):
+        return self._market_closes[-1]
+
     @property
     def first_trading_day(self):
         return self._first_trading_day

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numpy import dtype, around, full, nan, concatenate
+from abc import (
+    ABCMeta,
+    abstractmethod,
+    abstractproperty,
+)
+from numpy import dtype, around
+from pandas.tslib import normalize_date
 
-from six import iteritems
+from six import iteritems, with_metaclass
 
 from zipline.pipeline.data.equity_pricing import USEquityPricing
 from zipline.lib._float64window import AdjustedArrayWindow as Float64Window
 from zipline.lib.adjustment import Float64Multiply
 from zipline.utils.cache import CachedObject, Expired
+from zipline.utils.memoize import lazyval
 
 
 class SlidingWindow(object):
@@ -60,28 +67,36 @@ class SlidingWindow(object):
         return self.current
 
 
-class USEquityHistoryLoader(object):
+class USEquityHistoryLoader(with_metaclass(ABCMeta)):
     """
     Loader for sliding history windows of adjusted US Equity Pricing data.
 
     Parameters
     ----------
-    daily_reader : DailyBarReader
-        Reader for daily bars.
+    reader : DailyBarReader, MinuteBarReader
+        Reader for pricing bars.
     adjustment_reader : SQLiteAdjustmentReader
         Reader for adjustment data.
     """
-
-    def __init__(self, env, daily_reader, adjustment_reader):
+    def __init__(self, env, reader, adjustment_reader):
         self.env = env
-        self._daily_reader = daily_reader
-        self._calendar = daily_reader._calendar
+        self._reader = reader
         self._adjustments_reader = adjustment_reader
-        self._daily_window_blocks = {}
+        self._window_blocks = {}
 
-        self._prefetch_length = 40
+    @abstractproperty
+    def _prefetch_length(self):
+        pass
 
-    def _get_adjustments_in_range(self, assets, days, field):
+    @abstractproperty
+    def _calendar(self):
+        pass
+
+    @abstractmethod
+    def _array(self, start, end, assets, field):
+        pass
+
+    def _get_adjustments_in_range(self, assets, dts, field):
         """
         Get the Float64Multiply objects to pass to an AdjustedArrayWindow.
 
@@ -111,8 +126,8 @@ class USEquityHistoryLoader(object):
         out : The adjustments as a dict of loc -> Float64Multiply
         """
         sids = {int(asset): i for i, asset in enumerate(assets)}
-        start = days[0]
-        end = days[-1]
+        start = normalize_date(dts[0])
+        end = normalize_date(dts[-1])
         adjs = {}
         for sid, i in iteritems(sids):
             if field != 'volume':
@@ -121,7 +136,7 @@ class USEquityHistoryLoader(object):
                 for m in mergers:
                     dt = m[0]
                     if start < dt <= end:
-                        end_loc = days.get_loc(dt)
+                        end_loc = dts.searchsorted(dt)
                         mult = Float64Multiply(0,
                                                end_loc - 1,
                                                i,
@@ -136,7 +151,7 @@ class USEquityHistoryLoader(object):
                 for d in divs:
                     dt = d[0]
                     if start < dt <= end:
-                        end_loc = days.get_loc(dt)
+                        end_loc = dts.searchsorted(dt)
                         mult = Float64Multiply(0,
                                                end_loc - 1,
                                                i,
@@ -155,7 +170,7 @@ class USEquityHistoryLoader(object):
                 else:
                     ratio = s[1]
                 if start < dt <= end:
-                    end_loc = days.get_loc(dt)
+                    end_loc = dts.searchsorted(dt)
                     mult = Float64Multiply(0,
                                            end_loc - 1,
                                            i,
@@ -168,10 +183,42 @@ class USEquityHistoryLoader(object):
         return adjs
 
     def _ensure_sliding_window(
-            self, assets, start, end, size, field):
+            self, assets, dts, field):
+        """
+        Ensure that there is a Float64Multiply window that can provide data
+        for the given parameters.
+        If the corresponding window for the (assets, len(dts), field) does not
+        exist, then create a new one.
+        If a corresponding window does exist for (assets, len(dts), field), but
+        can not provide data for the current dts range, then create a new
+        one and replace the expired window.
+
+        WARNING: A simulation with a high variance of assets, may cause
+        unbounded growth of floating windows stored in `_window_blocks`.
+        There should be some regular clean up of the cache, if stale windows
+        prevent simulations from completing because of memory constraints.
+
+        Parameters
+        ----------
+        assets : iterable of Assets
+            The assets in the window
+        dts : iterable of datetime64-like
+            The datetimes for which to fetch data.
+            Makes an assumption that all dts are present and contiguous,
+            in the calendar.
+        field : str
+            The OHLCV field for which to retrieve data.
+
+        Returns
+        -------
+        out : Float64Window with sufficient data so that the window can
+        provide `get` for the index corresponding with the last value in `dts`
+        """
+        end = dts[-1]
+        size = len(dts)
         assets_key = frozenset(assets)
         try:
-            block_cache = self._daily_window_blocks[(assets_key, field, size)]
+            block_cache = self._window_blocks[(assets_key, field, size)]
             try:
                 return block_cache.unwrap(end)
             except Expired:
@@ -179,59 +226,34 @@ class USEquityHistoryLoader(object):
         except KeyError:
             pass
 
-        # Handle case where data is request before the start of data available
-        # in the daily_reader. In that case, prepend nans until the start
-        # of data.
-        pre_array = None
-        if start < self._daily_reader._calendar[0]:
-            start_ix = 0
-            td = self.env.trading_days
-            offset = td.get_loc(start) - td.get_loc(
-                self._daily_reader._calendar[0])
-            if end < self._daily_reader._calendar[0]:
-                fill_size = size
-                end_ix = 0
-            else:
-                pre_slice = self._calendar.slice_indexer(start, end)
-                fill_size = pre_slice.stop - pre_slice.start
-                end_ix = self._calendar.get_loc(end)
-            if field != 'volume':
-                pre_array = full((fill_size, 1), nan)
-            else:
-                pre_array = full((fill_size, 1), 0)
-        else:
-            offset = 0
-            start_ix = self._calendar.get_loc(start)
-            end_ix = self._calendar.get_loc(end)
+        start = dts[0]
 
-        col = getattr(USEquityPricing, field)
+        offset = 0
+        start_ix = self._calendar.get_loc(start)
+        end_ix = self._calendar.get_loc(end)
+
         cal = self._calendar
         prefetch_end_ix = min(end_ix + self._prefetch_length, len(cal) - 1)
         prefetch_end = cal[prefetch_end_ix]
-
-        days = cal[start_ix:prefetch_end_ix + 1]
-        array = self._daily_reader.load_raw_arrays(
-            [col], days[0], prefetch_end, assets)[0]
+        prefetch_dts = cal[start_ix:prefetch_end_ix + 1]
+        array = self._array(prefetch_dts, assets, field)
         if self._adjustments_reader:
-            adjs = self._get_adjustments_in_range(assets, days, col)
+            adjs = self._get_adjustments_in_range(assets, prefetch_dts, field)
         else:
             adjs = {}
         if field == 'volume':
             array = array.astype('float64')
         dtype_ = dtype('float64')
 
-        if pre_array is not None:
-            array = concatenate([pre_array, array])
-
         window = Float64Window(
             array,
             dtype_,
             adjs,
-            0,
+            offset,
             size
         )
         block = SlidingWindow(window, size, start_ix, offset)
-        self._daily_window_blocks[(assets_key, field, size)] = CachedObject(
+        self._window_blocks[(assets_key, field, size)] = CachedObject(
             block, prefetch_end)
         return block
 
@@ -256,12 +278,39 @@ class USEquityHistoryLoader(object):
         -------
         out : np.ndarray with shape(len(days between start, end), len(assets))
         """
-        start = dts[0]
-        end = dts[-1]
-        size = len(dts)
-        block = self._ensure_sliding_window(assets, start, end, size, field)
-        if end > self._calendar[0]:
-            end_ix = self._calendar.get_loc(end)
-        else:
-            end_ix = size
+        block = self._ensure_sliding_window(assets, dts, field)
+        end_ix = self._calendar.get_loc(dts[-1])
         return block.get(end_ix)
+
+
+class USEquityDailyHistoryLoader(USEquityHistoryLoader):
+
+    @property
+    def _prefetch_length(self):
+        return 40
+
+    @property
+    def _calendar(self):
+        return self._reader._calendar
+
+    def _array(self, dts, assets, field):
+        col = getattr(USEquityPricing, field)
+        return self._reader.load_raw_arrays(
+            [col], dts[0], dts[-1], assets)[0]
+
+
+class USEquityMinuteHistoryLoader(USEquityHistoryLoader):
+
+    @property
+    def _prefetch_length(self):
+        return 1560
+
+    @lazyval
+    def _calendar(self):
+        mm = self.env.market_minutes
+        return mm[mm.slice_indexer(start=self._reader.first_trading_day,
+                                   end=self._reader.last_available_dt)]
+
+    def _array(self, dts, assets, field):
+        return self._reader.unadjusted_window(
+            [field], dts[0], dts[-1], assets)[0].T

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -14,6 +14,7 @@
 from abc import (
     ABCMeta,
     abstractmethod,
+    abstractproperty,
 )
 from errno import ENOENT
 from os import remove
@@ -339,6 +340,10 @@ class DailyBarReader(with_metaclass(ABCMeta)):
     def spot_price(self, sid, day, colname):
         pass
 
+    @abstractproperty
+    def last_available_dt(self):
+        pass
+
 
 class BcolzDailyBarReader(DailyBarReader):
     """
@@ -491,6 +496,10 @@ class BcolzDailyBarReader(DailyBarReader):
     def first_trading_day(self):
         return self._first_trading_day
 
+    @property
+    def last_available_dt(self):
+        return self._calendar[-1]
+
     def _spot_col(self, colname):
         """
         Get the colname from daily_bar_table and read all of it into memory,
@@ -630,6 +639,10 @@ class PanelDailyBarReader(DailyBarReader):
         self._calendar = calendar
 
         self.panel = panel
+
+    @property
+    def last_available_dt(self):
+        return self._calendar[-1]
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
         col_names = [col.name for col in columns]


### PR DESCRIPTION
Factor out USEquityHistoryLoader into a base class which can be
overridden to support daily or minute history.

Use the minute version of the history loader in data portal minute
equity window history calls, in the same manner that the daily history
loader is used to pre-fetch history windows and apply adjustments as the
window is rolled.

Change some test case sim params so that the tests are started far
enough from the dataset start so that history calls can be made.