### PR TITLE
Pass a mask (filter) to custom factors

### DIFF
--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -114,7 +114,6 @@ class BoundColumn(LoadableTerm):
         The name of this column.
     """
     mask = AssetExists()
-    extra_input_rows = 0
     inputs = ()
 
     def __new__(cls, dtype, missing_value, dataset, name):

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -242,8 +242,11 @@ class SimplePipelineEngine(object):
         Load mask and mask row labels for term.
         """
         mask = term.mask
-        offset = graph.extra_rows[mask] - graph.extra_rows[term]
-        return workspace[mask][offset:], dates[offset:]
+        mask_offset = graph.extra_rows[mask] - graph.extra_rows[term]
+        dates_offset = (
+            graph.extra_rows[self._root_mask_term] - graph.extra_rows[term]
+        )
+        return workspace[mask][mask_offset:], dates[dates_offset:]
 
     @staticmethod
     def _inputs_for_term(term, workspace, graph):

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -237,16 +237,20 @@ class SimplePipelineEngine(object):
         assert shape[0] * shape[1] != 0, 'root mask cannot be empty'
         return ret
 
-    def _mask_and_dates_for_term(self, term, workspace, graph, dates):
+    def _mask_and_dates_for_term(self, term, workspace, graph, all_dates):
         """
         Load mask and mask row labels for term.
         """
         mask = term.mask
         mask_offset = graph.extra_rows[mask] - graph.extra_rows[term]
+
+        # This offset is computed against _root_mask_term because that is what
+        # determines the shape of the top-level dates array.
         dates_offset = (
             graph.extra_rows[self._root_mask_term] - graph.extra_rows[term]
         )
-        return workspace[mask][mask_offset:], dates[dates_offset:]
+
+        return workspace[mask][mask_offset:], all_dates[dates_offset:]
 
     @staticmethod
     def _inputs_for_term(term, workspace, graph):

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -9,7 +9,7 @@ from six import itervalues, iteritems
 from zipline.utils.memoize import lazyval
 from zipline.pipeline.visualize import display_graph
 
-from .term import ComputableTerm, LoadableTerm
+from .term import LoadableTerm
 
 
 class CyclicDependency(Exception):


### PR DESCRIPTION
When a custom factor is passed a mask, it computes only over the assets for which the mask returns `True`. This allows computationally expensive factors to not have to compute over an entire universe of stocks.