### PR TITLE
BUG: Stop blowing up when trying to do week_start with trading day zero

### DIFF
--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -335,6 +335,17 @@ class TestStatelessRules(RuleTestCase):
         self.assertTrue(should_trigger(FULL_DAY))
         self.assertFalse(should_trigger(HALF_DAY))
 
+    def test_NthTradingDayOfWeek_day_zero(self):
+        """
+        Test that we don't blow up when trying to call week_start's
+        should_trigger on the first day of a trading environment.
+        """
+        self.assertTrue(
+            NthTradingDayOfWeek(0).should_trigger(
+                self.env.trading_days[0], self.env
+            )
+        )
+
     @subtest(param_range(MAX_WEEK_RANGE), 'n')
     def test_NthTradingDayOfWeek(self, n):
         should_trigger = partial(NthTradingDayOfWeek(n).should_trigger,

--- a/zipline/utils/events.py
+++ b/zipline/utils/events.py
@@ -482,9 +482,19 @@ class NthTradingDayOfWeek(TradingDayOfWeekRule):
     def get_first_trading_day_of_week(dt, env):
         prev = dt
         dt = env.previous_trading_day(dt)
+        # If we're on the first trading day of the TradingEnvironment,
+        # calling previous_trading_day on it will return None, which
+        # will blow up when we try and call .date() on it. The first
+        # trading day of the env is also the first trading day of the
+        # week(in the TradingEnvironment, at least), so just return
+        # that date.
+        if dt is None:
+            return prev
         while dt.date().weekday() < prev.date().weekday():
             prev = dt
             dt = env.previous_trading_day(dt)
+            if dt is None:
+                return prev
         return prev.date()
 
     date_func = get_first_trading_day_of_week


### PR DESCRIPTION
Small bugfix for when we tried to call week_start.should_trigger(trading_days[0]). 

@jbredeche mind taking a look?