### PR TITLE
Fixes to context.portfolio and context.portfolio crashes

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -34,7 +34,8 @@ from zipline.api import FixedSlippage
 from zipline.data.data_portal import DataPortal
 from zipline.data.minute_bars import BcolzMinuteBarWriter, \
     US_EQUITIES_MINUTES_PER_DAY, BcolzMinuteBarReader
-from zipline.data.us_equity_pricing import BcolzDailyBarReader
+from zipline.data.us_equity_pricing import BcolzDailyBarReader, \
+    SQLiteAdjustmentWriter, SQLiteAdjustmentReader
 from zipline.finance.commission import PerShare
 from zipline.finance.execution import LimitOrder
 from zipline.finance.order import ORDER_STATUS
@@ -46,7 +47,8 @@ from zipline.testing.core import (
     create_data_portal,
     create_data_portal_from_trade_history,
     DailyBarWriterFromDataFrames,
-    create_daily_df_for_asset, write_minute_data_for_asset
+    create_daily_df_for_asset, write_minute_data_for_asset,
+    MockDailyBarReader
 )
 from zipline.errors import (
     OrderDuringInitialize,
@@ -107,6 +109,7 @@ from zipline.testing import (
     setup_logger,
     teardown_logger,
     parameter_space,
+    str_to_seconds
 )
 from zipline.utils.api_support import ZiplineAPI, set_algo_instance
 from zipline.utils.context_tricks import CallbackManager
@@ -1017,7 +1020,7 @@ class TestBeforeTradingStart(TestCase):
         )
 
         equities_data = {}
-        for sid in [1, 2]:
+        for sid in [1, 2, 3]:
             equities_data[sid] = {
                 "start_date": cls.trading_days[0],
                 "end_date": cls.trading_days[-1],
@@ -1028,6 +1031,7 @@ class TestBeforeTradingStart(TestCase):
 
         cls.asset1 = cls.env.asset_finder.retrieve_asset(1)
         cls.asset2 = cls.env.asset_finder.retrieve_asset(2)
+        cls.SPLIT_ASSET = cls.env.asset_finder.retrieve_asset(3)
 
         market_opens = cls.env.open_and_closes.market_open.loc[
             cls.trading_days]
@@ -1048,6 +1052,24 @@ class TestBeforeTradingStart(TestCase):
                 cls.trading_days[-1], sid
             )
 
+        # Write data with split asset
+        asset_minutes = cls.env.minutes_for_days_in_range(
+            cls.trading_days[0], cls.trading_days[-1])
+        minutes_count = len(asset_minutes)
+        minutes_arr = np.array(range(1, 1 + minutes_count))
+
+        df = pd.DataFrame({
+            "open": minutes_arr + 1,
+            "high": minutes_arr + 2,
+            "low": minutes_arr - 1,
+            "close": minutes_arr,
+            "volume": 100 * minutes_arr,
+            "dt": asset_minutes
+        }).set_index("dt")
+        df.iloc[780:] = df.iloc[780:] / 2.0
+
+        minute_writer.write(3, df)
+
         # asset2 only trades every 50 minutes
         write_minute_data_for_asset(
             cls.env, minute_writer, cls.trading_days[0],
@@ -1055,12 +1077,15 @@ class TestBeforeTradingStart(TestCase):
         )
 
         cls.minute_reader = BcolzMinuteBarReader(cls.tempdir.path)
+        cls.adj_reader = cls.create_adjustments_reader()
 
         cls.daily_path = cls.tempdir.getpath("testdaily.bcolz")
         dfs = {
             1: create_daily_df_for_asset(cls.env, cls.trading_days[0],
                                          cls.trading_days[-1]),
             2: create_daily_df_for_asset(cls.env, cls.trading_days[0],
+                                         cls.trading_days[-1]),
+            3: create_daily_df_for_asset(cls.env, cls.trading_days[0],
                                          cls.trading_days[-1])
         }
         daily_writer = DailyBarWriterFromDataFrames(dfs)
@@ -1076,8 +1101,44 @@ class TestBeforeTradingStart(TestCase):
         cls.data_portal = DataPortal(
             env=cls.env,
             equity_daily_reader=BcolzDailyBarReader(cls.daily_path),
-            equity_minute_reader=cls.minute_reader
+            equity_minute_reader=cls.minute_reader,
+            adjustment_reader=cls.adj_reader
         )
+
+    @classmethod
+    def create_adjustments_reader(cls):
+        path = cls.tempdir.getpath("test_adjustments.db")
+
+        adj_writer = SQLiteAdjustmentWriter(
+            path,
+            cls.env.trading_days,
+            MockDailyBarReader()
+        )
+
+        splits = pd.DataFrame([
+            {
+                'effective_date': str_to_seconds("2016-01-07"),
+                'ratio': 0.5,
+                'sid': cls.SPLIT_ASSET.sid
+            }
+        ])
+
+        # Mergers and Dividends are not tested, but we need to have these
+        # anyway
+        mergers = pd.DataFrame({}, columns=['effective_date', 'ratio', 'sid'])
+        mergers.effective_date = mergers.effective_date.astype(int)
+        mergers.ratio = mergers.ratio.astype(float)
+        mergers.sid = mergers.sid.astype(int)
+
+        dividends = pd.DataFrame({}, columns=['ex_date', 'record_date',
+                                              'declared_date', 'pay_date',
+                                              'amount', 'sid'])
+        dividends.amount = dividends.amount.astype(float)
+        dividends.sid = dividends.sid.astype(int)
+
+        adj_writer.write(splits, mergers, dividends)
+
+        return SQLiteAdjustmentReader(path)
 
     @classmethod
     def tearDownClass(cls):
@@ -1239,6 +1300,46 @@ class TestBeforeTradingStart(TestCase):
         # second bar of 1/06, where the price is 391, and costs the default
         # commission of 1. On 1/07, the price is 780, and the increase in
         # portfolio value is 780-392-1
+        self.assertEqual(results.port_value.iloc[0], 10000)
+        self.assertAlmostEqual(results.port_value.iloc[1],
+                               10000 + 780 - 392 - 1)
+
+    def test_portfolio_and_account_bts_with_overnight_split(self):
+        algo_code = dedent("""
+        from zipline.api import order, sid, get_datetime, record
+
+        def initialize(context):
+            context.ordered = False
+
+        def before_trading_start(context, data):
+            record(pos_value=context.portfolio.positions_value)
+            record(pos_amount=context.portfolio.positions[sid(3)]['amount'])
+            record(port_value=context.account.equity_with_loan)
+
+        def handle_data(context, data):
+            if not context.ordered:
+                order(sid(3), 1)
+                context.ordered = True
+        """)
+
+        algo = TradingAlgorithm(
+            script=algo_code,
+            data_frequency="minute",
+            sim_params=self.sim_params,
+            env=self.env
+        )
+
+        results = algo.run(self.data_portal)
+
+        # On 1/07, positions value should by 780, same as without split
+        self.assertEqual(results.pos_value.iloc[0], 0)
+        self.assertEqual(results.pos_value.iloc[1], 780)
+
+        # On 1/07, after applying the split, 1 share becomes 2
+        self.assertEqual(results.pos_amount.iloc[0], 0)
+        self.assertEqual(results.pos_amount.iloc[1], 2)
+
+        # On 1/07, portfolio value is the same as without split
         self.assertEqual(results.port_value.iloc[0], 10000)
         self.assertAlmostEqual(results.port_value.iloc[1],
                                10000 + 780 - 392 - 1)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1066,7 +1066,13 @@ class TradingAlgorithm(object):
 
         self.portfolio_needs_update = True
         self.account_needs_update = True
-        self.performance_needs_update = True
+
+        # Do not update performance if we are at midnight. Portfolio and
+        # Account have already been adjusted for splits
+        if not normalize_date(dt) == dt:
+            self.performance_needs_update = True
+        else:
+            self.performance_needs_update = False
 
     @api_method
     def get_datetime(self, tz=None):

--- a/zipline/finance/performance/position.py
+++ b/zipline/finance/performance/position.py
@@ -103,6 +103,10 @@ class Position(object):
         self.cost_basis = new_cost_basis
         self.amount = full_share_count
 
+        # adjust the last sale price so the portfolio is up-to-date in
+        # before_trading_start
+        self.last_sale_price = round(self.last_sale_price * ratio, 2)
+
         return_cash = round(float(fractional_share_count * new_cost_basis), 2)
 
         log.info("after split: " + str(self))

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -169,9 +169,6 @@ class PerformanceTracker(object):
         self.day_count = 0.0
         self.txn_count = 0
 
-        self.account_needs_update = True
-        self._account = None
-
     def __repr__(self):
         return "%s(%r)" % (
             self.__class__.__name__,
@@ -194,7 +191,6 @@ class PerformanceTracker(object):
         if performance_needs_update:
             self.position_tracker.sync_last_sale_prices(dt)
             self.update_performance()
-            self.account_needs_update = True
         return self.cumulative_performance.as_portfolio()
 
     def update_performance(self):
@@ -206,14 +202,7 @@ class PerformanceTracker(object):
         if performance_needs_update:
             self.position_tracker.sync_last_sale_prices(dt)
             self.update_performance()
-            self.account_needs_update = True
-        if self.account_needs_update:
-            self._update_account()
-        return self._account
-
-    def _update_account(self):
-        self._account = self.cumulative_performance.as_account()
-        self.account_needs_update = False
+        return self.cumulative_performance.as_account()
 
     def to_dict(self, emission_type=None):
         """

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -166,9 +166,6 @@ class AlgorithmSimulator(object):
             # before cleaning up expired assets.
             self._cleanup_expired_assets(midnight_dt, position_assets)
 
-            # call before trading start
-            algo.before_trading_start(current_data)
-
             perf_tracker = algo.perf_tracker
 
             # handle any splits that impact any positions or any open orders.
@@ -182,6 +179,9 @@ class AlgorithmSimulator(object):
                 if splits:
                     algo.blotter.process_splits(splits)
                     perf_tracker.position_tracker.handle_splits(splits)
+
+            # call before trading start
+            algo.before_trading_start(current_data)
 
         def handle_benchmark(date):
             algo.perf_tracker.all_benchmark_returns[date] = \


### PR DESCRIPTION
- Minute bar reader is now compatible with non trading minutes
- Calls to context.portfolio and context.account in BTS should adjust for overnight splits

IMPORTANT: Only the first commit passes right now. The second commit breaks tests for daily mode algos