### PR TITLE
Apply adjustments for portfolio and account in BTS

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -190,7 +190,8 @@ def calculate_results(sim_params,
             pass
 
         msg = perf_tracker.handle_market_close_daily(date)
-        msg['account'] = perf_tracker.get_account(True, date)
+        perf_tracker.position_tracker.sync_last_sale_prices(date, False)
+        msg['account'] = perf_tracker.get_account(True)
         results.append(copy.deepcopy(msg))
     return results
 
@@ -1251,7 +1252,7 @@ class TestPositionPerformance(unittest.TestCase):
         pp.handle_execution(txn2)
 
         dt = trades_1[-2].dt
-        pt.sync_last_sale_prices(dt)
+        pt.sync_last_sale_prices(dt, False)
 
         pp.calculate_performance()
 
@@ -1279,7 +1280,7 @@ class TestPositionPerformance(unittest.TestCase):
                       net_liquidation=1000.0)
 
         dt = trades_1[-1].dt
-        pt.sync_last_sale_prices(dt)
+        pt.sync_last_sale_prices(dt, False)
 
         pp.calculate_performance()
 
@@ -1354,7 +1355,7 @@ class TestPositionPerformance(unittest.TestCase):
             shorts_count=0)
 
         # Validate that the account attributes were updated.
-        pt.sync_last_sale_prices(trades[-2].dt)
+        pt.sync_last_sale_prices(trades[-2].dt, False)
 
         # Validate that the account attributes were updated.
         account = pp.as_account()
@@ -1372,7 +1373,7 @@ class TestPositionPerformance(unittest.TestCase):
                       net_liquidation=1000.0)
 
         # now simulate a price jump to $11
-        pt.sync_last_sale_prices(trades[-1].dt)
+        pt.sync_last_sale_prices(trades[-1].dt, False)
 
         pp.calculate_performance()
 
@@ -1443,7 +1444,7 @@ class TestPositionPerformance(unittest.TestCase):
         # stocks with a last sale price of 0.
         self.assertEqual(pp.positions[1].last_sale_price, 10.0)
 
-        pt.sync_last_sale_prices(trades[-1].dt)
+        pt.sync_last_sale_prices(trades[-1].dt, False)
 
         pp.calculate_performance()
 
@@ -1554,7 +1555,7 @@ single short-sale transaction"""
         pt.execute_transaction(txn)
         pp.handle_execution(txn)
 
-        pt.sync_last_sale_prices(trades_1[-1].dt)
+        pt.sync_last_sale_prices(trades_1[-1].dt, False)
 
         pp.calculate_performance()
 
@@ -1610,7 +1611,7 @@ single short-sale transaction"""
         # simulate a rollover to a new period
         pp.rollover()
 
-        pt.sync_last_sale_prices(trades[-1].dt)
+        pt.sync_last_sale_prices(trades[-1].dt, False)
 
         pp.calculate_performance()
 
@@ -1674,7 +1675,7 @@ single short-sale transaction"""
         ptTotal.execute_transaction(txn)
         ppTotal.handle_execution(txn)
 
-        ptTotal.sync_last_sale_prices(trades[-1].dt)
+        ptTotal.sync_last_sale_prices(trades[-1].dt, False)
 
         ppTotal.calculate_performance()
 
@@ -1794,7 +1795,7 @@ cost of sole txn in test"
         # stocks with a last sale price of 0.
         self.assertEqual(pp.positions[3].last_sale_price, 10.0)
 
-        pt.sync_last_sale_prices(trades[-1].dt)
+        pt.sync_last_sale_prices(trades[-1].dt, False)
         pp.calculate_performance()
 
         self.assertEqual(
@@ -1908,7 +1909,7 @@ single short-sale transaction"""
         pt.execute_transaction(txn)
         pp.handle_execution(txn)
 
-        pt.sync_last_sale_prices(trades[-3].dt)
+        pt.sync_last_sale_prices(trades[-3].dt, False)
         pp.calculate_performance()
 
         self.assertEqual(
@@ -1968,7 +1969,7 @@ single short-sale transaction"""
         # simulate a rollover to a new period
         pp.rollover()
 
-        pt.sync_last_sale_prices(trades_2[-1].dt)
+        pt.sync_last_sale_prices(trades_2[-1].dt, False)
         pp.calculate_performance()
 
         self.assertEqual(
@@ -2034,13 +2035,13 @@ single short-sale transaction"""
         ppTotal.position_tracker = ptTotal
 
         for trade in trades_1:
-            ptTotal.sync_last_sale_prices(trade.dt)
+            ptTotal.sync_last_sale_prices(trade.dt, False)
 
         ptTotal.execute_transaction(txn)
         ppTotal.handle_execution(txn)
 
         for trade in trades_2:
-            ptTotal.sync_last_sale_prices(trade.dt)
+            ptTotal.sync_last_sale_prices(trade.dt, False)
 
         ppTotal.calculate_performance()
 
@@ -2155,7 +2156,7 @@ trade after cover"""
         pt.execute_transaction(cover_txn)
         pp.handle_execution(cover_txn)
 
-        pt.sync_last_sale_prices(trades[-1].dt)
+        pt.sync_last_sale_prices(trades[-1].dt, False)
 
         pp.calculate_performance()
 
@@ -2263,7 +2264,7 @@ shares in position"
             "should have a cost basis of 11"
         )
 
-        pt.sync_last_sale_prices(dt)
+        pt.sync_last_sale_prices(dt, False)
 
         pp.calculate_performance()
 
@@ -2280,7 +2281,7 @@ shares in position"
         pp.handle_execution(sale_txn)
 
         dt = down_tick.dt
-        pt.sync_last_sale_prices(dt)
+        pt.sync_last_sale_prices(dt, False)
 
         pp.calculate_performance()
         self.assertEqual(
@@ -2316,7 +2317,7 @@ shares in position"
         pp3.handle_execution(sale_txn)
 
         trades.append(down_tick)
-        pt3.sync_last_sale_prices(trades[-1].dt)
+        pt3.sync_last_sale_prices(trades[-1].dt, False)
 
         pp3.calculate_performance()
         self.assertEqual(

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1056,9 +1056,10 @@ class TradingAlgorithm(object):
 
     def updated_portfolio(self):
         if self.portfolio_needs_update:
+            self.perf_tracker.position_tracker.sync_last_sale_prices(
+                self.datetime, self._in_before_trading_start)
             self._portfolio = \
-                self.perf_tracker.get_portfolio(self.performance_needs_update,
-                                                self.datetime)
+                self.perf_tracker.get_portfolio(self.performance_needs_update)
             self.portfolio_needs_update = False
             self.performance_needs_update = False
         return self._portfolio
@@ -1069,9 +1070,10 @@ class TradingAlgorithm(object):
 
     def updated_account(self):
         if self.account_needs_update:
+            self.perf_tracker.position_tracker.sync_last_sale_prices(
+                self.datetime, self._in_before_trading_start)
             self._account = \
-                self.perf_tracker.get_account(self.performance_needs_update,
-                                              self.datetime)
+                self.perf_tracker.get_account(self.performance_needs_update)
             self.account_needs_update = False
             self.performance_needs_update = False
         return self._account

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -372,15 +372,28 @@ class PositionTracker(object):
                 positions.append(pos.to_dict())
         return positions
 
-    def sync_last_sale_prices(self, dt):
+    def sync_last_sale_prices(self, dt, in_bts):
         data_portal = self._data_portal
-        for asset, position in iteritems(self.positions):
-            last_sale_price = data_portal.get_spot_value(
-                asset, 'price', dt, self.data_frequency
-            )
+        if not in_bts:
+            for asset, position in iteritems(self.positions):
+                last_sale_price = data_portal.get_spot_value(
+                    asset, 'price', dt, self.data_frequency
+                )
 
-            if not np.isnan(last_sale_price):
-                position.last_sale_price = last_sale_price
+                if not np.isnan(last_sale_price):
+                    position.last_sale_price = last_sale_price
+        else:
+            for asset, position in iteritems(self.positions):
+                last_sale_price = data_portal.get_adjusted_value(
+                    asset,
+                    'price',
+                    data_portal.env.previous_market_minute(dt),
+                    dt,
+                    self.data_frequency
+                )
+
+                if not np.isnan(last_sale_price):
+                    position.last_sale_price = last_sale_price
 
     def stats(self):
         amounts = []

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -190,9 +190,8 @@ class PerformanceTracker(object):
             self.saved_dt = date
             self.todays_performance.period_close = self.saved_dt
 
-    def get_portfolio(self, performance_needs_update, dt):
+    def get_portfolio(self, performance_needs_update):
         if performance_needs_update:
-            self.position_tracker.sync_last_sale_prices(dt)
             self.update_performance()
             self.account_needs_update = True
         return self.cumulative_performance.as_portfolio()
@@ -202,9 +201,8 @@ class PerformanceTracker(object):
         self.cumulative_performance.calculate_performance()
         self.todays_performance.calculate_performance()
 
-    def get_account(self, performance_needs_update, dt):
+    def get_account(self, performance_needs_update):
         if performance_needs_update:
-            self.position_tracker.sync_last_sale_prices(dt)
             self.update_performance()
             self.account_needs_update = True
         if self.account_needs_update:
@@ -329,10 +327,10 @@ class PerformanceTracker(object):
             A tuple of the minute perf packet and daily perf packet.
             If the market day has not ended, the daily perf packet is None.
         """
-        self.position_tracker.sync_last_sale_prices(dt)
+        self.position_tracker.sync_last_sale_prices(dt, False)
         self.update_performance()
         todays_date = normalize_date(dt)
-        account = self.get_account(False, dt)
+        account = self.get_account(False)
 
         bench_returns = self.all_benchmark_returns.loc[todays_date:dt]
         # cumulative returns
@@ -357,10 +355,10 @@ class PerformanceTracker(object):
         Function called after handle_data when running with daily emission
         rate.
         """
-        self.position_tracker.sync_last_sale_prices(dt)
+        self.position_tracker.sync_last_sale_prices(dt, False)
         self.update_performance()
         completed_date = self.day
-        account = self.get_account(False, dt)
+        account = self.get_account(False)
 
         benchmark_value = self.all_benchmark_returns[completed_date]
 

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -166,9 +166,6 @@ class AlgorithmSimulator(object):
             # before cleaning up expired assets.
             self._cleanup_expired_assets(midnight_dt, position_assets)
 
-            # call before trading start
-            algo.before_trading_start(current_data)
-
             perf_tracker = algo.perf_tracker
 
             # handle any splits that impact any positions or any open orders.
@@ -182,6 +179,9 @@ class AlgorithmSimulator(object):
                 if splits:
                     algo.blotter.process_splits(splits)
                     perf_tracker.position_tracker.handle_splits(splits)
+
+            # call before trading start
+            algo.before_trading_start(current_data)
 
         def handle_benchmark(date):
             algo.perf_tracker.all_benchmark_returns[date] = \


### PR DESCRIPTION
Adjust for overnight splits when calculating `context.account` and `context.portfolio` in `before_trading_start`:
  - `sync_last_sale_price` takes an additional argument `in_bts`, which if True, will cause the price be calculated using `data_portal.get_adjusted_value` as opposed to `data_portal.get_spot_value`
  - Move the call to `sync_last_sale_price` to `TradingAlgorithm`
  - Call the user `before_trading_start` after applying adjustments
  - Tests for these functionalities, plus improvements on previous tests for account and portfolio in BTS 