### PR TITLE
TST: Remove coverage from default nose config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 before_script:
   - pip freeze | sort
 script:
-  - nosetests tests/
+  - nosetests --with-coverage tests/
   - flake8 zipline tests
   # deactive env to get access to anaconda command
   - source deactivate

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ detailed-errors=1
 with-ignore-docstrings=1
 with-timer=1
 timer-top-n=15
-with-coverage=1
 cover-package=zipline
 
 [metadata]


### PR DESCRIPTION
Add --with-coverage flag to Travis, so that reports are generated during
continuous integration, but not during every invocation when running
tests locally.