### PR TITLE
FIX: time_rules should trigger only at dt specified

### DIFF
--- a/zipline/utils/events.py
+++ b/zipline/utils/events.py
@@ -364,11 +364,7 @@ class AfterOpen(StatelessRule):
         ):
             self.calculate_dates(dt, env)
 
-        if self._period_start <= dt < self._period_end:
-            # haven't made it past the offset yet
-            return False
-        else:
-            return True
+        return dt == self._period_end
 
 
 class BeforeClose(StatelessRule):
@@ -394,7 +390,7 @@ class BeforeClose(StatelessRule):
         # given a dt, find that day's close and period start (close - offset)
         self._period_end = env.get_open_and_close(dt)[1]
         self._period_start = \
-            self._period_end - self.offset - self._one_minute
+            self._period_end - self.offset
         self._period_close = self._period_end
 
     def should_trigger(self, dt, env):
@@ -413,8 +409,7 @@ class BeforeClose(StatelessRule):
         ):
             self.calculate_dates(dt, env)
 
-        # Return true if we're within the interval specified.
-        return self._period_start < dt <= self._period_end
+        return self._period_start == dt
 
 
 class NotHalfDay(StatelessRule):


### PR DESCRIPTION
Previously, in Q1, a `time_rule` triggered when the dt specified has passed. This was to accommodate the possibility that `handle_data` would not run if there was no new event or data for a particular bar. In Q2, we necessarily check every bar to see if `time_rule` triggers. Thus, we should check that the current dt equals the rule dt.

As a result, in the case of a live algo starting mid-day, any function scheduled for earlier that day will not run. For example:
  - live algo starts at 2 pm and has a function with a time rule of 1 hr after open --> function will not run on first day
  - live algo starts at 2 pm and has a function with a date rule of every day (no time rule means it runs at market open) --> function will not run on first day    