### PR TITLE
ENH: make handle_data optional

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -106,8 +106,8 @@ from zipline.test_algorithms import (
     call_with_kwargs,
     call_without_kwargs,
     call_with_bad_kwargs_current,
-    call_with_bad_kwargs_history
-)
+    call_with_bad_kwargs_history,
+    no_handle_data)
 from zipline.testing import (
     make_jagged_equity_info,
     to_utc,
@@ -1489,6 +1489,10 @@ class TestAlgoScript(TestCase):
 
     def test_noop_string(self):
         algo = TradingAlgorithm(script=noop_algo)
+        algo.run(self.data_portal)
+
+    def test_no_handle_data(self):
+        algo = TradingAlgorithm(script=no_handle_data)
         algo.run(self.data_portal)
 
     def test_api_calls(self):

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -318,6 +318,8 @@ class TradingAlgorithm(object):
             create_context=kwargs.pop('create_event_context', None),
         )
 
+        self._handle_data = None
+
         if self.algoscript is not None:
             filename = kwargs.pop('algo_filename', None)
             if filename is None:
@@ -325,9 +327,7 @@ class TradingAlgorithm(object):
             code = compile(self.algoscript, filename, 'exec')
             exec_(code, self.namespace)
             self._initialize = self.namespace.get('initialize')
-            if 'handle_data' not in self.namespace:
-                raise ValueError('You must define a handle_data function.')
-            else:
+            if 'handle_data' in self.namespace:
                 self._handle_data = self.namespace['handle_data']
 
             self._before_trading_start = \
@@ -407,7 +407,8 @@ class TradingAlgorithm(object):
         self._in_before_trading_start = False
 
     def handle_data(self, data):
-        self._handle_data(self, data)
+        if self._handle_data:
+            self._handle_data(self, data)
 
         # Unlike trading controls which remain constant unless placing an
         # order, account controls can change each bar. Thus, must check

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -784,6 +784,11 @@ def handle_data(context, data):
     pass
 """
 
+no_handle_data = """
+def initialize(context):
+    pass
+"""
+
 api_algo = """
 from zipline.api import (order,
                          set_slippage,


### PR DESCRIPTION
`handle_data` is no longer strictly needed, as one can use `schedule_function` to define trading logic that doesn't need to happen every minute.