### PR TITLE
FIX: Check types of args passed to api methods on data

### DIFF
--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -42,14 +42,12 @@ cdef class check_parameters(object):
     TypeError with a meaningful message.
     """
     cdef tuple keyword_names
-    cdef object method
     cdef tuple types
     cdef dict keys_to_types
 
-    def __init__(self, method_name, keyword_names, types):
+    def __init__(self, keyword_names, types):
         self.keyword_names = keyword_names
         self.types = types
-        self.method = method_name
 
         self.keys_to_types = dict(zip(keyword_names, types))
 
@@ -59,7 +57,7 @@ cdef class check_parameters(object):
             for field in kwargs:
                 if field not in self.keyword_names:
                     raise TypeError("%s() got an unexpected keyword argument"
-                                    " '%s'" % (self.method, field))
+                                    " '%s'" % (func.__name__, field))
 
             # verify type of each arg
             for i, arg in enumerate(args[1:]):
@@ -206,7 +204,7 @@ cdef class BarData:
 
         return dt
 
-    @check_parameters('current', ('assets', 'fields'), ((Asset, str), str))
+    @check_parameters(('assets', 'fields'), ((Asset, str), str))
     def current(self, assets, fields):
         """
         Returns the current value of the given assets for the given fields
@@ -381,7 +379,7 @@ cdef class BarData:
 
                 return pd.DataFrame(data)
 
-    @check_parameters('can_trade', ('assets',), (Asset,))
+    @check_parameters(('assets',), (Asset,))
     def can_trade(self, assets):
         """
         For the given asset or iterable of assets, returns true if the asset
@@ -428,7 +426,7 @@ cdef class BarData:
 
         return False
 
-    @check_parameters('is_stale', ('assets',), (Asset,))
+    @check_parameters(('assets',), (Asset,))
     def is_stale(self, assets):
         """
         For the given asset or iterable of assets, returns true if the asset
@@ -488,8 +486,7 @@ cdef class BarData:
 
             return not (last_traded_dt is pd.NaT)
 
-    @check_parameters('history',
-                      ('assets', 'fields', 'bar_count', 'frequency'),
+    @check_parameters(('assets', 'fields', 'bar_count', 'frequency'),
                       ((Asset, str), str, int, str))
     def history(self, assets, fields, bar_count, frequency):
         """

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -21,6 +21,7 @@ import numpy as np
 
 from six import iteritems
 from cpython cimport bool
+from collections import Iterable
 
 from zipline.assets import Asset
 from zipline.zipline_warnings import ZiplineDeprecationWarning
@@ -33,18 +34,78 @@ class assert_keywords(object):
     meaningful message, unlike the one cython returns by default.
     """
 
-    def __init__(self, *args):
-        self.names = args
+    def __init__(self, arg_names, method_name):
+        self.names = arg_names
+        self.method = method_name
 
     def __call__(self, func):
         def assert_keywords_and_call(*args, **kwargs):
             for field in kwargs:
                 if field not in self.names:
                     raise TypeError("%s() got an unexpected keyword argument"
-                                    " '%s'" % (func.__name__, field))
+                                    " '%s'" % (self.method, field))
             return func(*args, **kwargs)
 
         return assert_keywords_and_call
+
+
+KEYWORDS = ['assets', 'fields', 'bar_count', 'frequency']
+
+
+class assert_types(object):
+    """
+    Asserts that the arguments passed into the wrapped function are consistent
+    with the types passed into this decorator. If not, raise a TypeError with
+    a meaningful message.
+    """
+
+    def __init__(self, *args):
+        self.types = args
+        self.keys_to_types = dict(zip(KEYWORDS, args))
+
+    def _is_iterable(self, obj):
+        return isinstance(obj, Iterable) and not isinstance(obj, str)
+
+    def __call__(self, func):
+        def assert_types_and_call(*args, **kwargs):
+            for i, arg in enumerate(args[1:]):
+                if isinstance(arg, self.types[i]):
+                    continue
+                elif i in (0, 1) and self._is_iterable(arg):
+                    if isinstance(arg[0], self.types[i]):
+                        continue
+
+                expected_type = self.types[i].__name__ \
+                    if not self._is_iterable(self.types[i]) \
+                    else ', '.join([type.__name__ for type in self.types[i]])
+                raise TypeError("Expected %s argument to be of type %s%s" %
+                                (KEYWORDS[i],
+                                 'or iterable of type ' if i in (0, 1) else '',
+                                 expected_type)
+                )
+
+            for keyword, arg in iteritems(kwargs):
+                if isinstance(arg, self.keys_to_types[keyword]):
+                    continue
+                elif keyword in ('assets', 'fields') and \
+                        self._is_iterable(arg):
+                    if isinstance(arg[0], self.keys_to_types[i]):
+                        continue
+
+                expected_type = self.keys_to_types[keyword].__name__ \
+                    if not self._is_iterable(self.keys_to_types[keyword]) \
+                    else ', '.join([type.__name__ for type in
+                                    self.keys_to_types[keyword]])
+                raise TypeError("Expected %s argument to be of type %s%s" %
+                                (keyword,
+                                 'or iterable of type ' if keyword in
+                                 ('assets', 'fields') else '',
+                                 expected_type)
+                )
+
+            return func(*args, **kwargs)
+
+        return assert_types_and_call
 
 
 @contextmanager
@@ -149,7 +210,8 @@ cdef class BarData:
 
         return dt
 
-    @assert_keywords('assets', 'fields')
+    @assert_keywords(arg_names=('assets', 'fields'), method_name='current')
+    @assert_types((Asset, str), str)
     def current(self, assets, fields):
         """
         Returns the current value of the given assets for the given fields
@@ -327,6 +389,7 @@ cdef class BarData:
     cdef bool _is_iterable(self, obj):
         return hasattr(obj, '__iter__') and not isinstance(obj, str)
 
+    @assert_types(Asset)
     def can_trade(self, assets):
         """
         For the given asset or iterable of assets, returns true if the asset
@@ -373,6 +436,7 @@ cdef class BarData:
 
         return False
 
+    @assert_types(Asset)
     def is_stale(self, assets):
         """
         For the given asset or iterable of assets, returns true if the asset
@@ -432,7 +496,9 @@ cdef class BarData:
 
             return not (last_traded_dt is pd.NaT)
 
-    @assert_keywords('assets', 'fields', 'bar_count', 'frequency')
+    @assert_keywords(arg_names=('assets', 'fields', 'bar_count', 'frequency'),
+                     method_name='history')
+    @assert_types((Asset, str), str, int, str)
     def history(self, assets, fields, bar_count, frequency):
         """
         Returns a window of data for the given assets and fields.

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -714,9 +714,6 @@ class DataPortal(object):
         if field not in BASE_FIELDS:
             raise KeyError("Invalid column: " + str(field))
 
-        if isinstance(asset, int):
-            asset = self.env.asset_finder.retrieve_asset(asset)
-
         if dt < asset.start_date or \
                 (data_frequency == "daily" and dt > asset.end_date) or \
                 (data_frequency == "minute" and
@@ -847,8 +844,6 @@ class DataPortal(object):
         -------
         The value of the desired field at the desired time.
         """
-        if isinstance(asset, int):
-            asset = self._asset_finder.retrieve_asset(asset)
 
         if spot_value is None:
             spot_value = self.get_spot_value(asset, field, dt, data_frequency)

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -957,3 +957,134 @@ def initialize(context):
 def handle_data(context, data):
     current = data.current(assets=symbol('TEST'), blahblah="price")
 """
+
+bad_type_history_assets = """
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(1, 'price', 5, '1d')
+"""
+
+bad_type_history_fields = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(symbol('TEST'), 10 , 5, '1d')
+"""
+
+bad_type_history_bar_count = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(symbol('TEST'), 'price', '5', '1d')
+"""
+
+bad_type_history_frequency = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(symbol('TEST'), 'price', 5, 1)
+"""
+
+bad_type_current_assets = """
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.current(1, 'price')
+"""
+
+bad_type_current_fields = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.current(symbol('TEST'), 10)
+"""
+
+bad_type_is_stale_assets = """
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.is_stale('TEST')
+"""
+
+bad_type_can_trade_assets = """
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.can_trade('TEST')
+"""
+
+bad_type_history_assets_kwarg = """
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(frequency='1d', fields='price', assets=1, bar_count=5)
+"""
+
+bad_type_history_fields_kwarg = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(frequency='1d', fields=10, assets=symbol('TEST'),
+                 bar_count=5)
+"""
+
+bad_type_history_bar_count_kwarg = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(frequency='1d', fields='price', assets=symbol('TEST'),
+                 bar_count='5')
+"""
+
+bad_type_history_frequency_kwarg = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.history(frequency=1, fields='price', assets=symbol('TEST'),
+                 bar_count=5)
+"""
+
+bad_type_current_assets_kwarg = """
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.current(fields='price', assets=1)
+"""
+
+bad_type_current_fields_kwarg = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    data.current(fields=10, assets=symbol('TEST'))
+"""


### PR DESCRIPTION
Ensures that for methods `current`, `history`, `can_trade` and `is_stale`:
  - assets must be an Asset object or str (or iterable of either) for `current` and `history` but only Asset (or iterable of Asset) for the other two
  - fields must be str or iterable or str
  - bar_count must be int
  - frequency must be str

This solution is not particularly elegant, but we have a new decorator `assert_types` that takes the expected types, and checks that the args passed to the function are of the correct type
  