### PR TITLE
Support multiple outputs for custom factors

### DIFF
--- a/docs/source/whatsnew/1.0.0.txt
+++ b/docs/source/whatsnew/1.0.0.txt
@@ -24,6 +24,14 @@ Enhancements
   dataframe. This model allows us to pass these writer objects around as a
   resource for other classes and functions to consume (:issue:`1109`).
 
+* Implemented :class:`zipline.pipeline.factors.RecarrayField`, a new pipeline
+  term designed to be the output type of a CustomFactor with multiple outputs.
+  (:issue:`1119`)
+
+* Added optional `outputs` parameter to :class:`zipline.pipeline.CustomFactor`.
+  Custom factors are now capable of computing and returning multiple outputs,
+  each of which are themselves a Factor. (:issue:`1119`)
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -433,10 +433,20 @@ class TermInputsNotSpecified(ZiplineError):
     msg = "{termname} requires inputs, but no inputs list was passed."
 
 
+class TermOutputsEmpty(ZiplineError):
+    """
+    Raised if a user attempts to construct a term with an empty outputs list.
+    """
+    msg = (
+        "{termname} requires at least one output when passed an outputs "
+        "argument."
+    )
+
+
 class WindowLengthNotSpecified(ZiplineError):
     """
-    Raised if a user attempts to construct a term without specifying inputs and
-    that term does not have class-level default inputs.
+    Raised if a user attempts to construct a term without specifying window
+    length and that term does not have a class-level default window length.
     """
     msg = (
         "{termname} requires a window_length, but no window_length was passed."

--- a/zipline/pipeline/factors/__init__.py
+++ b/zipline/pipeline/factors/__init__.py
@@ -1,7 +1,8 @@
 from .factor import (
     CustomFactor,
     Factor,
-    Latest
+    Latest,
+    RecarrayField,
 )
 from .events import (
     BusinessDaysSinceCashBuybackAuth,
@@ -44,6 +45,7 @@ __all__ = [
     'Latest',
     'MaxDrawdown',
     'RSI',
+    'RecarrayField',
     'Returns',
     'SimpleMovingAverage',
     'VWAP',

--- a/zipline/pipeline/mixins.py
+++ b/zipline/pipeline/mixins.py
@@ -1,7 +1,7 @@
 """
 Mixins classes for use with Filters and Factors.
 """
-from numpy import full_like
+from numpy import full_like, recarray
 
 from zipline.utils.control_flow import nullctx
 from zipline.errors import WindowLengthNotPositive, UnsupportedDataType
@@ -69,6 +69,7 @@ class CustomTermMixin(object):
 
     def __new__(cls,
                 inputs=NotSpecified,
+                outputs=NotSpecified,
                 window_length=NotSpecified,
                 mask=NotSpecified,
                 dtype=NotSpecified,
@@ -88,6 +89,7 @@ class CustomTermMixin(object):
         return super(CustomTermMixin, cls).__new__(
             cls,
             inputs=inputs,
+            outputs=outputs,
             window_length=window_length,
             mask=mask,
             dtype=dtype,
@@ -109,7 +111,16 @@ class CustomTermMixin(object):
         compute = self.compute
         missing_value = self.missing_value
         params = self.params
-        out = full_like(mask, missing_value, dtype=self.dtype)
+        outputs = self.outputs
+        if outputs is not NotSpecified:
+            out = recarray(
+                mask.shape,
+                formats=[self.dtype.str] * len(outputs),
+                names=outputs,
+            )
+            out[:] = missing_value
+        else:
+            out = full_like(mask, missing_value, dtype=self.dtype)
         with self.ctx:
             # TODO: Consider pre-filtering columns that are all-nan at each
             # time-step?


### PR DESCRIPTION
Add an optional `outputs` parameter to CustomFactor allowing multiple outputs to be computed and returned from a single CustomFactor, each output of which is itself a Factor.