### PR TITLE
BUG: Enforce sorted order on minutes to delete.

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -47,7 +47,10 @@ from zipline.data.minute_bars import (
 from zipline.finance.trading import TradingEnvironment
 
 
-TEST_CALENDAR_START = Timestamp('2015-06-01', tz='UTC')
+# Calendar is set to cover several half days, to check a case where half
+# days would be read out of order in cases of windows which spanned over
+# multiple half days.
+TEST_CALENDAR_START = Timestamp('2014-06-02', tz='UTC')
 TEST_CALENDAR_STOP = Timestamp('2015-12-31', tz='UTC')
 
 

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -695,7 +695,7 @@ class BcolzMinuteBarReader(object):
             intervals = itree[start_idx:end_idx]
             for interval in intervals:
                 ranges.append(interval.data)
-            return ranges
+            return sorted(ranges)
         else:
             return None
 


### PR DESCRIPTION
The intervals are returned as a set, so order is not guaranteed,
which becomes exposed when reading windows which span multiple years.

The deletion of values from the regular sized minute array assumes that
intervals can be reversed to delete the array from the back.