### PR TITLE
Limit leak in us equity loader on stock rotation

### DIFF
--- a/conda/cachetools/bld.bat
+++ b/conda/cachetools/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda/cachetools/build.sh
+++ b/conda/cachetools/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda/cachetools/meta.yaml
+++ b/conda/cachetools/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: cachetools
+  version: "1.1.6"
+
+source:
+  fn: cachetools-1.1.6.tar.gz
+  url: https://pypi.python.org/packages/source/c/cachetools/cachetools-1.1.6.tar.gz
+  md5: 387d7f34effd9335ae55bd0762e77bfa
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - cachetools = cachetools:main
+    #
+    # Would create an entry point called cachetools that calls cachetools.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - cachetools
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/tkem/cachetools
+  license: MIT License
+  summary: 'Extensible memoizing collections and decorators'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -58,3 +58,5 @@ sqlalchemy==1.0.8
 # for intervaltree
 sortedcontainers==1.4.4
 intervaltree==2.1.0
+
+cachetools==1.1.5


### PR DESCRIPTION
BUG: Add limit to memory growth on sliding windows

    Add a cap of 5 sliding windows (one per OHCLV column) to the history
    loader's cache of sliding windos.

    This prevents unbounded growth on algorithms that call history with a
    highly varied list of equities.

    To follow is splitting the cache up by column and by sid, so that the
    loader does not re-prefetch sids which have already been read with
    sufficient data; however this patch is enough to fix the issue where an
    algo with high rotation can add up a megabyte per day of memory on
    algorithms which rotate on a 5% dollar volume pipeline. With this cap
    those algorithms have more plateaus with regard to memory consumption.

    This patch requires new dependency of `cachetools` library.

Also, add cachetools recipe (via @richafrank )