### PR TITLE
BUG: Prevent out of order history arrays.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1584,6 +1584,36 @@ class DailyEquityHistoryTestCase(HistoryTestCaseBase):
                 "close"
             )[self.ASSET2]
 
+    def test_history_window_different_order(self):
+        """
+        Prevent regression on a bug where the passing the same assets, but
+        in a different order would return a history window with the values,
+        but not the keys, in order of the first history call.
+        """
+        # Both ASSET1 and ASSET2 have trades on this date.
+        day = self.ASSET2.end_date
+
+        window_1 = self.data_portal.get_history_window(
+            [self.ASSET1, self.ASSET2],
+            day,
+            4,
+            "1d",
+            "close"
+        )
+
+        window_2 = self.data_portal.get_history_window(
+            [self.ASSET2, self.ASSET1],
+            day,
+            4,
+            "1d",
+            "close"
+        )
+
+        np.testing.assert_almost_equal(window_1[self.ASSET1].values,
+                                       window_2[self.ASSET1].values)
+        np.testing.assert_almost_equal(window_1[self.ASSET2].values,
+                                       window_2[self.ASSET2].values)
+
 
 class MinuteToDailyAggregationTestCase(WithBcolzMinutes,
                                        ZiplineTestCase):

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -39,6 +39,7 @@ from numpy import (
     issubdtype,
     nan,
     uint32,
+    zeros,
 )
 from pandas import (
     DataFrame,
@@ -648,8 +649,16 @@ class PanelDailyBarReader(DailyBarReader):
         col_names = [col.name for col in columns]
         cal = self._calendar
         index = cal[cal.slice_indexer(start_date, end_date)]
-        result = self.panel.loc[assets, start_date:end_date, col_names]
-        return result.reindex_axis(index, 1).values
+        shape = (len(index), len(assets))
+        results = []
+        for col in col_names:
+            outbuf = zeros(shape=shape)
+            for i, asset in enumerate(assets):
+                data = self.panel.loc[asset, start_date:end_date, col]
+                data = data.reindex_axis(index).values
+                outbuf[:, i] = data
+            results.append(outbuf)
+        return results
 
     def spot_price(self, sid, day, colname):
         """


### PR DESCRIPTION
Fix a bug where if history were called with assets `[1, 2]` and then
subsequently, `[2, 1]`, the loader would return the cached array in
order for `[1, 2]`.

Instead cache an AdjustedArray for each asset, then when a history
window is requested, check if each asset has a sufficient cache, and if
not then read values for the assets which are missing or need to be
refreshed.

An added benefit of this change is that if a subsequent call to history
has a smaller number of assets than the previous, no new data needs to
be read from disk. e.g. a call with assets `[1, 2, 3]` and then `[1, 2]`
would use the cached values for `1` and `2` from the first call.

Conversely, if the second call has more assets, then only the data for
the new assets needs to be retrieved. e.g. a history with `[1, 2]`, then
`[1, 2, 3]` would only need (assuming `1` and `2` have not expired) to
retrieve data for `3`. Unfortunately, the benefit here is not great
because `load_raw_arrays` is optimized for reading many assets, and
pulls the entire daily bar dataset into memory. This change makes tuning
`load_raw_arrays` so that faster reads (e.g. by slicing from the carray
for each asset, instead of pulling all data into a numpy array), when
only a few assets are requested, more beneficial than it would have been
previously.