### PR TITLE
BUG: Week rule plus time rule doesn't work

### DIFF
--- a/zipline/utils/events.py
+++ b/zipline/utils/events.py
@@ -466,18 +466,15 @@ class TradingDayOfWeekRule(six.with_metaclass(ABCMeta, StatelessRule)):
             # of the simulation start
             self.calculate_start_and_end(dt, env)
 
-            # If we've missed the first trigger because it occurs before the
-            # simulation starts, recalculate for the next week
-            if dt > self.next_date_end:
-                self.calculate_start_and_end(dt + datetime.timedelta(days=7),
-                                             env)
+        # If we've passed the trigger, calculate the next one
+        if dt > self.next_date_end:
+            self.calculate_start_and_end(self.next_date_end +
+                                         datetime.timedelta(days=7),
+                                         env)
 
-        # if the given dt is within the next matching day, return true. Also
-        # calculate the start and end dates for the next trigger
+        # if the given dt is within the next matching day, return true.
         if self.next_date_start <= dt <= self.next_date_end or \
                 dt == self.next_midnight_timestamp:
-            self.calculate_start_and_end(dt + datetime.timedelta(days=7),
-                                         env)
             return True
 
         return False


### PR DESCRIPTION
A previous commit (1ee3c5f04968ab2b1ab4ff334c1cdefe487e7927), changed the schedule function week rules so that every time it triggers, we recalculate the next trigger. As a result, the rule only triggers once a week (on the first bar of the day it's supposed to trigger). This works if we only have a week rule, but it won't work if we combine a week and time rule, and the time rule triggers after the first bar of the day, because the week rule keeps getting recalculated before the time rule triggers.

So, we revert back to having the week rule trigger for the entire day, but recalculate based on the last triggered date, as opposed to the date after the last trigger  