### PR TITLE
BUG: Fetcher wasn't working properly in `before_trading_start`.

### DIFF
--- a/tests/resources/fetcher_inputs/fetcher_test_data.py
+++ b/tests/resources/fetcher_inputs/fetcher_test_data.py
@@ -134,6 +134,15 @@ Date,Value
 2006-01-01,199.3
 """.strip()
 
+NFLX_DATA = """
+Settlement Date,symbol,dtc
+7/31/13,NFLX,1.690317
+8/15/13,NFLX,2.811858
+8/30/13,NFLX,2.502331
+9/13/13,NFLX,2.550829
+9/30/13,NFLX,2.64484
+"""
+
 PALLADIUM_DATA = """
 Date,Hong Kong 8:30,Hong Kong 14:00,London 08:00,New York 9:30,New York 15:00
 2007-12-31,367.0,367.0,368.0,368.0,368.0

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -705,7 +705,7 @@ class FetcherDataPortal(DataPortal):
 
     def get_spot_value(self, asset, field, dt, data_frequency):
         # if this is a fetcher field, exercise the regular code path
-        if self._check_extra_sources(asset, field, (dt or self.current_dt)):
+        if self._is_extra_source(asset, field, self._augmented_sources_map):
             return super(FetcherDataPortal, self).get_spot_value(
                 asset, field, dt, data_frequency)
 


### PR DESCRIPTION
We were trying to use the previous day in before_trading_start because
we were looking for the previous market minute, then normalizing it.  That's
no longer the case, as we want to use today's date for fetcher lookups
in before_trading_start.

Also refactored a bit how dataportal determines if a query should be
routed to the fetcher data structures.