### PR TITLE
PERF: Improve read time for smaller num of assets.

### DIFF
--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from sys import maxsize
+
 from nose_parameterized import parameterized
 from numpy import (
     arange,
@@ -330,3 +332,21 @@ class BcolzDailyBarTestCase(WithBcolzDailyBarReader, ZiplineTestCase):
             self.assertEqual(-1, close)
         finally:
             reader._spot_col('close')[zero_ix] = old
+
+
+class BcolzDailyBarAlwaysReadAllTestCase(BcolzDailyBarTestCase):
+    """
+    Force tests defined in BcolzDailyBarTestCase to always read the entire
+    column into memory before selecting desired asset data, when invoking
+    `load_raw_array`.
+    """
+    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD = 0
+
+
+class BcolzDailyBarNeverReadAllTestCase(BcolzDailyBarTestCase):
+    """
+    Force tests defined in BcolzDailyBarTestCase to never read the entire
+    column into memory before selecting desired asset data, when invoking
+    `load_raw_array`.
+    """
+    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD = maxsize

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -597,6 +597,9 @@ class WithBcolzDailyBarReader(WithTradingEnvironment, WithTmpDir):
         If this flag is set the ``bcolz_daily_bar_days`` will be the full
         set of trading days from the trading environment. This flag overrides
         ``BCOLZ_DAILY_BAR_LOOKBACK_DAYS``.
+    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD : int
+        If this flag is set, use the value as the `read_all_threshold`
+        parameter to BcolzDailyBarReader, otherwise use the default value.
 
     Methods
     -------
@@ -618,6 +621,7 @@ class WithBcolzDailyBarReader(WithTradingEnvironment, WithTmpDir):
     BCOLZ_DAILY_BAR_USE_FULL_CALENDAR = False
     BCOLZ_DAILY_BAR_START_DATE = alias('START_DATE')
     BCOLZ_DAILY_BAR_END_DATE = alias('END_DATE')
+    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD = None
     # allows WithBcolzDailyBarReaderFromCSVs to call the `write_csvs` method
     # without needing to reimplement `init_class_fixtures`
     _write_method_name = 'write'
@@ -651,7 +655,11 @@ class WithBcolzDailyBarReader(WithTradingEnvironment, WithTmpDir):
             cls._write_method_name,
         )(cls.make_daily_bar_data())
 
-        cls.bcolz_daily_bar_reader = BcolzDailyBarReader(t)
+        if cls.BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD is not None:
+            cls.bcolz_daily_bar_reader = BcolzDailyBarReader(
+                t, cls.BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD)
+        else:
+            cls.bcolz_daily_bar_reader = BcolzDailyBarReader(t)
 
 
 class WithBcolzDailyBarReaderFromCSVs(WithBcolzDailyBarReader):


### PR DESCRIPTION
The BcolzDailyBarReader was optimized for the pipeline case of reading
all assets at once.

Now that the reader is also used to support daily history the case of
reading a data for a small number of assets is more common, particularly
in algorithms that use the history API which have a high rotation of
assets (e.g. an algorithm which pipeline uses to set the active
universe)

Remove the bottleneck in reading a small number of assets by
conditionally reading the slice for each asset from the carray, instead
of reading the data for all equities and then indexing into that full
array. On a certain number of assets, it is still better to read all the
data at once. On the Quantopian dataset, which holds data for 20000
about for the last 10 years of equity data (where not all equities trade
over the full range), stored in 118 blosc blp files per column, the
tipping point where the 'read all' mode wins out between 3000-4000
assets.

That number was tested by trying to exercise a worst case scenario where
the equities were spread out evenly across the blp files, by stepping
along a sorted list of assets that were alive over a query range which
spanned 70 trading days.
```
size = 3000
sids = [assets[i] for i in range(0, len(assets), len(assets) /
size)][:size]
```

Also, add parameter to WithBcolzDailyBarReader fixture which allows the
test to specify what the threshold count for reading all data should be,
so that the test_us_equity_pricing can be forced into either mode to
make sure that both branches in logic are covered by all test cases.

On local dev machine this patch improves the read time of `load_raw_array`
for one asset from 100 ms to 96.5 µs. (10^5 improvement.) With reading
only asset per call a being an observed common case when populating the
non-cached values in USEquityHistoryLoader.

** Other Notes

Here is the timing table from running the following:
```
In []:
start_date
Timestamp('2013-10-02 00:00:00+0000', tz='UTC')

In []:
end_date
Timestamp('2014-01-08 00:00:00+0000', tz='UTC')

In []:
(end_date - start_date) * 5 / 7
Timedelta('70 days 00:00:00')

In []:
size = 1 # Change this value per test.
sids = [assets[i] for i in range(0, len(assets), len(assets) / size)][:size]

In []:
%%timeit
reader.load_raw_arrays([USEquityPricing.close], start_date, end_date, sids)
10000 loops, best of 3: 96.9 µs per loop
```

```
1:    96.5 µs per loop
2:   311   µs per loop
5:   654   µs per loop
10:    1.2 ms per loop
100:  10.2 ms per loop
200:  16.1 ms per loop
300:  18.9 ms per loop
500:  26.2 ms per loop
750:  32.9 ms per loop
800:  35.5 ms per loop
900:  38.2 ms per loop
1000: 38   ms per loop
2000: 63.2 ms per loop
3000: 87.3 ms per loop
4000:109   ms per loop
````
