### PR TITLE
DEV: Better error message for sid= in get_open_orders

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -151,6 +151,9 @@ from zipline.test_algorithms import (
     bad_type_history_frequency_kwarg,
     bad_type_current_assets_kwarg,
     bad_type_current_fields_kwarg,
+    call_with_bad_kwargs_get_open_orders,
+    call_with_good_kwargs_get_open_orders,
+    call_with_no_kwargs_get_open_orders,
     no_handle_data,
 )
 from zipline.utils.api_support import ZiplineAPI, set_algo_instance
@@ -1774,6 +1777,27 @@ def handle_data(context, data):
         )
 
         algo.run(self.data_portal)
+
+    @parameterized.expand(
+        [('bad_kwargs', call_with_bad_kwargs_get_open_orders),
+         ('good_kwargs', call_with_good_kwargs_get_open_orders),
+         ('no_kwargs', call_with_no_kwargs_get_open_orders)]
+    )
+    def test_get_open_orders_kwargs(self, name, script):
+        algo = TradingAlgorithm(
+            script=script,
+            sim_params=self.sim_params,
+            env=self.env
+        )
+
+        if name == 'bad_kwargs':
+            with self.assertRaises(TypeError) as cm:
+                algo.run(self.data_portal)
+                self.assertEqual('Keyword argument `sid` is no longer '
+                                 'supported for get_open_orders. Use `asset` '
+                                 'instead.', cm.exception.args[0])
+        else:
+            algo.run(self.data_portal)
 
 
 class TestGetDatetime(WithLogger,

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -89,7 +89,8 @@ from zipline.utils.api_support import (
     require_not_initialized,
     ZiplineAPI,
     disallowed_in_before_trading_start)
-from zipline.utils.input_validation import ensure_upper_case
+
+from zipline.utils.input_validation import ensure_upper_case, error_keywords
 from zipline.utils.cache import CachedObject, Expired
 import zipline.utils.events
 from zipline.utils.events import (
@@ -1297,6 +1298,8 @@ class TradingAlgorithm(object):
                                        stop_price=stop_price,
                                        style=style)
 
+    @error_keywords(sid='Keyword argument `sid` is no longer supported for '
+                        'get_open_orders. Use `asset` instead.')
     @api_method
     def get_open_orders(self, asset=None):
         if asset is None:

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -1096,3 +1096,33 @@ def initialize(context):
 def handle_data(context, data):
     data.history(assets=[1,2], fields='price', bar_count=5, frequency="1d")
 """
+
+call_with_bad_kwargs_get_open_orders = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    context.get_open_orders(sid=symbol('TEST'))
+"""
+
+call_with_good_kwargs_get_open_orders = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    context.get_open_orders(asset=symbol('TEST'))
+"""
+
+call_with_no_kwargs_get_open_orders = """
+from zipline.api import symbol
+
+def initialize(context):
+    pass
+
+def handle_data(context, data):
+    context.get_open_orders(symbol('TEST'))
+"""

--- a/zipline/utils/input_validation.py
+++ b/zipline/utils/input_validation.py
@@ -445,4 +445,18 @@ def coerce(from_, to, **to_kwargs):
     return preprocessor
 
 
+class error_keywords(object):
+
+    def __init__(self, *args, **kwargs):
+        self.messages = kwargs
+
+    def __call__(self, func):
+        def assert_keywords_and_call(*args, **kwargs):
+            for field, message in iteritems(self.messages):
+                if field in kwargs:
+                    raise TypeError(message)
+            return func(*args, **kwargs)
+        return assert_keywords_and_call
+
+
 coerce_string = partial(coerce, string_types)


### PR DESCRIPTION
Let the user to know to use asset= instead