### PR TITLE
FIX: Error message for BenchmarkAssetNotAvailableTooLate is wrong

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -103,6 +103,10 @@ class TestBenchmark(WithDataPortal, WithSimParams, ZiplineTestCase):
             )
 
     def test_asset_not_trading(self):
+        benchmark = self.env.asset_finder.retrieve_asset(3)
+        benchmark_start = benchmark.start_date
+        benchmark_end = benchmark.end_date
+
         with self.assertRaises(BenchmarkAssetNotAvailableTooEarly) as exc:
             BenchmarkSource(
                 3,
@@ -112,8 +116,8 @@ class TestBenchmark(WithDataPortal, WithSimParams, ZiplineTestCase):
             )
 
         self.assertEqual(
-            '3 does not exist on 2006-01-04 00:00:00+00:00. '
-            'It started trading on 2006-05-26 00:00:00+00:00.',
+            '3 does not exist on %s. It started trading on %s.' %
+            (self.sim_params.trading_days[1], benchmark_start),
             exc.exception.message
         )
 
@@ -126,8 +130,8 @@ class TestBenchmark(WithDataPortal, WithSimParams, ZiplineTestCase):
             )
 
         self.assertEqual(
-            '3 does not exist on 2006-06-26 00:00:00+00:00. '
-            'It stopped trading on 2006-08-09 00:00:00+00:00.',
+            '3 does not exist on %s. It stopped trading on %s.' %
+            (self.sim_params.trading_days[-1], benchmark_end),
             exc2.exception.message
         )
 

--- a/zipline/sources/benchmark_source.py
+++ b/zipline/sources/benchmark_source.py
@@ -98,7 +98,7 @@ class BenchmarkSource(object):
             # the asset stopped trading before the last simulation day
             raise BenchmarkAssetNotAvailableTooLate(
                 sid=str(self.benchmark_sid),
-                dt=self.trading_days[0],
+                dt=self.trading_days[-1],
                 end_dt=benchmark_asset.end_date
             )
 


### PR DESCRIPTION
Should be '...does not exist on self.trading_days[-1]...' not
self.trading_days[0]