### PR TITLE
BUG: DAY_END action not emitted during minute emission

### DIFF
--- a/tests/test_perf_tracking.py
+++ b/tests/test_perf_tracking.py
@@ -198,7 +198,7 @@ def calculate_results(sim_params,
         except KeyError:
             pass
 
-        msg = perf_tracker.handle_market_close_daily(date, data_portal)
+        msg = perf_tracker.handle_market_close(date, data_portal)
         perf_tracker.position_tracker.sync_last_sale_prices(
             date, False, data_portal,
         )

--- a/zipline/gens/sim_engine.pyx
+++ b/zipline/gens/sim_engine.pyx
@@ -81,8 +81,8 @@ cdef class MinuteSimulationClock:
                 if minute_emission:
                     yield minute, MINUTE_END
 
-            if not minute_emission:
-                yield minutes[-1], DAY_END
+            yield minutes[-1], DAY_END
+
 
 
 cdef class DailySimulationClock:

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -199,19 +199,17 @@ class AlgorithmSimulator(object):
                     once_a_day(dt)
                 elif action == DAY_END:
                     # End of the day.
+                    if algo.perf_tracker.emission_rate == 'daily':
+                        handle_benchmark(normalize_date(dt))
                     execute_order_cancellation_policy()
-                    handle_benchmark(normalize_date(dt))
 
                     yield self._get_daily_message(dt, algo, algo.perf_tracker)
                 elif action == MINUTE_END:
                     handle_benchmark(dt)
-                    minute_msg, daily_msg = \
+                    minute_msg = \
                         self._get_minute_message(dt, algo, algo.perf_tracker)
 
                     yield minute_msg
-
-                    if daily_msg:
-                        yield daily_msg
 
         risk_message = algo.perf_tracker.handle_simulation_end()
         yield risk_message
@@ -256,7 +254,7 @@ class AlgorithmSimulator(object):
         """
         Get a perf message for the given datetime.
         """
-        perf_message = perf_tracker.handle_market_close_daily(
+        perf_message = perf_tracker.handle_market_close(
             dt, self.data_portal,
         )
         perf_message['daily_perf']['recorded_vars'] = algo.recorded_vars
@@ -268,12 +266,9 @@ class AlgorithmSimulator(object):
         """
         rvars = algo.recorded_vars
 
-        minute_message, daily_message = perf_tracker.handle_minute_close(
+        minute_message = perf_tracker.handle_minute_close(
             dt, self.data_portal,
         )
+
         minute_message['minute_perf']['recorded_vars'] = rvars
-
-        if daily_message:
-            daily_message["daily_perf"]["recorded_vars"] = rvars
-
-        return minute_message, daily_message
+        return minute_message


### PR DESCRIPTION
Refactor AlgorithmSimulator so that DAY_END is emitted for both
minute and daily emission, and that handling of end-of-minute
and end-of-day is separated