### PR TITLE
MAINT: Add validation for schedule_function params

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1836,6 +1836,50 @@ def handle_data(context, data):
         )
         algo.run(self.data_portal)
 
+    def test_schedule_function_validation(self):
+        """
+        Test that we raise a TypeError when we input a date_rule for a
+        time_rule and vice-versa
+        """
+
+        sim_params = factory.create_simulation_parameters(
+            start=pd.Timestamp('2006-01-14', tz='UTC'),
+            end=pd.Timestamp('2006-01-15', tz='UTC'),
+            data_frequency='minute'
+        )
+
+        algo = TradingAlgorithm(
+            script=noop_algo,
+            sim_params=sim_params,
+            env=self.env
+        )
+
+        def nothing(context, data):
+            pass
+
+        date_rules = [
+            DateRuleFactory.every_day(),
+            DateRuleFactory.month_start(),
+            DateRuleFactory.month_end(),
+            DateRuleFactory.week_start(),
+            DateRuleFactory.week_end()
+        ]
+
+        for rule in date_rules:
+            self.assertRaises(TypeError,
+                              algo.schedule_function, nothing, time_rule=rule)
+            algo.schedule_function(nothing, date_rule=rule)
+
+        time_rules = [
+            TimeRuleFactory.market_close(),
+            TimeRuleFactory.market_open()
+        ]
+
+        for rule in time_rules:
+            self.assertRaises(TypeError,
+                              algo.schedule_function, nothing, date_rule=rule)
+            algo.schedule_function(nothing, time_rule=rule)
+
 
 class TestGetDatetime(WithLogger,
                       WithSimParams,

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -32,6 +32,8 @@ from zipline.utils.events import (
     EventRule,
     StatelessRule,
     Always,
+    AllDays,
+    AllMinutes,
     Never,
     AfterOpen,
     ComposedRule,
@@ -293,6 +295,16 @@ class TestStatelessRules(RuleTestCase):
     @subtest(minutes_for_days(), 'ms')
     def test_Always(self, ms):
         should_trigger = partial(Always().should_trigger, env=self.env)
+        self.assertTrue(all(map(should_trigger, ms)))
+
+    @subtest(minutes_for_days(), 'ms')
+    def test_AllDays(self, ms):
+        should_trigger = partial(AllDays().should_trigger, env=self.env)
+        self.assertTrue(all(map(should_trigger, ms)))
+
+    @subtest(minutes_for_days(), 'ms')
+    def test_AllMinutes(self, ms):
+        should_trigger = partial(AllMinutes().should_trigger, env=self.env)
         self.assertTrue(all(map(should_trigger, ms)))
 
     @subtest(minutes_for_days(), 'ms')

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -98,6 +98,7 @@ from zipline.utils.events import (
     make_eventrule,
     DateRuleFactory,
     TimeRuleFactory,
+    AllMinutes
 )
 from zipline.utils.factory import create_simulation_parameters
 from zipline.utils.math_utils import (
@@ -835,7 +836,12 @@ class TradingAlgorithm(object):
         time_rule = ((time_rule or TimeRuleFactory.market_open())
                      if self.sim_params.data_frequency == 'minute' else
                      # If we are in daily mode the time_rule is ignored.
-                     zipline.utils.events.Always())
+                     AllMinutes())
+
+        if date_rule.rule_type and date_rule.rule_type != 'date':
+            raise TypeError('%s is not a valid date_rule.' % date_rule.alias)
+        if time_rule.rule_type and time_rule.rule_type != 'time':
+            raise TypeError('%s is not a valid time_rule.' % time_rule.alias)
 
         self.add_event(
             make_eventrule(date_rule, time_rule, half_days),


### PR DESCRIPTION
Return a TypeError if we passes a date_rule for a time_rule and
vice-versa