### PR TITLE
BUG: Fix multiple bugs in PanelDailyBarReader.

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -719,7 +719,7 @@ class PanelDailyBarReader(DailyBarReader):
     def __init__(self, calendar, panel):
 
         panel = panel.copy()
-        if 'volume' not in panel.items:
+        if 'volume' not in panel.minor_axis:
             # Fake volume if it does not exist.
             panel.loc[:, :, 'volume'] = int(1e9)
 

--- a/zipline/utils/input_validation.py
+++ b/zipline/utils/input_validation.py
@@ -37,7 +37,8 @@ def verify_indices_all_unique(obj):
 
     Returns
     -------
-    None
+    obj : pd.Series / pd.DataFrame / pd.Panel
+        The validated object, unchanged.
 
     Raises
     ------
@@ -61,6 +62,7 @@ def verify_indices_all_unique(obj):
                 dupes=sorted(index[index.duplicated()]),
             )
         )
+    return obj
 
 
 def optionally(preprocessor):


### PR DESCRIPTION
- Return a value from `verify_all_indices_unique` so that `panel` isn't
  unconditionally `None` in `PanelDailyBarReader`.

- Fix a bug where we always set the volume of every asset to `1e9`.

- Add minimal suite of tests for get_spot_value, which catch both of the
  above.

NOTE: There are still several issues with `PanelDailyBarReader`.  The
docstring for `get_spot_value` claims that it will return -1 on days
where an asset didn't trade, which isn't the case.  It also claims that
it will raise `NoDataOnDate` when a request is made outside the panel
range, but it just raises a KeyError.  We also still have no coverage
for `load_raw_arrays`, so it's likely that there are more bugs lurking.