### PR TITLE
PERF: takes ~14% off the time it takes to initialize a MinuteSimulationClock

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -478,7 +478,6 @@ class TradingAlgorithm(object):
                 self.sim_params.trading_days,
                 market_opens,
                 market_closes,
-                env.trading_days,
                 minutely_emission
             )
             return clock


### PR DESCRIPTION
on my machine, ~350ms -> ~300ms

also, clarifies the public API for MinuteSimulationClock (now, only `__iter__` is exposed)