### PR TITLE
String Classifier Cleanup

### DIFF
--- a/tests/pipeline/test_classifier.py
+++ b/tests/pipeline/test_classifier.py
@@ -434,7 +434,7 @@ class ClassifierTestCase(BasePipelineTestCase):
             errmsg = str(e.exception)
             expected = (
                 "Found self.missing_value ('not in the array') in choices"
-                " supplied to C.is_element().\n"
+                " supplied to C.element_of().\n"
                 "Missing values have NaN semantics, so the requested"
                 " comparison would always produce False.\n"
                 "Use the isnull() method to check for missing values.\n"
@@ -447,7 +447,7 @@ class ClassifierTestCase(BasePipelineTestCase):
 
         class C(Classifier):
             dtype = dtype_
-            missing_value = ''
+            missing_value = dtype.type('1')
             inputs = ()
             window_length = 0
 

--- a/tests/pipeline/test_classifier.py
+++ b/tests/pipeline/test_classifier.py
@@ -8,7 +8,6 @@ from zipline.pipeline import Classifier
 from zipline.testing import parameter_space
 from zipline.utils.numpy_utils import (
     categorical_dtype,
-    coerce_to_dtype,
     int64_dtype,
 )
 
@@ -162,7 +161,8 @@ class ClassifierTestCase(BasePipelineTestCase):
         dtype_=[int64_dtype, categorical_dtype],
     )
     def test_disallow_comparison_to_missing_value(self, missing, dtype_):
-        missing = coerce_to_dtype(dtype_, missing)
+        if dtype_ == categorical_dtype:
+            missing = str(missing)
 
         class C(Classifier):
             dtype = dtype_

--- a/tests/pipeline/test_factor.py
+++ b/tests/pipeline/test_factor.py
@@ -444,7 +444,7 @@ class FactorTestCase(BasePipelineTestCase):
         f = self.f
         m = Mask()
         c = C()
-        str_c = C(dtype=categorical_dtype)
+        str_c = C(dtype=categorical_dtype, missing_value=None)
 
         factor_data = array(
             [[1.0, 2.0, 3.0, 4.0],

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -602,3 +602,26 @@ class SubDataSetTestCase(TestCase):
         with self.assertRaises(ValueError) as e:
             SomeClassifier()
         self.assertEqual(str(e.exception), expected_error)
+
+    def test_unreasonable_missing_values(self):
+
+        for base_type, dtype_, bad_mv in ((Factor, float64_dtype, 'ayy'),
+                                          (Filter, bool_dtype, 'lmao'),
+                                          (Classifier, int64_dtype, 'lolwut'),
+                                          (Classifier, categorical_dtype, 7)):
+            class SomeTerm(base_type):
+                inputs = ()
+                window_length = 0
+                missing_value = bad_mv
+                dtype = dtype_
+
+            with self.assertRaises(TypeError) as e:
+                SomeTerm()
+
+            prefix = (
+                "^Missing value {mv!r} is not a valid choice "
+                "for term SomeTerm with dtype {dtype}.\n\n"
+                "Coercion attempt failed with:"
+            ).format(mv=bad_mv, dtype=dtype_)
+
+            self.assertRegexpMatches(str(e.exception), prefix)

--- a/zipline/lib/labelarray.py
+++ b/zipline/lib/labelarray.py
@@ -211,6 +211,10 @@ class LabelArray(ndarray):
         # This is a property because it should be immutable.
         return self._missing_value
 
+    @property
+    def missing_value_code(self):
+        return self.reverse_categories[self.missing_value]
+
     def has_label(self, value):
         return value in self.reverse_categories
 

--- a/zipline/pipeline/classifiers/classifier.py
+++ b/zipline/pipeline/classifiers/classifier.py
@@ -246,7 +246,7 @@ class Classifier(RestrictedDTypeMixin, ComputableTerm):
         if self.missing_value in choices:
             raise ValueError(
                 "Found self.missing_value ({mv!r}) in choices supplied to"
-                " {typename}.is_element().\n"
+                " {typename}.{meth_name}().\n"
                 "Missing values have NaN semantics, so the"
                 " requested comparison would always produce False.\n"
                 "Use the isnull() method to check for missing values.\n"
@@ -254,6 +254,7 @@ class Classifier(RestrictedDTypeMixin, ComputableTerm):
                     mv=self.missing_value,
                     typename=(type(self).__name__),
                     choices=sorted(choices),
+                    meth_name=self.element_of.__name__,
                 )
             )
 


### PR DESCRIPTION
Fixes a few latent bugs in string classifiers:
- Fixes groupby on Factor being broken with string classifiers.
- Adds validation of term missing_values and fixes several locations where we were constructing invalid terms.
- Fixes a broken error message for Classifier.element_of.