### PR TITLE
Cli improvements

### DIFF
--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -360,14 +360,11 @@ def bundles():
                 raise
             ingestions = []
 
-        print(
-            '\n'.join(
-                '%s %s' % (bundle, line)
-                for line in (
-                    ingestions if ingestions else ('<no ingestions>',)
-                )
-            ),
-        )
+        # If we got no ingestions, either because the directory didn't exist or
+        # becuase there were no entries, print a single message indicating that
+        # no ingestions have yet been made.
+        for timestamp in ingestions or ["<no ingestions>"]:
+            print("%s %s" % (bundle, timestamp))
 
 
 if __name__ == '__main__':

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -361,7 +361,7 @@ def bundles():
             ingestions = []
 
         # If we got no ingestions, either because the directory didn't exist or
-        # becuase there were no entries, print a single message indicating that
+        # because there were no entries, print a single message indicating that
         # no ingestions have yet been made.
         for timestamp in ingestions or ["<no ingestions>"]:
             print("%s %s" % (bundle, timestamp))

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -304,12 +304,6 @@ def quandl_bundle(environ,
     )
 
 
-QUANTOPIAN_QUANDL_URL = (
-    'https://s3.amazonaws.com/quantopian-public-zipline-data/quandl'
-)
-ONE_MEGABYTE = 1024 * 1024
-
-
 def download_with_progress(url, chunk_size, **progress_kwargs):
     """
     Download streaming data from a URL, printing progress information to the
@@ -356,9 +350,15 @@ def download_without_progress(url):
     data : BytesIO
         A BytesIO containing the downloaded data.
     """
-    resp = requests.get(QUANTOPIAN_QUANDL_URL)
+    resp = requests.get(url)
     resp.raise_for_status()
     return BytesIO(resp.content)
+
+
+QUANTOPIAN_QUANDL_URL = (
+    'https://s3.amazonaws.com/quantopian-public-zipline-data/quandl'
+)
+ONE_MEGABYTE = 1024 * 1024
 
 
 @bundles.register('quantopian-quandl', create_writers=False)

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -1,7 +1,6 @@
 """
 Module for building a complete daily dataset from Quandl's WIKI dataset.
 """
-from contextlib import closing
 from io import BytesIO
 from itertools import count
 import tarfile
@@ -12,7 +11,6 @@ from logbook import Logger
 import pandas as pd
 import requests
 from six.moves.urllib.parse import urlencode
-from six.moves.urllib.request import urlopen
 
 from . import core as bundles
 from zipline.utils.cli import maybe_show_progress

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -380,7 +380,6 @@ def quantopian_quandl_bundle(environ,
     else:
         data = download_without_progress(QUANTOPIAN_QUANDL_URL)
 
-    # use closing for py2 compat
     with tarfile.open('r', fileobj=data) as tar:
         if show_progress:
             print("Writing data to %s." % output_dir)


### PR DESCRIPTION
Adds a progress bar to quantopian-quandl downloads and fixes a bug where `zipline bundles` would print tuples in Python 2.