### PR TITLE
ENH: Allow leveraged etf as param to security list

### DIFF
--- a/tests/test_security_list.py
+++ b/tests/test_security_list.py
@@ -24,7 +24,10 @@ LEVERAGED_ETFS = load_from_directory('leveraged_etf_list')
 
 class RestrictedAlgoWithCheck(TradingAlgorithm):
     def initialize(self, symbol):
-        self.rl = SecurityListSet(self.get_datetime, self.asset_finder)
+        self.rl = SecurityListSet(
+            self.get_datetime,
+            self.asset_finder,
+            load_from_directory('leveraged_etf_list'))
         self.set_do_not_order_list(self.rl.leveraged_etf_list)
         self.order_count = 0
         self.sid = self.symbol(symbol)
@@ -39,7 +42,10 @@ class RestrictedAlgoWithCheck(TradingAlgorithm):
 
 class RestrictedAlgoWithoutCheck(TradingAlgorithm):
     def initialize(self, symbol):
-        self.rl = SecurityListSet(self.get_datetime, self.asset_finder)
+        self.rl = SecurityListSet(
+            self.get_datetime,
+            self.asset_finder,
+            load_from_directory('leveraged_etf_list'))
         self.set_do_not_order_list(self.rl.leveraged_etf_list)
         self.order_count = 0
         self.sid = self.symbol(symbol)
@@ -51,7 +57,10 @@ class RestrictedAlgoWithoutCheck(TradingAlgorithm):
 
 class IterateRLAlgo(TradingAlgorithm):
     def initialize(self, symbol):
-        self.rl = SecurityListSet(self.get_datetime, self.asset_finder)
+        self.rl = SecurityListSet(
+            self.get_datetime,
+            self.asset_finder,
+            load_from_directory('leveraged_etf_list'))
         self.set_do_not_order_list(self.rl.leveraged_etf_list)
         self.order_count = 0
         self.sid = self.symbol(symbol)
@@ -132,7 +141,6 @@ class SecurityListTestCase(WithLogger, ZiplineTestCase):
         def get_datetime():
             return list(LEVERAGED_ETFS.keys())[0]
 
-        rl = SecurityListSet(get_datetime, self.env.asset_finder)
         # assert that a sample from the leveraged list are in restricted
         should_exist = [
             asset.sid for asset in
@@ -141,6 +149,11 @@ class SecurityListTestCase(WithLogger, ZiplineTestCase):
                 as_of_date=self.extra_knowledge_date)
              for symbol in ["BZQ", "URTY", "JFT"]]
         ]
+        rl = SecurityListSet(
+            get_datetime,
+            self.env.asset_finder,
+            load_from_directory('leveraged_etf_list'))
+
         for sid in should_exist:
             self.assertIn(sid, rl.leveraged_etf_list)
 
@@ -160,7 +173,6 @@ class SecurityListTestCase(WithLogger, ZiplineTestCase):
             return pd.Timestamp("2015-01-27", tz='UTC')
         with security_list_copy():
             add_security_data(['AAPL', 'GOOG'], [])
-            rl = SecurityListSet(get_datetime, self.env.asset_finder)
             should_exist = [
                 asset.sid for asset in
                 [self.env.asset_finder.lookup_symbol(
@@ -168,6 +180,10 @@ class SecurityListTestCase(WithLogger, ZiplineTestCase):
                     as_of_date=self.extra_knowledge_date
                 ) for symbol in ["AAPL", "GOOG", "BZQ", "URTY"]]
             ]
+            rl = SecurityListSet(
+                get_datetime,
+                self.env.asset_finder,
+                load_from_directory('leveraged_etf_list'))
             for sid in should_exist:
                 self.assertIn(sid, rl.leveraged_etf_list)
 
@@ -175,7 +191,10 @@ class SecurityListTestCase(WithLogger, ZiplineTestCase):
         with security_list_copy():
             def get_datetime():
                 return pd.Timestamp("2015-01-27", tz='UTC')
-            rl = SecurityListSet(get_datetime, self.env.asset_finder)
+            rl = SecurityListSet(
+                get_datetime,
+                self.env.asset_finder,
+                load_from_directory('leveraged_etf_list'))
             self.assertNotIn("BZQ", rl.leveraged_etf_list)
             self.assertNotIn("URTY", rl.leveraged_etf_list)
 

--- a/zipline/utils/security_list.py
+++ b/zipline/utils/security_list.py
@@ -88,19 +88,20 @@ class SecurityListSet(object):
     # list implementations.
     security_list_type = SecurityList
 
-    def __init__(self, current_date_func, asset_finder):
+    def __init__(self,
+                 current_date_func,
+                 asset_finder,
+                 leveraged_etf_data):
         self.current_date_func = current_date_func
         self.asset_finder = asset_finder
-        self._leveraged_etf = None
+        self._leveraged_etf = self.security_list_type(
+            leveraged_etf_data,
+            self.current_date_func,
+            asset_finder=self.asset_finder
+        )
 
     @property
     def leveraged_etf_list(self):
-        if self._leveraged_etf is None:
-            self._leveraged_etf = self.security_list_type(
-                load_from_directory('leveraged_etf_list'),
-                self.current_date_func,
-                asset_finder=self.asset_finder
-            )
         return self._leveraged_etf
 
 


### PR DESCRIPTION
To enable reading the leveraged etf data before creation of an algorithm
instance, add a parameter to `SecurityListSet` which passes in the
`leveraged_etf_data`.

(`SecurityListSet` in its current design requires to be created post
algorithm init since the `current_date_func` is the `get_datetime`
method of an algorithm instance.)