### PR TITLE
DEV: Adjust performance calculations for capital changes

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -383,6 +383,9 @@ class TradingAlgorithm(object):
 
         self.benchmark_sid = kwargs.pop('benchmark_sid', None)
 
+        # A dictionary of capital change values keyed by timestamp
+        self.capital_changes = kwargs.pop('capital_changes', {})
+
     def init_engine(self, get_loader):
         """
         Construct and store a PipelineEngine from loader.

--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -231,6 +231,17 @@ class PerformanceTracker(object):
 
         return _dict
 
+    def process_capital_changes(self, capital_change, is_interday):
+        self.cumulative_performance.subdivide_period(capital_change)
+
+        if is_interday:
+            # Change comes between days
+            self.todays_performance.adjust_period_starting_capital(
+                capital_change)
+        else:
+            # Change comes in the middle of day
+            self.todays_performance.subdivide_period(capital_change)
+
     def process_transaction(self, transaction):
         self.txn_count += 1
         self.cumulative_performance.handle_execution(transaction)


### PR DESCRIPTION
When we introduce a capital change (inflow or outflow of cash), make the appropriate adjustments to all the relevant performance fields on the `PerformancePeriod`.

Two types of capital changes:
- Capital Change between periods (daily periods)
  - When a capital change is specified outside of the algorithm's market hours
  - Because the capital change comes between daily periods, when a change is specified, just add that to the starting cash of that period (daily performance period starts with a greater portfolio value)
- Capital change within periods (daily periods or cumulative period)
  - if the capital change comes within the period (during market hours for daily periods, and anytime for the cumulative period), we need to segment this period by the datetime on which the changes come
  - example:
    - A cumulative period starts at t<sub>0</sub> with a PV of 1000, ends at t<sub>2</sub> with a PV of 3000
    - At t<sub>1</sub>, right before the capital change, it has a PV of 1500, and after the +1000 capital change at t<sub>1'</sub>, a PV of 2500
    - Returns = (PV<sub>t1</sub> - PV<sub>t0</sub>) * (PV<sub>t2</sub> - PV<sub>t1'</sub>) - 1 = 0.8   

- In `PerformancePeriod`, add a new method `subdivide_period`, which is called for the daily period when the change happens during market hours and for the cumulative period always:
  - Calculates the performance at that point and saves the pnl, returns and cash flow in memory
  - Adds the capital change, and then rolls over the ending value, exposure and cash to the new respective starting values and resets the cash flow, effectively starting a new 'subperiod'
  - When we calculate performance again, calculate the performance of the current and previous subperiod separately, and then incorporate them together
- In `PerformancePeriod`, `rollover` is called for the daily period when the change happens between days:
  - Adds the capital change, and rolls over a new period as before
- `TradingAlgorithm` get a `capital_changes` dictionary, with amount entries keyed by dt.
- `PerformanceTracker` has a new method `process_capital_changes`, which takes an amount, and calls appropriate methods on `PerformancePeriod` based whether its during the trading day or not
- `AlgorithmSimulator` calls `perf_tracker.process_capital_changes` at `DAY_START` and at `BAR`
- Tests:
  - performance in daily mode
  - performances in minute mode with (daily emission or minute emission) x (interperiod changes or intraperiod changes)