### PR TITLE
Support the passing of a time rule positionally on the date_rule arg

### DIFF
--- a/zipline/utils/events.py
+++ b/zipline/utils/events.py
@@ -689,6 +689,7 @@ class date_rules(object):
 class time_rules(object):
     market_open = AfterOpen
     market_close = BeforeClose
+    every_minute = Always
 
 
 def make_eventrule(date_rule, time_rule, half_days=True):


### PR DESCRIPTION
When the user calls schedule_function(func, a_time_rule), assume that the user meant to specify a time rule but no date rule, instead of a date rule and no time rule as the signature suggests