### PR TITLE
ENH: improve performance of blaze core loader

### DIFF
--- a/etc/requirements_blaze.txt
+++ b/etc/requirements_blaze.txt
@@ -1,3 +1,3 @@
--e git://github.com/quantopian/datashape.git@9bd8fb970a0fc55e866a0b46b5101c9aa47e24ed#egg=datashape-dev
--e git://github.com/quantopian/odo.git@4f7f45fb039d89ea101803b95da21fc055901d66#egg=odo-dev
--e git://github.com/quantopian/blaze.git@9c3fa1327236f777ca112a5bd8c3bb7e442d1052#egg=blaze-dev
+-e git://github.com/quantopian/datashape.git@bf06a41dc0908baf7c324aeacadba8820468ee78#egg=datashape-dev
+-e git://github.com/quantopian/odo.git@9e16310b5f2c3f05162145200db7e7908f0a866e#egg=odo-dev
+-e git://github.com/quantopian/blaze.git@8921fdd00bb040c61457937902036de5c404b6f3#egg=blaze-dev

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -904,44 +904,12 @@ class BlazeLoader(dict):
             q : Expr
                 The query to run.
             """
-            def lower_for_col(column):
-                pred = e[TS_FIELD_NAME] <= lower_dt
-                colname = column.name
-                schema = e[colname].schema.measure
-                if isinstance(schema, Option):
-                    pred &= e[colname].notnull()
-                    schema = schema.ty
-                if schema in floating:
-                    pred &= ~e[colname].isnan()
-
-                filtered = e[pred]
-                lower = filtered[TS_FIELD_NAME].max()
-                if have_sids:
-                    # If we have sids, then we need to take the earliest of the
-                    # greatest date that has a non-null value by sid.
-                    lower = bz.by(
-                        filtered[SID_FIELD_NAME],
-                        timestamp=lower,
-                    ).timestamp.min()
-                return lower
-
-            lower = odo(
-                reduce(
-                    bz.least,
-                    map(lower_for_col, columns),
-                ),
-                pd.Timestamp,
-                **odo_kwargs
-            )
-            if lower is pd.NaT:
-                lower = lower_dt
             return e[
-                (e[TS_FIELD_NAME] >= lower) &
                 (e[TS_FIELD_NAME] <= upper_dt)
             ][added_query_fields + list(map(getname, columns))]
 
         def collect_expr(e):
-            """Execute and merge all of the per-column subqueries.
+            """Materialize the expression as a dataframe.
 
             Parameters
             ----------

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -127,7 +127,7 @@ from __future__ import division, absolute_import
 from abc import ABCMeta, abstractproperty
 from collections import namedtuple, defaultdict
 from copy import copy
-from functools import partial, reduce
+from functools import partial
 from itertools import count
 import warnings
 from weakref import WeakKeyDictionary
@@ -137,7 +137,6 @@ from datashape import (
     Date,
     DateTime,
     Option,
-    floating,
     isrecord,
     isscalar,
 )

--- a/zipline/utils/pandas_utils.py
+++ b/zipline/utils/pandas_utils.py
@@ -1,6 +1,8 @@
 """
 Utilities for working with pandas objects.
 """
+import operator as op
+
 import pandas as pd
 
 
@@ -15,6 +17,86 @@ def explode(df):
 
 try:
     # pandas 0.16 compat
-    sort_values = pd.DataFrame.sort_values
+    _df_sort_values = pd.DataFrame.sort_values
+    _series_sort_values = pd.Series.sort_values
 except AttributeError:
-    sort_values = pd.DataFrame.sort
+    _df_sort_values = pd.DataFrame.sort
+    _series_sort_values = pd.Series.sort
+
+
+def sort_values(ob, *args, **kwargs):
+    if isinstance(ob, pd.DataFrame):
+        return _df_sort_values(ob, *args, **kwargs)
+    elif isinstance(ob, pd.Series):
+        return _series_sort_values(ob, *args, **kwargs)
+    raise ValueError(
+        'sort_values expected a dataframe or series, not %s: %r' % (
+            type(ob).__name__, ob,
+        ),
+    )
+
+
+def _time_to_micros(time):
+    """Convert a time into milliseconds since midnight.
+
+    Parameters
+    ----------
+    time : datetime.time
+        The time to convert.
+
+    Returns
+    -------
+    ms : int
+        The number of milliseconds since midnight.
+    """
+    seconds = time.hour * 60 * 60 + 60 * time.minute + time.second
+    return 1000000 * seconds + time.microsecond
+
+
+_opmap = {
+    (True, True): (op.le, op.le),
+    (True, False): (op.le, op.lt),
+    (False, True): (op.lt, op.le),
+    (False, False): (op.lt, op.lt),
+}
+
+
+def mask_between_time(dts, start, end, include_start=True, include_end=True):
+    """Return a mask of all of the datetimes in ``dts`` that are between
+    ``start`` and ``end``.
+
+    Parameters
+    ----------
+    dts : pd.DatetimeIndex
+        The index to mask.
+    start : time
+    end : time
+        The start and end times.
+    include_start : bool, optional
+        Inclusive on ``start``.
+    include_end : bool, optional
+        Inclusive on ``end``.
+
+    Returns
+    -------
+    mask : np.ndarray[bool]
+        A bool array masking ``dts``.
+
+    See Also
+    --------
+    :meth:`pandas.DatetimeIndex.indexer_between_times`
+    """
+    time_micros = dts._get_time_micros()
+    start_micros = _time_to_micros(start)
+    end_micros = _time_to_micros(end)
+
+    lop, rop = _opmap[include_start, include_end]
+    if start_micros <= end_micros:
+        join_op = op.and_
+    else:
+        join_op = op.or_
+
+    return join_op(
+        lop(start_micros, time_micros),
+        rop(time_micros, end_micros),
+    )


### PR DESCRIPTION
Breaking out what I have now so I don't build up a very large diff.

1. Only do the lower bound query for the base expression, not the deltas. This was extra work that is not needed.
1. `DatetimeIndex.time >= time` is _really_ slow. Implements a `mask_time_between` which will do the time comparison against the datetime index much more quickly.
1. Upgrade blaze ecosystem. One important change is to drop an unneeded copy in the blaze server/client.

This shaves about 1.5s off the tests which is nice.