### PR TITLE
BUG: Fixes bcolz padding to not always pad 390 minutes

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -475,7 +475,9 @@ class BcolzMinuteBarTestCase(TestCase):
         self.assertEqual(last_date, TEST_CALENDAR_START)
 
         freq = self.market_opens.index.freq
-        minute = self.market_opens[TEST_CALENDAR_START + freq]
+        day = TEST_CALENDAR_START + freq
+        minute = self.market_opens[day]
+
         data = DataFrame(
             data={
                 'open': [15.0],
@@ -506,6 +508,15 @@ class BcolzMinuteBarTestCase(TestCase):
         volume_price = self.reader.get_value(sid, minute, 'volume')
 
         self.assertEquals(100.0, volume_price)
+
+        # Check that if we then pad the rest of this day, we end up with
+        # 2 days worth of minutes.
+        self.writer.pad(sid, day)
+
+        self.assertEqual(
+            len(self.writer._ensure_ctable(sid)),
+            self.writer._minutes_per_day * 2,
+        )
 
     def test_nans(self):
         """

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -393,7 +393,12 @@ class BcolzMinuteBarWriter(object):
         return bcolz.ctable(rootdir=sidpath, mode='a')
 
     def _zerofill(self, table, numdays):
-        num_to_prepend = numdays * self._minutes_per_day
+        # Compute the number of minutes to be filled, accounting for the
+        # possibility of a partial day's worth of minutes existing for
+        # the previous day.
+        minute_offset = len(table) % self._minutes_per_day
+        num_to_prepend = numdays * self._minutes_per_day - minute_offset
+
         prepend_array = np.zeros(num_to_prepend, np.uint32)
         # Fill all OHLCV with zeros.
         table.append([prepend_array] * 5)


### PR DESCRIPTION
If minutes already exist for the last existing day, adjust the number of minutes padded to account for them. Previously we would always pad 390, leading to a mismatch in the number of rows.