### PR TITLE
MAINT: Adds first_trading_day arg to DataPortal

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -94,6 +94,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         with tmp_bcolz_minute_bar_reader(self.env, days, assets) as reader:
             data_portal = DataPortal(
                 self.env,
+                first_trading_day=reader.first_trading_day,
                 equity_minute_reader=reader,
             )
 
@@ -482,6 +483,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         with tmp_bcolz_minute_bar_reader(self.env, days, assets) as reader:
             data_portal = DataPortal(
                 self.env,
+                first_trading_day=reader.first_trading_day,
                 equity_minute_reader=reader,
             )
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -3372,9 +3372,11 @@ class TestEquityAutoClose(WithTmpDir, ZiplineTestCase):
             BcolzDailyBarWriter(path, dates).write(
                 iteritems(trade_data_by_sid),
             )
+            reader = BcolzDailyBarReader(path)
             data_portal = DataPortal(
                 env,
-                equity_daily_reader=BcolzDailyBarReader(path)
+                first_trading_day=reader.first_trading_day,
+                equity_daily_reader=reader,
             )
         elif frequency == 'minute':
             dates = env.minutes_for_days_in_range(
@@ -3400,9 +3402,11 @@ class TestEquityAutoClose(WithTmpDir, ZiplineTestCase):
                 volume_step_by_date=10,
                 frequency=frequency
             )
+            reader = BcolzMinuteBarReader(self.tmpdir.path)
             data_portal = DataPortal(
                 env,
-                equity_minute_reader=BcolzMinuteBarReader(self.tmpdir.path)
+                first_trading_day=reader.first_trading_day,
+                equity_minute_reader=reader,
             )
         else:
             self.fail("Unknown frequency in make_data: %r" % frequency)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -151,6 +151,7 @@ class TestBenchmark(WithDataPortal, WithSimParams, ZiplineTestCase):
         with tmp_reader as reader:
             data_portal = DataPortal(
                 self.env,
+                first_trading_day=reader.first_trading_day,
                 equity_minute_reader=reader,
                 equity_daily_reader=self.bcolz_daily_bar_reader,
                 adjustment_reader=self.adjustment_reader,

--- a/tests/test_data_portal.py
+++ b/tests/test_data_portal.py
@@ -26,7 +26,7 @@ class TestDataPortal(WithTradingEnvironment, ZiplineTestCase):
     def init_instance_fixtures(self):
         super(TestDataPortal, self).init_instance_fixtures()
 
-        self.data_portal = DataPortal(self.env)
+        self.data_portal = DataPortal(self.env, first_trading_day=None)
 
     def test_bar_count_for_simple_transforms(self):
         # July 2015

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -227,6 +227,7 @@ class FinanceTestCase(WithLogger,
 
                 data_portal = DataPortal(
                     env,
+                    first_trading_day=equity_minute_reader.first_trading_day,
                     equity_minute_reader=equity_minute_reader,
                 )
             else:
@@ -254,6 +255,7 @@ class FinanceTestCase(WithLogger,
 
                 data_portal = DataPortal(
                     env,
+                    first_trading_day=equity_daily_reader.first_trading_day,
                     equity_daily_reader=equity_daily_reader,
                 )
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -617,12 +617,14 @@ class TradingAlgorithm(object):
                         copy_panel.items
                     )
                 )
+                equity_daily_reader = PanelDailyBarReader(
+                    self.trading_environment.trading_days,
+                    copy_panel,
+                )
                 self.data_portal = DataPortal(
                     self.trading_environment,
-                    equity_daily_reader=PanelDailyBarReader(
-                        self.trading_environment.trading_days,
-                        copy_panel,
-                    ),
+                    first_trading_day=equity_daily_reader.first_trading_day,
+                    equity_daily_reader=equity_daily_reader,
                 )
 
         # Force a reset of the performance tracker, in case

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -470,8 +470,10 @@ class DataPortal(object):
     env : TradingEnvironment
         The trading environment for the simulation. This includes the trading
         calendar and benchmark data.
+    first_trading_day : pd.Timestamp
+        The first trading day for the simulation.
     equity_daily_reader : BcolzDailyBarReader, optional
-        The daily bar ready for equities. This will be used to service
+        The daily bar reader for equities. This will be used to service
         daily data backtests or daily history calls in a minute backetest.
         If a daily bar reader is not provided but a minute bar reader is,
         the minutes will be rolled up to serve the daily requests.
@@ -494,6 +496,7 @@ class DataPortal(object):
     """
     def __init__(self,
                  env,
+                 first_trading_day,
                  equity_daily_reader=None,
                  equity_minute_reader=None,
                  future_daily_reader=None,
@@ -540,7 +543,7 @@ class DataPortal(object):
         self._future_daily_reader = future_daily_reader
         self._future_minute_reader = future_minute_reader
 
-        self._first_trading_day = None
+        self._first_trading_day = first_trading_day
 
         if self._equity_minute_reader is not None:
             self._equity_daily_aggregator = DailyHistoryAggregator(
@@ -553,14 +556,6 @@ class DataPortal(object):
             )
             self.MINUTE_PRICE_ADJUSTMENT_FACTOR = \
                 self._equity_minute_reader._ohlc_inverse
-
-        # get the first trading day from our readers.
-        if self._equity_daily_reader is not None:
-            self._first_trading_day = \
-                self._equity_daily_reader.first_trading_day
-        elif self._equity_minute_reader is not None:
-            self._first_trading_day = \
-                self._equity_minute_reader.first_trading_day
 
     def _reindex_extra_source(self, df, source_date_index):
         return df.reindex(index=source_date_index, method='ffill')

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -483,6 +483,7 @@ def create_data_portal(env, tempdir, sim_params, sids, adjustment_reader=None):
 
         return DataPortal(
             env,
+            first_trading_day=equity_daily_reader.first_trading_day,
             equity_daily_reader=equity_daily_reader,
             adjustment_reader=adjustment_reader
         )
@@ -498,6 +499,7 @@ def create_data_portal(env, tempdir, sim_params, sids, adjustment_reader=None):
 
         return DataPortal(
             env,
+            first_trading_day=equity_minute_reader.first_trading_day,
             equity_minute_reader=equity_minute_reader,
             adjustment_reader=adjustment_reader
         )
@@ -618,6 +620,7 @@ def create_data_portal_from_trade_history(env, tempdir, sim_params,
 
         return DataPortal(
             env,
+            first_trading_day=equity_daily_reader.first_trading_day,
             equity_daily_reader=equity_daily_reader,
         )
     else:
@@ -669,17 +672,18 @@ def create_data_portal_from_trade_history(env, tempdir, sim_params,
 
         return DataPortal(
             env,
+            first_trading_day=equity_minute_reader.first_trading_day,
             equity_minute_reader=equity_minute_reader,
         )
 
 
 class FakeDataPortal(DataPortal):
 
-    def __init__(self, env=None):
+    def __init__(self, env=None, first_trading_day=None):
         if env is None:
             env = TradingEnvironment()
 
-        super(FakeDataPortal, self).__init__(env)
+        super(FakeDataPortal, self).__init__(env, first_trading_day)
 
     def get_spot_value(self, asset, field, dt, data_frequency):
         if field == "volume":
@@ -708,8 +712,8 @@ class FetcherDataPortal(DataPortal):
     Mock dataportal that returns fake data for history and non-fetcher
     spot value.
     """
-    def __init__(self, env):
-        super(FetcherDataPortal, self).__init__(env)
+    def __init__(self, env, first_trading_day=None):
+        super(FetcherDataPortal, self).__init__(env, first_trading_day)
 
     def get_spot_value(self, asset, field, dt, data_frequency):
         # if this is a fetcher field, exercise the regular code path

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -1156,8 +1156,16 @@ class WithDataPortal(WithAdjustmentReader,
     DATA_PORTAL_USE_ADJUSTMENTS = True
 
     def make_data_portal(self):
+        if self.DATA_PORTAL_USE_MINUTE_DATA:
+            first_trading_day = self.bcolz_minute_bar_reader.first_trading_day
+        elif self.DATA_PORTAL_USE_DAILY_DATA:
+            first_trading_day = self.bcolz_daily_bar_reader.first_trading_day
+        else:
+            first_trading_day = None
+
         return DataPortal(
             self.env,
+            first_trading_day=first_trading_day,
             equity_daily_reader=(
                 self.bcolz_daily_bar_reader
                 if self.DATA_PORTAL_USE_DAILY_DATA else

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -130,6 +130,7 @@ def _run(handle_data,
         env = TradingEnvironment(asset_db_path=connstr)
         data = DataPortal(
             env,
+            first_trading_day=bundle_data.minute_bar_reader.first_trading_day,
             equity_minute_reader=bundle_data.minute_bar_reader,
             equity_daily_reader=bundle_data.daily_bar_reader,
             adjustment_reader=bundle_data.adjustment_reader,


### PR DESCRIPTION
Instead of inferring it from the minute/daily writer, we now require the first trading day to be passed explicitly, so the creator of the `DataPortal` controls what is used as the first trading day.