### PR TITLE
BUG: Fixes reading and writing of daily bars first_trading_day attr

### DIFF
--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -186,6 +186,12 @@ class BcolzDailyBarTestCase(WithBcolzDailyBarReader, ZiplineTestCase):
             DatetimeIndex(result.attrs['calendar'], tz='UTC'),
         )
 
+    def test_read_first_trading_day(self):
+        self.assertEqual(
+            self.bcolz_daily_bar_reader.first_trading_day,
+            self.trading_days[0],
+        )
+
     def _check_read_results(self, columns, assets, start_date, end_date):
         results = self.bcolz_daily_bar_reader.load_raw_arrays(
             columns,

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -358,9 +358,7 @@ class BcolzDailyBarWriter(object):
         )
 
         full_table.attrs['first_trading_day'] = (
-            earliest_date // 1e6
-            if earliest_date is not None else
-            iNaT
+            earliest_date if earliest_date is not None else iNaT
         )
         full_table.attrs['first_row'] = first_row
         full_table.attrs['last_row'] = last_row
@@ -507,7 +505,7 @@ class BcolzDailyBarReader(DailyBarReader):
         try:
             return Timestamp(
                 self._table.attrs['first_trading_day'],
-                unit='ms',
+                unit='s',
                 tz='UTC'
             )
         except KeyError:


### PR DESCRIPTION
When writing `'first_trading_day'`, it is already in the correct frame of reference (seconds since epoch) and does not need to be transformed further. Adjusts the reader to expect this value.