### PR TITLE
BUG: Don't delete namespace if import fails.

### DIFF
--- a/zipline/dispatch.py
+++ b/zipline/dispatch.py
@@ -13,9 +13,9 @@ except ImportError:
     pass
 else:
     globals().update(namespace)
+    del namespace
 
 dispatch = partial(dispatch, namespace=globals())
 
-del namespace
 del partial
 del sys


### PR DESCRIPTION
datashape should be optional, this ensures it is actually optional.