### PR TITLE
MAINT: Break reference cycle between algorithm and simulator

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from functools import partial
-import gc
 import tarfile
 
 import matplotlib
@@ -53,20 +52,6 @@ class ExamplesTests(WithTmpDir, ZiplineTestCase):
             ),
             serialization='pickle',
         )
-
-        # We need to call gc.collect before tearing down our class because we
-        # have a cycle between TradingAlgorithm and AlgorithmSimulator which
-        # ultimately holds a reference to the pipeline engine passed to the
-        # tests here.
-
-        # This means that we're not guaranteed to have deleted our disk-backed
-        # resource readers (e.g. SQLiteAdjustmentReader) before trying to
-        # delete the tempdir, which causes failures on Windows because Windows
-        # doesn't allow you to delete a file if someone still has an open
-        # handle to that file.
-
-        # :(
-        cls.add_class_callback(gc.collect)
 
     @parameterized.expand(examples.EXAMPLE_MODULES)
     def test_example(self, example_name):

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -142,9 +142,9 @@ class AlgorithmSimulator(object):
                 for new_order in new_orders:
                     perf_tracker.process_order(new_order)
 
-            self.algo.portfolio_needs_update = True
-            self.algo.account_needs_update = True
-            self.algo.performance_needs_update = True
+            algo.portfolio_needs_update = True
+            algo.account_needs_update = True
+            algo.performance_needs_update = True
 
         def once_a_day(midnight_dt, current_data=self.current_data,
                        data_portal=self.data_portal):
@@ -191,6 +191,10 @@ class AlgorithmSimulator(object):
                 benchmark_source.get_value(date)
 
         def on_exit():
+            # Remove references to algo, data portal, et al to break cycles
+            # and ensure deterministic cleanup of these objects when the
+            # simulation finishes.
+            self.algo = None
             self.benchmark_source = self.current_data = self.data_portal = None
 
         with ExitStack() as stack:


### PR DESCRIPTION
when simulation finishes, so that resources are cleaned up
deterministically.

See #1235.