### PR TITLE
Correct typo

### DIFF
--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -211,7 +211,7 @@ def run(ctx,
     if start is None:
         ctx.fail("must specify a start date with '-s' / '--start'")
     if end is None:
-        ctx.fail("must specify an end date with '-s' / '--end'")
+        ctx.fail("must specify an end date with '-e' / '--end'")
 
     if (algotext is not None) == (algofile is not None):
         ctx.fail(

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -408,7 +408,7 @@ def _make_bundle_core():
                 raise
             raise ValueError(
                 'no data for bundle {bundle!r} on or before {timestamp}\n'
-                'maybe you need to run: $ zipline ingest {bundle}'.format(
+                'maybe you need to run: $ zipline ingest -b {bundle}'.format(
                     bundle=bundle_name,
                     timestamp=timestamp,
                 ),


### PR DESCRIPTION
```
18:55  $ zipline ingest quantopian-quandl                                                                                           (zipline_conda)
Usage: zipline ingest [OPTIONS]

Error: Got unexpected extra argument (quantopian-quandl)
```

Need to add `-b` flag. 
