### PR TITLE
BUG: Apply latest adjustment for minute `1d`

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -1336,7 +1336,8 @@ class DataPortal(object):
             self, assets, field, minutes_for_window):
         return self._equity_minute_history_loader.history(assets,
                                                           minutes_for_window,
-                                                          field)
+                                                          field,
+                                                          False)
 
     def _apply_all_adjustments(self, data, asset, dts, field,
                                price_adj_factor=1.0):
@@ -1452,7 +1453,8 @@ class DataPortal(object):
         if bar_count != 0:
             data = self._equity_history_loader.history(assets,
                                                        days_in_window,
-                                                       field)
+                                                       field,
+                                                       extra_slot)
             if extra_slot:
                 return_array[:len(return_array) - 1, :] = data
             else:

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -189,11 +189,11 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
             'splits', sid)
         for s in splits:
             dt = s[0]
-            if field == 'volume':
-                ratio = 1.0 / s[1]
-            else:
-                ratio = s[1]
             if start < dt <= end:
+                if field == 'volume':
+                    ratio = 1.0 / s[1]
+                else:
+                    ratio = s[1]
                 end_loc = dts.searchsorted(dt)
                 adj_loc = end_loc
                 if is_perspective_after:

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -103,7 +103,8 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
     def _array(self, start, end, assets, field):
         pass
 
-    def _get_adjustments_in_range(self, asset, dts, field):
+    def _get_adjustments_in_range(self, asset, dts, field,
+                                  is_perspective_after):
         """
         Get the Float64Multiply objects to pass to an AdjustedArrayWindow.
 
@@ -126,6 +127,12 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
             The days for which adjustment data is needed.
         field : str
             OHLCV field for which to get the adjustments.
+        is_perspective_after : bool
+            see: `USEquityHistoryLoader.history`
+            If True, the index at which the Multiply object is registered to
+            be popped is calculated so that it applies to the last slot in the
+            sliding window  when the adjustment occurs immediately after the dt
+            that slot represents.
 
         Returns
         -------
@@ -142,30 +149,42 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
                 dt = m[0]
                 if start < dt <= end:
                     end_loc = dts.searchsorted(dt)
+                    adj_loc = end_loc
+                    if is_perspective_after:
+                        # Set adjustment pop location so that it applies
+                        # to last value if adjustment occurs immediately after
+                        # the last slot.
+                        adj_loc -= 1
                     mult = Float64Multiply(0,
                                            end_loc - 1,
                                            0,
                                            0,
                                            m[1])
                     try:
-                        adjs[end_loc].append(mult)
+                        adjs[adj_loc].append(mult)
                     except KeyError:
-                        adjs[end_loc] = [mult]
+                        adjs[adj_loc] = [mult]
             divs = self._adjustments_reader.get_adjustments_for_sid(
                 'dividends', sid)
             for d in divs:
                 dt = d[0]
                 if start < dt <= end:
                     end_loc = dts.searchsorted(dt)
+                    adj_loc = end_loc
+                    if is_perspective_after:
+                        # Set adjustment pop location so that it applies
+                        # to last value if adjustment occurs immediately after
+                        # the last slot.
+                        adj_loc -= 1
                     mult = Float64Multiply(0,
                                            end_loc - 1,
                                            0,
                                            0,
                                            d[1])
                     try:
-                        adjs[end_loc].append(mult)
+                        adjs[adj_loc].append(mult)
                     except KeyError:
-                        adjs[end_loc] = [mult]
+                        adjs[adj_loc] = [mult]
         splits = self._adjustments_reader.get_adjustments_for_sid(
             'splits', sid)
         for s in splits:
@@ -176,18 +195,25 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
                 ratio = s[1]
             if start < dt <= end:
                 end_loc = dts.searchsorted(dt)
+                adj_loc = end_loc
+                if is_perspective_after:
+                    # Set adjustment pop location so that it applies
+                    # to last value if adjustment occurs immediately after
+                    # the last slot.
+                    adj_loc -= 1
                 mult = Float64Multiply(0,
                                        end_loc - 1,
                                        0,
                                        0,
                                        ratio)
                 try:
-                    adjs[end_loc].append(mult)
+                    adjs[adj_loc].append(mult)
                 except KeyError:
-                    adjs[end_loc] = [mult]
+                    adjs[adj_loc] = [mult]
         return adjs
 
-    def _ensure_sliding_windows(self, assets, dts, field):
+    def _ensure_sliding_windows(self, assets, dts, field,
+                                is_perspective_after):
         """
         Ensure that there is a Float64Multiply window for each asset that can
         provide data for the given parameters.
@@ -207,6 +233,8 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
             in the calendar.
         field : str
             The OHLCV field for which to retrieve data.
+        is_perspective_after : bool
+            see: `USEquityHistoryLoader.history`
 
         Returns
         -------
@@ -218,10 +246,11 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
         size = len(dts)
         asset_windows = {}
         needed_assets = []
+
         for asset in assets:
             try:
                 asset_windows[asset] = self._window_blocks[field].get(
-                    (asset, size), end)
+                    (asset, size, is_perspective_after), end)
             except KeyError:
                 needed_assets.append(asset)
 
@@ -245,7 +274,7 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
             for i, asset in enumerate(needed_assets):
                 if self._adjustments_reader:
                     adjs = self._get_adjustments_in_range(
-                        asset, prefetch_dts, field)
+                        asset, prefetch_dts, field, is_perspective_after)
                 else:
                     adjs = {}
                 window = Float64Window(
@@ -257,13 +286,14 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
                 )
                 sliding_window = SlidingWindow(window, size, start_ix, offset)
                 asset_windows[asset] = sliding_window
-                self._window_blocks[field].set((asset, size),
-                                               sliding_window,
-                                               prefetch_end)
+                self._window_blocks[field].set(
+                    (asset, size, is_perspective_after),
+                    sliding_window,
+                    prefetch_end)
 
         return [asset_windows[asset] for asset in assets]
 
-    def history(self, assets, dts, field):
+    def history(self, assets, dts, field, is_perspective_after):
         """
         A window of pricing data with adjustments applied assuming that the
         end of the window is the day before the current simulation time.
@@ -278,13 +308,70 @@ class USEquityHistoryLoader(with_metaclass(ABCMeta)):
             in the calendar.
         field : str
             The OHLCV field for which to retrieve data.
+        is_perspective_after : bool
+            True, if the window is being viewed immediately after the last dt
+            in the sliding window.
+            False, if the window is viewed on the last dt.
 
+            This flag is used for handling the case where the last dt in the
+            requested window immediately precedes a corporate action, e.g.:
+
+            - is_perspective_after is True
+
+            When the viewpoint is after the last dt in the window, as when a
+            daily history window is accessed from a simulation that uses a
+            minute data frequency, the history call to this loader will not
+            include the current simulation dt. At that point in time, the raw
+            data for the last day in the window will require adjustment, so the
+            most recent adjustment with respect to the simulation time is
+            applied to the last dt in the requested window.
+
+            An example equity which has a 0.5 split ratio dated for 05-27,
+            with the dts for a history call of 5 bars with a '1d' frequency at
+            05-27 9:31. Simulation frequency is 'minute'.
+
+            (In this case this function is called with 4 daily dts, and the
+             calling function is responsible for stitching back on the
+             'current' dt)
+
+            |       |       |       |       | last dt | <-- viewer is here |
+            |       | 05-23 | 05-24 | 05-25 | 05-26   | 05-27 9:31         |
+            | raw   | 10.10 | 10.20 | 10.30 | 10.40   |                    |
+            | adj   |  5.05 |  5.10 |  5.15 |  5.25   |                    |
+
+            The adjustment is applied to the last dt, 05-26, and all previous
+            dts.
+
+            - is_perspective_after is False, daily
+
+            When the viewpoint is the same point in time as the last dt in the
+            window, as when a daily history window is accessed from a
+            simulation that uses a daily data frequency, the history call will
+            include the current dt. At that point in time, the raw data for the
+            last day in the window will be post-adjustment, so no adjustment
+            is applied to the last dt.
+
+            An example equity which has a 0.5 split ratio dated for 05-27,
+            with the dts for a history call of 5 bars with a '1d' frequency at
+            05-27 0:00. Simulation frequency is 'daily'.
+
+            |       |       |       |       |       | <-- viewer is here |
+            |       |       |       |       |       | last dt            |
+            |       | 05-23 | 05-24 | 05-25 | 05-26 | 05-27              |
+            | raw   | 10.10 | 10.20 | 10.30 | 10.40 | 5.25               |
+            | adj   |  5.05 |  5.10 |  5.15 |  5.20 | 5.25               |
+
+            Adjustments are applied 05-23 through 05-26 but not to the last dt,
+            05-27
 
         Returns
         -------
         out : np.ndarray with shape(len(days between start, end), len(assets))
         """
-        block = self._ensure_sliding_windows(assets, dts, field)
+        block = self._ensure_sliding_windows(assets,
+                                             dts,
+                                             field,
+                                             is_perspective_after)
         end_ix = self._calendar.get_loc(dts[-1])
         return hstack([window.get(end_ix) for window in block])
 


### PR DESCRIPTION
Fix behavior in minute mode history with frequency `1d`, where on the
day immediately following an adjustment action, the overnight adjustment
would not apply. (However the adjustment would be applied after a 1 day
lag.)

The root cause of the bug was that the history data for minute mode when
using `1d` stitches together a sliding window of the daily data for
previous  and the current minute. That daily data sliding window and
corresponding adjustments was being read as if the data was being viewed
from on the last day of the window; however in this case the data is
being viewed from the day after the window has completed. The difference
in view points requires the adjustments to popped and applied by the
adjusted array one index earlier. The fix uses the `extra_slot` value as
signifier on whether the data is being viewed on the following day and
then accordingly adjusts the index of the mulitpy object.

Also, change the split and merger test data ratios to have different values,
to ensure that different adjustment values are applied; as opposed to
doubling up on just one of the values.