### PR TITLE
MAINT: Removes the set_first_trading_day method of DataPortal

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -27,7 +27,8 @@ from zipline.testing import (
 from zipline.testing.fixtures import (
     WithBcolzMinuteBarReader,
     WithDataPortal,
-    ZiplineTestCase
+    ZiplineTestCase,
+    alias,
 )
 
 
@@ -447,6 +448,7 @@ MINUTE_FIELD_INFO = {
 class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
 
     BCOLZ_DAILY_BAR_SOURCE_FROM_MINUTE = True
+    DATA_PORTAL_FIRST_TRADING_DAY = alias('TRADING_START_DT')
 
     @classmethod
     def make_minute_bar_data(cls):
@@ -1006,7 +1008,6 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
     def test_history_window_before_first_trading_day(self):
         # trading_start is 2/3/2014
         # get a history window that starts before that, and ends after that
-        self.data_portal.set_first_trading_day(self.TRADING_START_DT)
         first_day_minutes = self.trading_schedule.execution_minutes_for_day(
             self.TRADING_START_DT
         )
@@ -1514,8 +1515,6 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
     def test_history_window_before_first_trading_day(self):
         # trading_start is 2/3/2014
         # get a history window that starts before that, and ends after that
-
-        self.data_portal.set_first_trading_day(self.TRADING_START_DT)
         second_day = self.trading_schedule.next_execution_day(
             self.TRADING_START_DT
         )

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -556,25 +556,27 @@ class DataPortal(object):
             self.MINUTE_PRICE_ADJUSTMENT_FACTOR = \
                 self._equity_minute_reader._ohlc_inverse
 
-        self.set_first_trading_day(first_trading_day)
-
-    def set_first_trading_day(self, first_trading_day):
         self._first_trading_day = first_trading_day
 
         # Get the first trading minute
-        if self._first_trading_day is not None:
-            self._first_trading_minute, _ = \
-                self.trading_schedule.start_and_end(self._first_trading_day)
+        self._first_trading_minute, _ = (
+            self.trading_schedule.start_and_end(self._first_trading_day)
+            if self._first_trading_day is not None else (None, None)
+        )
 
-            # Store the locs of the first day and first minute
-            self._first_trading_day_loc = \
-                self.trading_schedule.all_execution_days.get_loc(
-                    self.trading_schedule.session_date(self._first_trading_day)
-                )
-            self._first_trading_minute_loc = \
-                self.trading_schedule.all_execution_minutes.get_loc(
-                    self._first_trading_minute
-                )
+        # Store the locs of the first day and first minute
+        self._first_trading_day_loc = (
+            self.trading_schedule.all_execution_days.get_loc(
+                self.trading_schedule.session_date(self._first_trading_day)
+            )
+            if self._first_trading_day is not None else None
+        )
+        self._first_trading_minute_loc = (
+            self.trading_schedule.all_execution_minutes.get_loc(
+                self._first_trading_minute
+            )
+            if self._first_trading_minute is not None else None
+        )
 
     def _reindex_extra_source(self, df, source_date_index):
         return df.reindex(index=source_date_index, method='ffill')

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -1188,18 +1188,21 @@ class WithDataPortal(WithAdjustmentReader,
     DATA_PORTAL_USE_MINUTE_DATA = True
     DATA_PORTAL_USE_ADJUSTMENTS = True
 
+    DATA_PORTAL_FIRST_TRADING_DAY = None
+
     def make_data_portal(self):
-        if self.DATA_PORTAL_USE_MINUTE_DATA:
-            first_trading_day = self.bcolz_minute_bar_reader.first_trading_day
-        elif self.DATA_PORTAL_USE_DAILY_DATA:
-            first_trading_day = self.bcolz_daily_bar_reader.first_trading_day
-        else:
-            first_trading_day = None
+        if self.DATA_PORTAL_FIRST_TRADING_DAY is None:
+            if self.DATA_PORTAL_USE_MINUTE_DATA:
+                self.DATA_PORTAL_FIRST_TRADING_DAY = (
+                    self.bcolz_minute_bar_reader.first_trading_day)
+            elif self.DATA_PORTAL_USE_DAILY_DATA:
+                self.DATA_PORTAL_FIRST_TRADING_DAY = (
+                    self.bcolz_daily_bar_reader.first_trading_day)
 
         return DataPortal(
             self.env.asset_finder,
             self.trading_schedule,
-            first_trading_day=first_trading_day,
+            first_trading_day=self.DATA_PORTAL_FIRST_TRADING_DAY,
             equity_daily_reader=(
                 self.bcolz_daily_bar_reader
                 if self.DATA_PORTAL_USE_DAILY_DATA else


### PR DESCRIPTION
Since the first trading day is now passed directly to the `DataPortal` on init, there's no need for a method that does this. Moves all the additional logic/assignments into the init. Also corrects an issue where we would never create certain attributes if `self._first_trading_day` was `None`.

Adds the ability to specify the first trading day for a data portal in a test case when using the `WithDataPortal` fixture.