### PR TITLE
Schedule function rules refactoring

### DIFF
--- a/zipline/finance/performance/tracker.py
+++ b/zipline/finance/performance/tracker.py
@@ -66,7 +66,7 @@ import pandas as pd
 from pandas.tseries.tools import normalize_date
 
 from zipline.finance.performance.period import PerformancePeriod
-
+from zipline.errors import NoFurtherDataError
 import zipline.finance.risk as risk
 
 from . position_tracker import PositionTracker
@@ -391,9 +391,12 @@ class PerformanceTracker(object):
 
         # Get the next trading day and, if it is past the bounds of this
         # simulation, return the daily perf packet
-        next_trading_day = self.trading_schedule.next_execution_day(
-            completed_date
-        )
+        try:
+            next_trading_day = self.trading_schedule.next_execution_day(
+                completed_date
+            )
+        except NoFurtherDataError:
+            next_trading_day = None
 
         # Take a snapshot of our current performance to return to the
         # browser.

--- a/zipline/utils/calendars/calendar_helpers.py
+++ b/zipline/utils/calendars/calendar_helpers.py
@@ -73,7 +73,7 @@ def next_scheduled_day(date, last_trading_day, is_scheduled_day_hook):
         dt += delta
         if is_scheduled_day_hook(dt):
             return dt
-    return None
+    raise NoFurtherDataError(msg='Cannot find next day after %s' % date)
 
 
 def previous_scheduled_day(date, first_trading_day, is_scheduled_day_hook):
@@ -97,7 +97,7 @@ def previous_scheduled_day(date, first_trading_day, is_scheduled_day_hook):
         dt += delta
         if is_scheduled_day_hook(dt):
             return dt
-    return None
+    raise NoFurtherDataError(msg='Cannot find previous day before %s' % date)
 
 
 def next_open_and_close(date, open_and_close_hook,


### PR DESCRIPTION
- refactor the week rules to eliminate unnecessary type coercion of dates
- `next_scheduled_day` and `previous_scheduled_day` will raise `NoFurtherDataError` if there is no such day available in the calendar, instead of returning None. This is what `add_scheduled_days` does when `|n| > 1`, and make the behavior of the function consistent across all values of `n`
