### PR TITLE
MAINT: Creates deprecation warning for tradingcalendar imports

### DIFF
--- a/zipline/utils/tradingcalendar.py
+++ b/zipline/utils/tradingcalendar.py
@@ -14,14 +14,24 @@
 # limitations under the License.
 import pandas as pd
 import pytz
+import warnings
 
 from datetime import datetime
 from dateutil import rrule
 from functools import partial
 
+from zipline.zipline_warnings import ZiplineDeprecationWarning
+
 # IMPORTANT: This module is deprecated and is only here for temporary backwards
 # compatibility.  Look at the `zipline.utils.calendars.trading_schedule`
 # module, as well as the calendar definitions in `zipline.utils.calendars`.
+warnings.warn(
+    "The `tradingcalendar` module is deprecated. See the "
+    "`zipline.utils.calendars.trading_schedule` module,  as well as the "
+    "calendar definitions in `zipline.utils.calendars`.",
+    category=ZiplineDeprecationWarning,
+    stacklevel=1,
+)
 
 start = pd.Timestamp('1990-01-01', tz='UTC')
 end_base = pd.Timestamp('today', tz='UTC')


### PR DESCRIPTION
The `tradingcalendar` module was been replaced by the new exchange calendars and trading schedules. Sets up an import hook in `algorithm.py` to issue a ZiplineDeprecationWarning on `tradingcalendar` imports.