### PR TITLE
BUG: Fail fast on invalid pipeline columns

### DIFF
--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -63,6 +63,9 @@ class PipelineTestCase(TestCase):
         with self.assertRaises(TypeError):
             Pipeline({}, SomeFactor())
 
+        with self.assertRaises(TypeError):
+            Pipeline({'open': USEquityPricing.open})
+
         Pipeline({}, SomeFactor() > 5)
 
     def test_add(self):
@@ -77,6 +80,9 @@ class PipelineTestCase(TestCase):
 
         with self.assertRaises(TypeError):
             p.add(f, 1)
+
+        with self.assertRaises(TypeError):
+            p.add(USEquityPricing.open, 'open')
 
     def test_overwrite(self):
         p = Pipeline()

--- a/zipline/pipeline/pipeline.py
+++ b/zipline/pipeline/pipeline.py
@@ -1,6 +1,6 @@
 from zipline.utils.input_validation import expect_types, optional
 
-from .term import Term, AssetExists
+from .term import AssetExists, ComputableTerm
 from .filters import Filter
 from .graph import TermGraph
 
@@ -37,6 +37,12 @@ class Pipeline(object):
 
         if columns is None:
             columns = {}
+        for term in columns.values():
+            if not isinstance(term, ComputableTerm):
+                raise TypeError(
+                    '"{term}" is not a valid pipeline column. Did you mean '
+                    'to add ".latest"?'.format(term=term)
+                )
         self._columns = columns
         self._screen = screen
 
@@ -54,7 +60,7 @@ class Pipeline(object):
         """
         return self._screen
 
-    @expect_types(term=Term, name=str)
+    @expect_types(term=ComputableTerm, name=str)
     def add(self, term, name, overwrite=False):
         """
         Add a column.

--- a/zipline/pipeline/pipeline.py
+++ b/zipline/pipeline/pipeline.py
@@ -1,6 +1,6 @@
 from zipline.utils.input_validation import expect_types, optional
 
-from .term import AssetExists, ComputableTerm
+from .term import AssetExists, ComputableTerm, Term
 from .filters import Filter
 from .graph import TermGraph
 
@@ -37,11 +37,13 @@ class Pipeline(object):
 
         if columns is None:
             columns = {}
-        for term in columns.values():
+        for column_name, term in columns.items():
             if not isinstance(term, ComputableTerm):
                 raise TypeError(
-                    '"{term}" is not a valid pipeline column. Did you mean '
-                    'to add ".latest"?'.format(term=term)
+                    "Column {column_name!r} contains an invalid pipeline term "
+                    "({term}). Did you mean to append '.latest'?".format(
+                        column_name=column_name, term=term,
+                    )
                 )
         self._columns = columns
         self._screen = screen
@@ -60,7 +62,7 @@ class Pipeline(object):
         """
         return self._screen
 
-    @expect_types(term=ComputableTerm, name=str)
+    @expect_types(term=Term, name=str)
     def add(self, term, name, overwrite=False):
         """
         Add a column.
@@ -84,6 +86,12 @@ class Pipeline(object):
                 self.remove(name)
             else:
                 raise KeyError("Column '{}' already exists.".format(name))
+
+        if not isinstance(term, ComputableTerm):
+            raise TypeError(
+                "{term} is not a valid pipeline column. Did you mean to "
+                "append '.latest'?".format(term=term)
+            )
 
         self._columns[name] = term
 


### PR DESCRIPTION
If you try to run a pipeline with a column of `USEquityPricing.close` (or something similar) and you meant to use `USEquityPricing.close.latest`, it errors in a non-helpful/obvious way.