### PR TITLE
MAINT: Fixes DataPortal.get_spot_value to correctly handle 'price' field

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -787,8 +787,12 @@ class DataPortal(object):
             return self._get_daily_data(asset, field, day_to_use)
         else:
             if isinstance(asset, Future):
-                return self._get_minute_spot_value_future(
-                    asset, field, dt)
+                if field == "price":
+                    return self._get_minute_spot_value_future(
+                        asset, "close", dt)
+                else:
+                    return self._get_minute_spot_value_future(
+                        asset, field, dt)
             else:
                 if field == "last_traded":
                     return self._equity_minute_reader.get_last_traded_dt(


### PR DESCRIPTION
Querying for the price field of an equity actually looks at the close field, so we should do the same for futures. Otherwise `data.can_trade` and `data.current` of 'price' fail for futures.