### PR TITLE
BUG: Removes Hurricane Sandy closings from CME exchange calendar

### DIFF
--- a/zipline/utils/calendars/exchange_calendar_cme.py
+++ b/zipline/utils/calendars/exchange_calendar_cme.py
@@ -154,12 +154,6 @@ ChristmasEveInOrAfter1993 = Holiday(
 # http://en.wikipedia.org/wiki/Aftermath_of_the_September_11_attacks
 September11Closings = date_range('2001-09-11', '2001-09-16', tz='UTC')
 
-# http://en.wikipedia.org/wiki/Hurricane_sandy
-HurricaneSandyClosings = date_range(
-    '2012-10-29',
-    '2012-10-30',
-    tz='UTC'
-)
 
 # National Days of Mourning
 # - President Richard Nixon - April 27, 1994
@@ -264,7 +258,6 @@ class CMEExchangeCalendar(ExchangeCalendar):
 
     holidays_adhoc = list(chain(
         September11Closings,
-        HurricaneSandyClosings,
         USNationalDaysofMourning,
     ))
 


### PR DESCRIPTION
Since the CME calendar was based off of the NYSE calendar, closings for Hurricane Sandy were included, but shouldn't have been for CME.

This is the explanation we had included prior to the new exchange calendars:

http://en.wikipedia.org/wiki/Hurricane_sandy

We *do not* add any non-trading days for Hurricane Sandy. Although trading on CME Group exchanges was disrupted, trading still occurred at some point on each day. Importantly, the disruptions do not appear to have affected the expiration dates stipulated in the futures contracts expiring during this period.

Trading of CME US equity index futures & NYMEX futures was disrupted due to the hurricane's impact on New York. CME US equity index futures markets were disrupted on October 29th 2012, but reopened at 5:00pm CT.

The US equity index markets were closed from 8:15am CT on October 30, both for the trading floor and CME Globex. The trading floor of the NYMEX was closed on October 30, but all floor-trading products were available electronically on CME Globex.

Source:
http://investor.cmegroup.com/investor-relations/releasedetail.cfm?ReleaseID=716923

```
    October 2012
Su Mo Tu We Th Fr Sa
    1  2  3  4  5  6
 7  8  9 10 11 12 13
14 15 16 17 18 19 20
21 22 23 24 25 26 27
28 29 30 31
```

Also see:
-- http://www.chicagobusiness.com/article/20121029/NEWS01/121029818/cme-cboe-other-markets-closed-for-hurricane-sandy-about-500-local-flights-scrapped
-- http://money.cnn.com/2012/10/29/investing/hurricane-sandy-stock-markets