### PR TITLE
DOC: Fix typo in command line to ingest quandl

### DIFF
--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -128,7 +128,7 @@ API key we may run:
 
 .. code-block:: bash
 
-   $ QUANDL_API_KEY=<api-key> zipline ingest quandl
+   $ QUANDL_API_KEY=<api-key> zipline ingest -b quandl
 
 though we may still run ``ingest`` as an anonymous quandl user (with no API
 key). We may also set the ``QUANDL_DOWNLOAD_ATTEMPTS`` environment variable to


### PR DESCRIPTION
-b flag is required:

```
# zipline ingest quandl                                                                                                                                           
Usage: zipline ingest [OPTIONS]

Error: Got unexpected extra argument (quandl)
```

As help suggests:

```
Usage: zipline ingest [OPTIONS]

  Ingest the data for the given bundle.

Options:
  -b, --bundle BUNDLE-NAME        The data bundle to ingest.  [default:
                                  quantopian-quandl]

  <...>
```