### PR TITLE
MAINT: Disable deprecation warning for tradingcalendar

### DIFF
--- a/zipline/utils/tradingcalendar.py
+++ b/zipline/utils/tradingcalendar.py
@@ -14,24 +14,29 @@
 # limitations under the License.
 import pandas as pd
 import pytz
-import warnings
+# import warnings
 
 from datetime import datetime
 from dateutil import rrule
 from functools import partial
 
-from zipline.zipline_warnings import ZiplineDeprecationWarning
+# from zipline.zipline_warnings import ZiplineDeprecationWarning
 
 # IMPORTANT: This module is deprecated and is only here for temporary backwards
 # compatibility.  Look at the `zipline.utils.calendars.trading_schedule`
 # module, as well as the calendar definitions in `zipline.utils.calendars`.
-warnings.warn(
-    "The `tradingcalendar` module is deprecated. See the "
-    "`zipline.utils.calendars.trading_schedule` module,  as well as the "
-    "calendar definitions in `zipline.utils.calendars`.",
-    category=ZiplineDeprecationWarning,
-    stacklevel=1,
-)
+
+# TODO: The new calendar API is currently in flux, so the deprecation
+#       warning for this module is currently disabled. Re-enable once
+#       the new API is stabilized.
+#
+# warnings.warn(
+#     "The `tradingcalendar` module is deprecated. See the "
+#     "`zipline.utils.calendars.trading_schedule` module,  as well as the "
+#     "calendar definitions in `zipline.utils.calendars`.",
+#     category=ZiplineDeprecationWarning,
+#     stacklevel=1,
+# )
 
 start = pd.Timestamp('1990-01-01', tz='UTC')
 end_base = pd.Timestamp('today', tz='UTC')


### PR DESCRIPTION
The new calendar API is currently in flux, so disabling the deprecation warning for `tradingcalendar`. To be re-enabled once the new API is stabilized.