### PR TITLE
MAINT:  Add equity to naming of bar data classes.

### DIFF
--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -176,7 +176,7 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
 
         columns = 'open', 'high', 'low', 'close', 'volume'
 
-        actual = bundle.minute_bar_reader.load_raw_arrays(
+        actual = bundle.equity_minute_bar_reader.load_raw_arrays(
             columns,
             minutes[0],
             minutes[-1],
@@ -190,7 +190,7 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
                 msg=colname,
             )
 
-        actual = bundle.daily_bar_reader.load_raw_arrays(
+        actual = bundle.equity_daily_bar_reader.load_raw_arrays(
             columns,
             calendar[0],
             calendar[-1],

--- a/tests/data/bundles/test_quandl.py
+++ b/tests/data/bundles/test_quandl.py
@@ -216,7 +216,7 @@ class QuandlBundleTestCase(ZiplineTestCase):
             assert_equal(equity.end_date, self.asset_end, msg=equity)
 
         cal = self.calendar
-        actual = bundle.daily_bar_reader.load_raw_arrays(
+        actual = bundle.equity_daily_bar_reader.load_raw_arrays(
             self.columns,
             cal[cal.get_loc(self.asset_start, 'bfill')],
             cal[cal.get_loc(self.asset_end, 'ffill')],

--- a/tests/data/bundles/test_yahoo.py
+++ b/tests/data/bundles/test_yahoo.py
@@ -177,7 +177,7 @@ class YahooBundleTestCase(WithResponses, ZiplineTestCase):
             assert_equal(equity.start_date, self.asset_start, msg=equity)
             assert_equal(equity.end_date, self.asset_end, msg=equity)
 
-        actual = bundle.daily_bar_reader.load_raw_arrays(
+        actual = bundle.equity_daily_bar_reader.load_raw_arrays(
             self.columns,
             cal[cal.get_loc(self.asset_start, 'bfill')],
             cal[cal.get_loc(self.asset_end, 'ffill')],

--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -43,7 +43,7 @@ from zipline.pipeline.loaders.synthetic import (
 )
 from zipline.testing import seconds_to_timestamp
 from zipline.testing.fixtures import (
-    WithBcolzDailyBarReader,
+    WithBcolzEquityDailyBarReader,
     ZiplineTestCase,
 )
 from zipline.utils.calendars import get_calendar
@@ -79,19 +79,19 @@ EQUITY_INFO = DataFrame(
 TEST_QUERY_ASSETS = EQUITY_INFO.index
 
 
-class BcolzDailyBarTestCase(WithBcolzDailyBarReader, ZiplineTestCase):
-    BCOLZ_DAILY_BAR_START_DATE = TEST_CALENDAR_START
-    BCOLZ_DAILY_BAR_END_DATE = TEST_CALENDAR_STOP
+class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, ZiplineTestCase):
+    EQUITY_DAILY_BAR_START_DATE = TEST_CALENDAR_START
+    EQUITY_DAILY_BAR_END_DATE = TEST_CALENDAR_STOP
 
     @classmethod
     def make_equity_info(cls):
         return EQUITY_INFO
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         return make_bar_data(
             EQUITY_INFO,
-            cls.bcolz_daily_bar_days,
+            cls.equity_daily_bar_days,
         )
 
     @classmethod
@@ -187,12 +187,12 @@ class BcolzDailyBarTestCase(WithBcolzDailyBarReader, ZiplineTestCase):
 
     def test_read_first_trading_day(self):
         self.assertEqual(
-            self.bcolz_daily_bar_reader.first_trading_day,
+            self.bcolz_equity_daily_bar_reader.first_trading_day,
             self.trading_days[0],
         )
 
     def _check_read_results(self, columns, assets, start_date, end_date):
-        results = self.bcolz_daily_bar_reader.load_raw_arrays(
+        results = self.bcolz_equity_daily_bar_reader.load_raw_arrays(
             columns,
             start_date,
             end_date,
@@ -280,7 +280,7 @@ class BcolzDailyBarTestCase(WithBcolzDailyBarReader, ZiplineTestCase):
             )
 
     def test_unadjusted_spot_price(self):
-        reader = self.bcolz_daily_bar_reader
+        reader = self.bcolz_equity_daily_bar_reader
         # At beginning
         price = reader.spot_price(1, Timestamp('2015-06-01', tz='UTC'),
                                   'close')
@@ -318,7 +318,7 @@ class BcolzDailyBarTestCase(WithBcolzDailyBarReader, ZiplineTestCase):
             reader.spot_price(4, Timestamp('2015-06-16', tz='UTC'), 'close')
 
     def test_unadjusted_spot_price_empty_value(self):
-        reader = self.bcolz_daily_bar_reader
+        reader = self.bcolz_equity_daily_bar_reader
 
         # A sid, day and corresponding index into which to overwrite a zero.
         zero_sid = 1

--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -32,7 +32,7 @@ from zipline.finance.blotter import Order
 
 from zipline.data.data_portal import DataPortal
 from zipline.protocol import BarData
-from zipline.testing import tmp_bcolz_minute_bar_reader
+from zipline.testing import tmp_bcolz_equity_minute_bar_reader
 from zipline.testing.fixtures import (
     WithDataPortal,
     WithSimParams,
@@ -57,7 +57,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
     )
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         yield 133, pd.DataFrame(
             {
                 'open': [3.0, 3.0, 3.5, 4.0, 3.5],
@@ -91,7 +91,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
             start=normalize_date(self.minutes[0]),
             end=normalize_date(self.minutes[-1])
         )
-        with tmp_bcolz_minute_bar_reader(self.trading_schedule, days, assets) \
+        with tmp_bcolz_equity_minute_bar_reader(self.trading_schedule, days, assets) \
                 as reader:
             data_portal = DataPortal(
                 self.env.asset_finder, self.trading_schedule,
@@ -481,7 +481,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
             start=normalize_date(self.minutes[0]),
             end=normalize_date(self.minutes[-1])
         )
-        with tmp_bcolz_minute_bar_reader(self.trading_schedule, days, assets) \
+        with tmp_bcolz_equity_minute_bar_reader(self.trading_schedule, days, assets) \
                 as reader:
             data_portal = DataPortal(
                 self.env.asset_finder, self.trading_schedule,

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -893,10 +893,10 @@ class SyntheticBcolzTestCase(WithAdjustmentReader,
         return ret
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         return make_bar_data(
             cls.equity_info,
-            cls.bcolz_daily_bar_days,
+            cls.equity_daily_bar_days,
         )
 
     @classmethod
@@ -905,7 +905,7 @@ class SyntheticBcolzTestCase(WithAdjustmentReader,
         cls.all_asset_ids = cls.asset_finder.sids
         cls.last_asset_end = cls.equity_info['end_date'].max()
         cls.pipeline_loader = USEquityPricingLoader(
-            cls.bcolz_daily_bar_reader,
+            cls.bcolz_equity_daily_bar_reader,
             cls.adjustment_reader,
         )
 

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -56,7 +56,7 @@ from zipline.testing import (
 )
 from zipline.testing.fixtures import (
     WithAdjustmentReader,
-    WithBcolzDailyBarReaderFromCSVs,
+    WithBcolzEquityDailyBarReaderFromCSVs,
     WithDataPortal,
     ZiplineTestCase,
 )
@@ -120,7 +120,7 @@ class ClosesOnly(WithDataPortal, ZiplineTestCase):
         return ret
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         cls.closes = DataFrame(
             {sid: arange(1, len(cls.dates) + 1) * sid for sid in cls.sids},
             index=cls.dates,
@@ -340,7 +340,7 @@ class MockDailyBarSpotReader(object):
         return 100.0
 
 
-class PipelineAlgorithmTestCase(WithBcolzDailyBarReaderFromCSVs,
+class PipelineAlgorithmTestCase(WithBcolzEquityDailyBarReaderFromCSVs,
                                 WithAdjustmentReader,
                                 ZiplineTestCase):
     AAPL = 1
@@ -352,7 +352,7 @@ class PipelineAlgorithmTestCase(WithBcolzDailyBarReaderFromCSVs,
     END_DATE = Timestamp('2015')
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         resources = {
             cls.AAPL: join(TEST_RESOURCE_PATH, 'AAPL.csv'),
             cls.MSFT: join(TEST_RESOURCE_PATH, 'MSFT.csv'),
@@ -398,7 +398,7 @@ class PipelineAlgorithmTestCase(WithBcolzDailyBarReaderFromCSVs,
     def init_class_fixtures(cls):
         super(PipelineAlgorithmTestCase, cls).init_class_fixtures()
         cls.pipeline_loader = USEquityPricingLoader(
-            cls.bcolz_daily_bar_reader,
+            cls.bcolz_equity_daily_bar_reader,
             cls.adjustment_reader,
         )
         cls.dates = cls.raw_data[cls.AAPL].index.tz_localize('UTC')

--- a/tests/pipeline/test_us_equity_pricing_loader.py
+++ b/tests/pipeline/test_us_equity_pricing_loader.py
@@ -277,14 +277,14 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
         return DIVIDENDS
 
     @classmethod
-    def make_adjustment_writer_daily_bar_reader(cls):
+    def make_adjustment_writer_equity_daily_bar_reader(cls):
         return MockDailyBarReader()
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         return make_bar_data(
             EQUITY_INFO,
-            cls.bcolz_daily_bar_days,
+            cls.equity_daily_bar_days,
         )
 
     @classmethod
@@ -306,13 +306,13 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
                 self.assertLessEqual(eff_date, asset_end)
 
     def calendar_days_between(self, start_date, end_date, shift=0):
-        slice_ = self.bcolz_daily_bar_days.slice_indexer(start_date, end_date)
+        slice_ = self.equity_daily_bar_days.slice_indexer(start_date, end_date)
         start = slice_.start + shift
         stop = slice_.stop + shift
         if start < 0:
             raise KeyError(start_date, shift)
 
-        return self.bcolz_daily_bar_days[start:stop]
+        return self.equity_daily_bar_days[start:stop]
 
     def expected_adjustments(self, start_date, end_date):
         price_adjustments = {}
@@ -417,7 +417,7 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
         self.assertEqual(adjustments, [{}, {}])
 
         pricing_loader = USEquityPricingLoader(
-            self.bcolz_daily_bar_reader,
+            self.bcolz_equity_daily_bar_reader,
             adjustment_reader,
         )
 
@@ -494,7 +494,7 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
         )
 
         pricing_loader = USEquityPricingLoader(
-            self.bcolz_daily_bar_reader,
+            self.bcolz_equity_daily_bar_reader,
             self.adjustment_reader,
         )
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -741,7 +741,7 @@ class TestTransformAlgorithm(WithLogger,
         return pd.DataFrame.from_dict({3: {'multiplier': 10}}, 'index')
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         return trades_by_sid_to_dfs(
             {
                 sid: factory.create_trade_history(
@@ -1010,7 +1010,7 @@ class TestBeforeTradingStart(WithDataPortal,
     END_DATE = pd.Timestamp('2016-01-07', tz='utc')
     SIM_PARAMS_CAPITAL_BASE = 10000
     SIM_PARAMS_DATA_FREQUENCY = 'minute'
-    BCOLZ_DAILY_BAR_LOOKBACK_DAYS = BCOLZ_MINUTE_BAR_LOOKBACK_DAYS = 1
+    EQUITY_DAILY_BAR_LOOKBACK_DAYS = EQUITY_MINUTE_BAR_LOOKBACK_DAYS = 1
 
     data_start = ASSET_FINDER_EQUITY_START_DATE = pd.Timestamp(
         '2016-01-05',
@@ -1021,7 +1021,7 @@ class TestBeforeTradingStart(WithDataPortal,
     ASSET_FINDER_EQUITY_SIDS = 1, 2, SPLIT_ASSET_SID
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         asset_minutes = \
             cls.trading_schedule.execution_minutes_for_days_in_range(
                 cls.data_start,
@@ -1066,7 +1066,7 @@ class TestBeforeTradingStart(WithDataPortal,
         ])
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         for sid in cls.ASSET_FINDER_EQUITY_SIDS:
             yield sid, create_daily_df_for_asset(
                 cls.trading_schedule,
@@ -1357,7 +1357,7 @@ class TestAlgoScript(WithLogger,
     START_DATE = pd.Timestamp('2006-01-03', tz='utc')
     END_DATE = pd.Timestamp('2006-12-31', tz='utc')
     DATA_PORTAL_USE_MINUTE_DATA = False
-    BCOLZ_DAILY_BAR_LOOKBACK_DAYS = 5  # max history window length
+    EQUITY_DAILY_BAR_LOOKBACK_DAYS = 5  # max history window length
 
     ARG_TYPE_TEST_CASES = (
         ('history__assets', (bad_type_history_assets, 'Asset, str', True)),
@@ -1397,8 +1397,8 @@ class TestAlgoScript(WithLogger,
         return data
 
     @classmethod
-    def make_daily_bar_data(cls):
-        days = len(cls.bcolz_daily_bar_days)
+    def make_equity_daily_bar_data(cls):
+        days = len(cls.equity_daily_bar_days)
         return trades_by_sid_to_dfs(
             {
                 0: factory.create_trade_history(
@@ -1416,7 +1416,7 @@ class TestAlgoScript(WithLogger,
                     cls.sim_params,
                     cls.trading_schedule)
             },
-            index=cls.bcolz_daily_bar_days,
+            index=cls.equity_daily_bar_days,
         )
 
     def test_noop(self):
@@ -1942,7 +1942,7 @@ class TestCapitalChanges(WithLogger,
         return data
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         minutes = cls.trading_schedule.execution_minutes_for_days_in_range(
             pd.Timestamp('2006-01-03', tz='UTC'),
             pd.Timestamp('2006-01-09', tz='UTC')
@@ -1961,7 +1961,7 @@ class TestCapitalChanges(WithLogger,
         )
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         days = cls.trading_schedule.execution_days_in_range(
             pd.Timestamp('2006-01-03', tz='UTC'),
             pd.Timestamp('2006-01-09', tz='UTC')
@@ -2904,7 +2904,7 @@ class TestAccountControls(WithDataPortal, WithSimParams, ZiplineTestCase):
     sidint, = ASSET_FINDER_EQUITY_SIDS = (133,)
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         return trades_by_sid_to_dfs(
             {
                 cls.sidint: factory.create_trade_history(
@@ -3051,7 +3051,7 @@ class TestFutureFlip(WithDataPortal, WithSimParams, ZiplineTestCase):
     sid, = ASSET_FINDER_EQUITY_SIDS = (1,)
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         return trades_by_sid_to_dfs(
             {
                 cls.sid: factory.create_trade_history(
@@ -3169,7 +3169,7 @@ class TestOrderCancelation(WithDataPortal,
     )
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         asset_minutes = \
             cls.trading_schedule.execution_minutes_for_days_in_range(
                 cls.sim_params.period_start,
@@ -3192,7 +3192,7 @@ class TestOrderCancelation(WithDataPortal,
         )
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         yield 1, pd.DataFrame(
             {
                 'open': np.full(3, 1),

--- a/tests/test_api_shim.py
+++ b/tests/test_api_shim.py
@@ -121,7 +121,7 @@ class TestAPIShim(WithDataPortal, WithSimParams, ZiplineTestCase):
     sids = ASSET_FINDER_EQUITY_SIDS = 1, 2, 3
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         for sid in cls.sids:
             yield sid, create_minute_df_for_asset(
                 cls.trading_schedule,
@@ -130,7 +130,7 @@ class TestAPIShim(WithDataPortal, WithSimParams, ZiplineTestCase):
             )
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         for sid in cls.sids:
             yield sid, create_daily_df_for_asset(
                 cls.trading_schedule,
@@ -149,7 +149,7 @@ class TestAPIShim(WithDataPortal, WithSimParams, ZiplineTestCase):
         ])
 
     @classmethod
-    def make_adjustment_writer_daily_bar_reader(cls):
+    def make_adjustment_writer_equity_daily_bar_reader(cls):
         return MockDailyBarReader()
 
     @classmethod

--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -103,7 +103,7 @@ class TestMinuteBarData(WithBarDataChecks,
     HILARIOUSLY_ILLIQUID_ASSET_SID = 5
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         # asset1 has trades every minute
         # asset2 has trades every 10 minutes
         # split_asset trades every minute
@@ -111,22 +111,22 @@ class TestMinuteBarData(WithBarDataChecks,
         for sid in (1, cls.SPLIT_ASSET_SID):
             yield sid, create_minute_df_for_asset(
                 cls.trading_schedule,
-                cls.bcolz_minute_bar_days[0],
-                cls.bcolz_minute_bar_days[-1],
+                cls.equity_minute_bar_days[0],
+                cls.equity_minute_bar_days[-1],
             )
 
         for sid in (2, cls.ILLIQUID_SPLIT_ASSET_SID):
             yield sid, create_minute_df_for_asset(
                 cls.trading_schedule,
-                cls.bcolz_minute_bar_days[0],
-                cls.bcolz_minute_bar_days[-1],
+                cls.equity_minute_bar_days[0],
+                cls.equity_minute_bar_days[-1],
                 10,
             )
 
         yield cls.HILARIOUSLY_ILLIQUID_ASSET_SID, create_minute_df_for_asset(
             cls.trading_schedule,
-            cls.bcolz_minute_bar_days[0],
-            cls.bcolz_minute_bar_days[-1],
+            cls.equity_minute_bar_days[0],
+            cls.equity_minute_bar_days[-1],
             50,
         )
 
@@ -167,7 +167,7 @@ class TestMinuteBarData(WithBarDataChecks,
         # grab minutes that include the day before the asset start
         minutes = self.trading_schedule.execution_minutes_for_day(
             self.trading_schedule.previous_execution_day(
-                self.bcolz_minute_bar_days[0]
+                self.equity_minute_bar_days[0]
             )
         )
 
@@ -195,7 +195,7 @@ class TestMinuteBarData(WithBarDataChecks,
 
     def test_regular_minute(self):
         minutes = self.trading_schedule.execution_minutes_for_day(
-            self.bcolz_minute_bar_days[0]
+            self.equity_minute_bar_days[0]
         )
 
         for idx, minute in enumerate(minutes):
@@ -287,7 +287,7 @@ class TestMinuteBarData(WithBarDataChecks,
 
     def test_minute_of_last_day(self):
         minutes = self.trading_schedule.execution_minutes_for_day(
-            self.bcolz_daily_bar_days[-1],
+            self.equity_daily_bar_days[-1],
         )
 
         # this is the last day the assets exist
@@ -300,12 +300,12 @@ class TestMinuteBarData(WithBarDataChecks,
     def test_minute_after_assets_stopped(self):
         minutes = self.trading_schedule.execution_minutes_for_day(
             self.trading_schedule.next_execution_day(
-                self.bcolz_minute_bar_days[-1]
+                self.equity_minute_bar_days[-1]
             )
         )
 
         last_trading_minute = self.trading_schedule.execution_minutes_for_day(
-            self.bcolz_minute_bar_days[-1]
+            self.equity_minute_bar_days[-1]
         )[-1]
 
         # this entire day is after both assets have stopped trading
@@ -347,8 +347,8 @@ class TestMinuteBarData(WithBarDataChecks,
 
         # ... but that's it's not applied when using spot value
         minutes = self.trading_schedule.execution_minutes_for_days_in_range(
-            start=self.bcolz_minute_bar_days[0],
-            end=self.bcolz_minute_bar_days[1]
+            start=self.equity_minute_bar_days[0],
+            end=self.equity_minute_bar_days[1]
         )
 
         for idx, minute in enumerate(minutes):
@@ -362,10 +362,10 @@ class TestMinuteBarData(WithBarDataChecks,
         # on cls.days[1], the first 9 minutes of ILLIQUID_SPLIT_ASSET are
         # missing. let's get them.
         day0_minutes = self.trading_schedule.execution_minutes_for_day(
-            self.bcolz_minute_bar_days[0]
+            self.equity_minute_bar_days[0]
         )
         day1_minutes = self.trading_schedule.execution_minutes_for_day(
-            self.bcolz_minute_bar_days[1]
+            self.equity_minute_bar_days[1]
         )
 
         for idx, minute in enumerate(day0_minutes[-10:-1]):
@@ -396,7 +396,7 @@ class TestMinuteBarData(WithBarDataChecks,
     def test_spot_price_at_midnight(self):
         # make sure that if we try to get a minute price at a non-market
         # minute, we use the previous market close's timestamp
-        day = self.bcolz_minute_bar_days[1]
+        day = self.equity_minute_bar_days[1]
 
         eight_fortyfive_am_eastern = \
             pd.Timestamp("{0}-{1}-{2} 8:45".format(
@@ -439,7 +439,7 @@ class TestMinuteBarData(WithBarDataChecks,
         # make sure that if we use `can_trade` at midnight, we don't pretend
         # we're in the previous day's last minute
         the_day_after = self.trading_schedule.next_execution_day(
-            self.bcolz_minute_bar_days[-1]
+            self.equity_minute_bar_days[-1]
         )
 
         bar_data = BarData(self.data_portal, lambda: the_day_after, "minute")
@@ -453,7 +453,7 @@ class TestMinuteBarData(WithBarDataChecks,
         # but make sure it works when the assets are alive
         bar_data2 = BarData(
             self.data_portal,
-            lambda: self.bcolz_minute_bar_days[1],
+            lambda: self.equity_minute_bar_days[1],
             "minute",
         )
         for asset in [self.ASSET1, self.HILARIOUSLY_ILLIQUID_ASSET]:
@@ -465,7 +465,7 @@ class TestMinuteBarData(WithBarDataChecks,
     def test_is_stale_at_midnight(self):
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_minute_bar_days[1],
+            lambda: self.equity_minute_bar_days[1],
             "minute",
         )
 
@@ -487,7 +487,7 @@ class TestMinuteBarData(WithBarDataChecks,
         )
 
         # Current day is 1/06/16
-        day = self.bcolz_daily_bar_days[1]
+        day = self.equity_daily_bar_days[1]
         eight_fortyfive_am_eastern = \
             pd.Timestamp("{0}-{1}-{2} 8:45".format(
                 day.year, day.month, day.day),
@@ -602,16 +602,16 @@ class TestDailyBarData(WithBarDataChecks,
         )
 
     @classmethod
-    def make_adjustment_writer_daily_bar_reader(cls):
+    def make_adjustment_writer_equity_daily_bar_reader(cls):
         return MockDailyBarReader()
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         for sid in cls.sids:
             yield sid, create_daily_df_for_asset(
                 cls.trading_schedule,
-                cls.bcolz_daily_bar_days[0],
-                cls.bcolz_daily_bar_days[-1],
+                cls.equity_daily_bar_days[0],
+                cls.equity_daily_bar_days[-1],
                 interval=2 - sid % 2
             )
 
@@ -642,9 +642,9 @@ class TestDailyBarData(WithBarDataChecks,
         cls.ASSETS = [cls.ASSET1, cls.ASSET2]
 
     def test_day_before_assets_trading(self):
-        # use the day before self.bcolz_daily_bar_days[0]
+        # use the day before self.equity_daily_bar_days[0]
         day = self.trading_schedule.previous_execution_day(
-            self.bcolz_daily_bar_days[0]
+            self.equity_daily_bar_days[0]
         )
 
         bar_data = BarData(self.data_portal, lambda: day, "daily")
@@ -668,10 +668,10 @@ class TestDailyBarData(WithBarDataChecks,
                     self.assertTrue(asset_value is pd.NaT)
 
     def test_semi_active_day(self):
-        # on self.bcolz_daily_bar_days[0], only asset1 has data
+        # on self.equity_daily_bar_days[0], only asset1 has data
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[0],
+            lambda: self.equity_daily_bar_days[0],
             "daily",
         )
         self.check_internal_consistency(bar_data)
@@ -691,7 +691,7 @@ class TestDailyBarData(WithBarDataChecks,
         self.assertEqual(2, bar_data.current(self.ASSET1, "close"))
         self.assertEqual(200, bar_data.current(self.ASSET1, "volume"))
         self.assertEqual(2, bar_data.current(self.ASSET1, "price"))
-        self.assertEqual(self.bcolz_daily_bar_days[0],
+        self.assertEqual(self.equity_daily_bar_days[0],
                          bar_data.current(self.ASSET1, "last_traded"))
 
         for field in OHLCP:
@@ -706,12 +706,12 @@ class TestDailyBarData(WithBarDataChecks,
     def test_fully_active_day(self):
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[1],
+            lambda: self.equity_daily_bar_days[1],
             "daily",
         )
         self.check_internal_consistency(bar_data)
 
-        # on self.bcolz_daily_bar_days[1], both assets have data
+        # on self.equity_daily_bar_days[1], both assets have data
         for asset in self.ASSETS:
             self.assertTrue(bar_data.can_trade(asset))
             self.assertFalse(bar_data.is_stale(asset))
@@ -723,14 +723,14 @@ class TestDailyBarData(WithBarDataChecks,
             self.assertEqual(300, bar_data.current(asset, "volume"))
             self.assertEqual(3, bar_data.current(asset, "price"))
             self.assertEqual(
-                self.bcolz_daily_bar_days[1],
+                self.equity_daily_bar_days[1],
                 bar_data.current(asset, "last_traded")
             )
 
     def test_last_active_day(self):
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[-1],
+            lambda: self.equity_daily_bar_days[-1],
             "daily",
         )
         self.check_internal_consistency(bar_data)
@@ -749,7 +749,7 @@ class TestDailyBarData(WithBarDataChecks,
     def test_after_assets_dead(self):
         # both assets end on self.day[-1], so let's try the next day
         next_day = self.trading_schedule.next_execution_day(
-            self.bcolz_daily_bar_days[-1]
+            self.equity_daily_bar_days[-1]
         )
 
         bar_data = BarData(self.data_portal, lambda: next_day, "daily")
@@ -767,9 +767,10 @@ class TestDailyBarData(WithBarDataChecks,
             last_traded_dt = bar_data.current(asset, "last_traded")
 
             if asset == self.ASSET1:
-                self.assertEqual(self.bcolz_daily_bar_days[-2], last_traded_dt)
+                self.assertEqual(self.equity_daily_bar_days[-2],
+                                 last_traded_dt)
             else:
-                self.assertEqual(self.bcolz_daily_bar_days[1], last_traded_dt)
+                self.assertEqual(self.equity_daily_bar_days[1], last_traded_dt)
 
     @parameterized.expand([
         ("split", 2, 3, 3, 1.5),
@@ -805,7 +806,7 @@ class TestDailyBarData(WithBarDataChecks,
         # ... but that's it's not applied when using spot value
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[0],
+            lambda: self.equity_daily_bar_days[0],
             "daily",
         )
         self.assertEqual(
@@ -814,7 +815,7 @@ class TestDailyBarData(WithBarDataChecks,
         )
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[1],
+            lambda: self.equity_daily_bar_days[1],
             "daily",
         )
         self.assertEqual(
@@ -826,7 +827,7 @@ class TestDailyBarData(WithBarDataChecks,
         # ILLIQUID_ASSET has no data on days 0 and 2, and a split on day 2
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[1],
+            lambda: self.equity_daily_bar_days[1],
             "daily",
         )
         self.assertEqual(
@@ -835,7 +836,7 @@ class TestDailyBarData(WithBarDataChecks,
 
         bar_data = BarData(
             self.data_portal,
-            lambda: self.bcolz_daily_bar_days[2],
+            lambda: self.equity_daily_bar_days[2],
             "daily",
         )
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -25,7 +25,7 @@ from zipline.sources.benchmark_source import BenchmarkSource
 from zipline.testing import (
     MockDailyBarReader,
     create_minute_bar_data,
-    tmp_bcolz_minute_bar_reader,
+    tmp_bcolz_equity_minute_bar_reader,
 )
 from zipline.testing.fixtures import (
     WithDataPortal,
@@ -65,7 +65,7 @@ class TestBenchmark(WithDataPortal, WithSimParams, WithTradingSchedule,
         )
 
     @classmethod
-    def make_adjustment_writer_daily_bar_reader(cls):
+    def make_adjustment_writer_equity_daily_bar_reader(cls):
         return MockDailyBarReader()
 
     @classmethod
@@ -147,7 +147,7 @@ class TestBenchmark(WithDataPortal, WithSimParams, WithTradingSchedule,
             self.sim_params.trading_days[5]
         )
 
-        tmp_reader = tmp_bcolz_minute_bar_reader(
+        tmp_reader = tmp_bcolz_equity_minute_bar_reader(
             self.trading_schedule,
             self.trading_schedule.all_execution_days,
             create_minute_bar_data(minutes, [2]),
@@ -157,7 +157,7 @@ class TestBenchmark(WithDataPortal, WithSimParams, WithTradingSchedule,
                 self.env.asset_finder, self.trading_schedule,
                 first_trading_day=reader.first_trading_day,
                 equity_minute_reader=reader,
-                equity_daily_reader=self.bcolz_daily_bar_reader,
+                equity_daily_reader=self.bcolz_equity_daily_bar_reader,
                 adjustment_reader=self.adjustment_reader,
             )
 

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -49,7 +49,7 @@ class BlotterTestCase(WithLogger,
     ASSET_FINDER_EQUITY_SIDS = 24, 25
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         yield 24, pd.DataFrame(
             {
                 'open': [50, 50],

--- a/tests/test_commissions.py
+++ b/tests/test_commissions.py
@@ -130,7 +130,7 @@ class CommissionAlgorithmTests(WithDataPortal, WithSimParams, ZiplineTestCase):
     )
 
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         num_days = len(cls.sim_params.trading_days)
 
         return trades_by_sid_to_dfs(

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -25,7 +25,7 @@ from zipline.testing import (
     MockDailyBarReader,
 )
 from zipline.testing.fixtures import (
-    WithBcolzMinuteBarReader,
+    WithBcolzEquityMinuteBarReader,
     WithDataPortal,
     ZiplineTestCase,
     alias,
@@ -223,7 +223,7 @@ class WithHistory(WithDataPortal):
         )
 
     @classmethod
-    def make_adjustment_writer_daily_bar_reader(cls):
+    def make_adjustment_writer_equity_daily_bar_reader(cls):
         return MockDailyBarReader()
 
     def verify_regular_dt(self, idx, dt, mode, fields=None, assets=None):
@@ -447,11 +447,11 @@ MINUTE_FIELD_INFO = {
 
 class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
 
-    BCOLZ_DAILY_BAR_SOURCE_FROM_MINUTE = True
+    EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE = True
     DATA_PORTAL_FIRST_TRADING_DAY = alias('TRADING_START_DT')
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         data = {}
         sids = {2, 5, cls.SHORT_ASSET_SID, cls.HALF_DAY_TEST_ASSET_SID}
         for sid in sids:
@@ -1314,7 +1314,7 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
 
 class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
     @classmethod
-    def make_daily_bar_data(cls):
+    def make_equity_daily_bar_data(cls):
         yield 1, cls.create_df_for_asset(
             cls.START_DATE,
             pd.Timestamp('2016-01-30', tz='UTC')
@@ -1715,7 +1715,7 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                                        window_2[self.ASSET2].values)
 
 
-class MinuteToDailyAggregationTestCase(WithBcolzMinuteBarReader,
+class MinuteToDailyAggregationTestCase(WithBcolzEquityMinuteBarReader,
                                        ZiplineTestCase):
 
     #    March 2016
@@ -1740,7 +1740,7 @@ class MinuteToDailyAggregationTestCase(WithBcolzMinuteBarReader,
                             tz='US/Eastern').tz_convert('UTC')
 
     @classmethod
-    def make_minute_bar_data(cls):
+    def make_equity_minute_bar_data(cls):
         # sid data is created so that at least one high is lower than a
         # previous high, and the inverse for low
         yield 1, pd.DataFrame(
@@ -1804,7 +1804,7 @@ class MinuteToDailyAggregationTestCase(WithBcolzMinuteBarReader,
         # needs to be tested.
         self.equity_daily_aggregator = DailyHistoryAggregator(
             self.trading_schedule.schedule.market_open,
-            self.bcolz_minute_bar_reader,
+            self.bcolz_equity_minute_bar_reader,
         )
 
     @parameterized.expand([

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -111,7 +111,8 @@ _BundlePayload = namedtuple(
 
 BundleData = namedtuple(
     'BundleData',
-    'asset_finder minute_bar_reader daily_bar_reader adjustment_reader',
+    'asset_finder equity_minute_bar_reader equity_daily_bar_reader '
+    'adjustment_reader',
 )
 
 BundleCore = namedtuple(
@@ -443,10 +444,10 @@ def _make_bundle_core():
             asset_finder=AssetFinder(
                 asset_db_path(name, timestr, environ=environ),
             ),
-            minute_bar_reader=BcolzMinuteBarReader(
+            equity_minute_bar_reader=BcolzMinuteBarReader(
                 minute_equity_path(name, timestr,  environ=environ),
             ),
-            daily_bar_reader=BcolzDailyBarReader(
+            equity_daily_bar_reader=BcolzDailyBarReader(
                 daily_equity_path(name, timestr, environ=environ),
             ),
             adjustment_reader=SQLiteAdjustmentReader(

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -486,7 +486,7 @@ class DataPortal(object):
         daily data backtests or daily history calls in a minute backetest.
         If a daily bar reader is not provided but a minute bar reader is,
         the minutes will be rolled up to serve the daily requests.
-    future_minute_reader : BcolzMinuteBarReader, optional
+    future_minute_reader : BcolzFutureMinuteBarReader, optional
         The minute bar reader for futures. This will be used to service
         minute data backtests or minute history calls. This can be used
         to serve daily calls if no daily bar reader is provided.

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -794,7 +794,7 @@ class SQLiteAdjustmentWriter(object):
     ----------
     conn_or_path : str or sqlite3.Connection
         A handle to the target sqlite database.
-    daily_bar_reader : BcolzDailyBarReader
+    equity_daily_bar_reader : BcolzDailyBarReader
         Daily bar reader to use for dividend writes.
     overwrite : bool, optional, default=False
         If True and conn_or_path is a string, remove any existing files at the
@@ -807,7 +807,7 @@ class SQLiteAdjustmentWriter(object):
 
     def __init__(self,
                  conn_or_path,
-                 daily_bar_reader,
+                 equity_daily_bar_reader,
                  calendar,
                  overwrite=False):
         if isinstance(conn_or_path, sqlite3.Connection):
@@ -824,7 +824,7 @@ class SQLiteAdjustmentWriter(object):
         else:
             raise TypeError("Unknown connection type %s" % type(conn_or_path))
 
-        self._daily_bar_reader = daily_bar_reader
+        self._equity_daily_bar_reader = equity_daily_bar_reader
         self._calendar = calendar
 
     def _write(self, tablename, expected_dtypes, frame):
@@ -930,7 +930,7 @@ class SQLiteAdjustmentWriter(object):
 
         ratios = full(len(amounts), nan)
 
-        daily_bar_reader = self._daily_bar_reader
+        equity_daily_bar_reader = self._equity_daily_bar_reader
 
         effective_dates = full(len(amounts), -1, dtype=int64)
         calendar = self._calendar
@@ -940,7 +940,7 @@ class SQLiteAdjustmentWriter(object):
             day_loc = calendar.get_loc(ex_date, method='bfill')
             prev_close_date = calendar[day_loc - 1]
             try:
-                prev_close = daily_bar_reader.spot_price(
+                prev_close = equity_daily_bar_reader.spot_price(
                     sid, prev_close_date, 'close')
                 if prev_close != 0.0:
                     ratio = 1.0 - amount / prev_close

--- a/zipline/testing/__init__.py
+++ b/zipline/testing/__init__.py
@@ -45,7 +45,7 @@ from .core import (  # noqa
     test_resource_path,
     tmp_asset_finder,
     tmp_assets_db,
-    tmp_bcolz_minute_bar_reader,
+    tmp_bcolz_equity_minute_bar_reader,
     tmp_dir,
     tmp_trading_env,
     to_series,

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -1319,7 +1319,8 @@ class tmp_dir(TempDirectory, object):
 
 
 class _TmpBarReader(with_metaclass(ABCMeta, tmp_dir)):
-    """A helper for tmp_bcolz_minute_bar_reader and tmp_bcolz_daily_bar_reader.
+    """A helper for tmp_bcolz_equity_minute_bar_reader and
+    tmp_bcolz_equity_daily_bar_reader.
 
     Parameters
     ----------
@@ -1363,7 +1364,7 @@ class _TmpBarReader(with_metaclass(ABCMeta, tmp_dir)):
             raise
 
 
-class tmp_bcolz_minute_bar_reader(_TmpBarReader):
+class tmp_bcolz_equity_minute_bar_reader(_TmpBarReader):
     """A temporary BcolzMinuteBarReader object.
 
     Parameters
@@ -1380,13 +1381,13 @@ class tmp_bcolz_minute_bar_reader(_TmpBarReader):
 
     See Also
     --------
-    tmp_bcolz_daily_bar_reader
+    tmp_bcolz_equity_daily_bar_reader
     """
     _reader_cls = BcolzMinuteBarReader
     _write = staticmethod(write_bcolz_minute_data)
 
 
-class tmp_bcolz_daily_bar_reader(_TmpBarReader):
+class tmp_bcolz_equity_daily_bar_reader(_TmpBarReader):
     """A temporary BcolzDailyBarReader object.
 
     Parameters
@@ -1403,7 +1404,7 @@ class tmp_bcolz_daily_bar_reader(_TmpBarReader):
 
     See Also
     --------
-    tmp_bcolz_daily_bar_reader
+    tmp_bcolz_equity_daily_bar_reader
     """
     _reader_cls = BcolzDailyBarReader
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -583,73 +583,44 @@ class WithInstanceTmpDir(object):
         )
 
 
-class WithBcolzDailyBarReader(WithTradingEnvironment, WithTmpDir):
+class WithEquityDailyBarData(WithTradingEnvironment):
     """
-    ZiplineTestCase mixin providing cls.bcolz_daily_bar_path,
-    cls.bcolz_daily_bar_ctable, and cls.bcolz_daily_bar_reader class level
-    fixtures.
-
-    After init_class_fixtures has been called:
-    - `cls.bcolz_daily_bar_path` is populated with
-      `cls.tmpdir.getpath(cls.BCOLZ_DAILY_BAR_PATH)`.
-    - `cls.bcolz_daily_bar_ctable` is populated with data returned from
-      `cls.make_daily_bar_data`. By default this calls
-      :func:`zipline.pipeline.loaders.synthetic.make_daily_bar_data`.
-    - `cls.bcolz_daily_bar_reader` is a daily bar reader pointing to the
-      directory that was just written to.
+    ZiplineTestCase mixin providing cls.make_equity_daily_bar_data.
 
     Attributes
     ----------
-    BCOLZ_DAILY_BAR_PATH : str
-        The path inside the tmpdir where this will be written.
-    BCOLZ_DAILY_BAR_LOOKBACK_DAYS : int
-        The number of days of data to add before the first day. This is used
-        when a test needs to use history, in which case this should be set to
-        the largest history window that will be
-        requested.
-    BCOLZ_DAILY_BAR_USE_FULL_CALENDAR : bool
-        If this flag is set the ``bcolz_daily_bar_days`` will be the full
-        set of trading days from the trading environment. This flag overrides
-        ``BCOLZ_DAILY_BAR_LOOKBACK_DAYS``.
-    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD : int
-        If this flag is set, use the value as the `read_all_threshold`
-        parameter to BcolzDailyBarReader, otherwise use the default value.
-    BCOLZ_DAILY_BAR_SOURCE_FROM_MINUTE : bool
-        If this flag is set, `make_daily_bar_data` will read data from the
-        minute bar reader defined by a `WithBcolzMinuteBarReader`.
+    EQUITY_DAILY_BAR_START_DATE : Timestamp
+        The date at to which to start creating data. This defaults to
+        ``START_DATE``.
+    EQUITY_DAILY_BAR_END_DATE = Timestamp
+        The end date up to which to create data. This defaults to ``END_DATE``.
+    EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE : bool
+        If this flag is set, `make_equity_daily_bar_data` will read data from
+        the minute bars defined by `WithMinuteBarData`.
+        The current default is `False`, but could be `True` in the future.
 
     Methods
     -------
-    make_daily_bar_data() -> iterable[(int, pd.DataFrame)]
+    make_equity_daily_bar_data() -> iterable[(int, pd.DataFrame)]
         A class method that returns an iterator of (sid, dataframe) pairs
         which will be written to the bcolz files that the class's
         ``BcolzDailyBarReader`` will read from. By default this creates
         some simple sythetic data with
         :func:`~zipline.testing.create_daily_bar_data`
-    make_bcolz_daily_bar_rootdir_path() -> string
-        A class method that returns the path for the rootdir of the daily
-        bars ctable. By default this is a subdirectory BCOLZ_DAILY_BAR_PATH in
-        the shared temp directory.
 
     See Also
     --------
-    WithBcolzMinuteBarReader
-    WithDataPortal
+    WithEquityMinuteBarData
     zipline.testing.create_daily_bar_data
     """
-    BCOLZ_DAILY_BAR_PATH = 'daily_equity_pricing.bcolz'
-    BCOLZ_DAILY_BAR_LOOKBACK_DAYS = 0
-    BCOLZ_DAILY_BAR_USE_FULL_CALENDAR = False
-    BCOLZ_DAILY_BAR_START_DATE = alias('START_DATE')
-    BCOLZ_DAILY_BAR_END_DATE = alias('END_DATE')
-    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD = None
-    BCOLZ_DAILY_BAR_SOURCE_FROM_MINUTE = False
-    # allows WithBcolzDailyBarReaderFromCSVs to call the `write_csvs` method
-    # without needing to reimplement `init_class_fixtures`
-    _write_method_name = 'write'
+    EQUITY_DAILY_BAR_LOOKBACK_DAYS = 0
+    EQUITY_DAILY_BAR_USE_FULL_CALENDAR = False
+    EQUITY_DAILY_BAR_START_DATE = alias('START_DATE')
+    EQUITY_DAILY_BAR_END_DATE = alias('END_DATE')
+    EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE = None
 
     @classmethod
-    def _make_daily_bar_from_minute(cls):
+    def _make_equity_daily_bar_from_minute(cls):
         assets = cls.asset_finder.retrieve_all(cls.asset_finder.sids)
         ohclv_how = {
             'open': 'first',
@@ -667,43 +638,102 @@ class WithBcolzDailyBarReader(WithTradingEnvironment, WithTmpDir):
         m_opens = cls.trading_schedule.schedule.market_open
         m_closes = cls.trading_schedule.schedule.market_close
 
+        minute_data = dict(cls.make_equity_minute_bar_data())
+
         for asset in assets:
             first_minute = m_opens.loc[asset.start_date]
             last_minute = m_closes.loc[asset.end_date]
-            window = cls.bcolz_minute_bar_reader.load_raw_arrays(
-                fields=['open', 'high', 'low', 'close', 'volume'],
-                start_dt=first_minute,
-                end_dt=last_minute,
-                sids=[asset.sid],
-            )
-            opens, highs, lows, closes, volumes = [c.reshape(-1)
-                                                   for c in window]
+            asset_df = minute_data[asset]
+            slicer = asset_df.index.slice_indexer(first_minute, last_minute)
+            asset_df = asset_df[slicer]
             minutes = mm[mm.slice_indexer(start=first_minute,
                                           end=last_minute)]
-            df = pd.DataFrame(
-                {
-                    'open': opens,
-                    'high': highs,
-                    'low': lows,
-                    'close': closes,
-                    'volume': volumes,
-                },
-                index=minutes
-            )
-
-            yield asset.sid, df.resample('1d', how=ohclv_how).dropna()
+            asset_df = asset_df.reindex(minutes)
+            yield asset.sid, asset_df.resample('1d', how=ohclv_how).dropna()
 
     @classmethod
-    def make_daily_bar_data(cls):
-        # Requires a minute bar reader to come before in the MRO.
+    def make_equity_daily_bar_data(cls):
+        # Requires a WithEquityMinuteBarData to come before in the MRO.
         # Resample that data so that daily and minute bar data are aligned.
-        if cls.BCOLZ_DAILY_BAR_SOURCE_FROM_MINUTE:
-            return cls._make_daily_bar_from_minute()
+        if cls.EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE:
+            return cls._make_equity_daily_bar_from_minute()
         else:
             return create_daily_bar_data(
-                cls.bcolz_daily_bar_days,
+                cls.equity_daily_bar_days,
                 cls.asset_finder.sids,
             )
+
+    @classmethod
+    def init_class_fixtures(cls):
+        super(WithEquityDailyBarData, cls).init_class_fixtures()
+        if cls.EQUITY_DAILY_BAR_USE_FULL_CALENDAR:
+            days = cls.trading_schedule.all_execution_days
+        else:
+            days = cls.trading_schedule.execution_days_in_range(
+                cls.trading_schedule.add_execution_days(
+                    -1 * cls.EQUITY_DAILY_BAR_LOOKBACK_DAYS,
+                    cls.EQUITY_DAILY_BAR_START_DATE,
+                ),
+                cls.EQUITY_DAILY_BAR_END_DATE,
+            )
+        cls.equity_daily_bar_days = days
+
+
+class WithBcolzEquityDailyBarReader(WithEquityDailyBarData, WithTmpDir):
+    """
+    ZiplineTestCase mixin providing cls.bcolz_daily_bar_path,
+    cls.bcolz_daily_bar_ctable, and cls.bcolz_equity_daily_bar_reader
+    class level fixtures.
+
+    After init_class_fixtures has been called:
+    - `cls.bcolz_daily_bar_path` is populated with
+      `cls.tmpdir.getpath(cls.BCOLZ_DAILY_BAR_PATH)`.
+    - `cls.bcolz_daily_bar_ctable` is populated with data returned from
+      `cls.make_equity_daily_bar_data`. By default this calls
+      :func:`zipline.pipeline.loaders.synthetic.make_equity_daily_bar_data`.
+    - `cls.bcolz_equity_daily_bar_reader` is a daily bar reader
+       pointing to the directory that was just written to.
+
+    Attributes
+    ----------
+    BCOLZ_DAILY_BAR_PATH : str
+        The path inside the tmpdir where this will be written.
+    EQUITY_DAILY_BAR_LOOKBACK_DAYS : int
+        The number of days of data to add before the first day. This is used
+        when a test needs to use history, in which case this should be set to
+        the largest history window that will be
+        requested.
+    EQUITY_DAILY_BAR_USE_FULL_CALENDAR : bool
+        If this flag is set the ``equity_daily_bar_days`` will be the full
+        set of trading days from the trading environment. This flag overrides
+        ``EQUITY_DAILY_BAR_LOOKBACK_DAYS``.
+    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD : int
+        If this flag is set, use the value as the `read_all_threshold`
+        parameter to BcolzDailyBarReader, otherwise use the default
+        value.
+    EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE : bool
+        If this flag is set, `make_equity_daily_bar_data` will read data from
+        the minute bar reader defined by a `WithBcolzEquityMinuteBarReader`.
+
+    Methods
+    -------
+    make_bcolz_daily_bar_rootdir_path() -> string
+        A class method that returns the path for the rootdir of the daily
+        bars ctable. By default this is a subdirectory BCOLZ_DAILY_BAR_PATH in
+        the shared temp directory.
+
+    See Also
+    --------
+    WithBcolzEquityMinuteBarReader
+    WithDataPortal
+    zipline.testing.create_daily_bar_data
+    """
+    BCOLZ_DAILY_BAR_PATH = 'daily_equity_pricing.bcolz'
+    BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD = None
+    EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE = False
+    # allows WithBcolzEquityDailyBarReaderFromCSVs to call the
+    # `write_csvs`method without needing to reimplement `init_class_fixtures`
+    _write_method_name = 'write'
 
     @classmethod
     def make_bcolz_daily_bar_rootdir_path(cls):
@@ -711,75 +741,131 @@ class WithBcolzDailyBarReader(WithTradingEnvironment, WithTmpDir):
 
     @classmethod
     def init_class_fixtures(cls):
-        super(WithBcolzDailyBarReader, cls).init_class_fixtures()
+        super(WithBcolzEquityDailyBarReader, cls).init_class_fixtures()
         cls.bcolz_daily_bar_path = p = cls.make_bcolz_daily_bar_rootdir_path()
-        if cls.BCOLZ_DAILY_BAR_USE_FULL_CALENDAR:
-            days = cls.trading_schedule.all_execution_days
-        else:
-            days = cls.trading_schedule.execution_days_in_range(
-                cls.trading_schedule.add_execution_days(
-                    -1 * cls.BCOLZ_DAILY_BAR_LOOKBACK_DAYS,
-                    cls.BCOLZ_DAILY_BAR_START_DATE,
-                ),
-                cls.BCOLZ_DAILY_BAR_END_DATE,
-            )
-        cls.bcolz_daily_bar_days = days
+        days = cls.equity_daily_bar_days
+
         cls.bcolz_daily_bar_ctable = t = getattr(
             BcolzDailyBarWriter(p, days),
             cls._write_method_name,
-        )(cls.make_daily_bar_data())
+        )(cls.make_equity_daily_bar_data())
 
         if cls.BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD is not None:
-            cls.bcolz_daily_bar_reader = BcolzDailyBarReader(
+            cls.bcolz_equity_daily_bar_reader = BcolzDailyBarReader(
                 t, cls.BCOLZ_DAILY_BAR_READ_ALL_THRESHOLD)
         else:
-            cls.bcolz_daily_bar_reader = BcolzDailyBarReader(t)
+            cls.bcolz_equity_daily_bar_reader = BcolzDailyBarReader(t)
 
 
-class WithBcolzDailyBarReaderFromCSVs(WithBcolzDailyBarReader):
+class WithBcolzEquityDailyBarReaderFromCSVs(WithBcolzEquityDailyBarReader):
     """
-    ZiplineTestCase mixin that provides cls.bcolz_daily_bar_reader from a
-    mapping of sids to CSV file paths.
+    ZiplineTestCase mixin that provides
+    cls.bcolz_equity_daily_bar_reader from a mapping of sids to CSV
+    file paths.
     """
     _write_method_name = 'write_csvs'
 
 
-class WithBcolzMinuteBarReader(WithTradingEnvironment, WithTmpDir):
+class WithEquityMinuteBarData(WithTradingEnvironment):
+    """
+    ZiplineTestCase mixin providing cls.equity_minute_bar_days.
+
+    After init_class_fixtures has been called:
+    - `cls.equyt_minute_bar_days` has the range over which data has been
+       generated.
+
+    Attributes
+    ----------
+    EQUITY_MINUTE_BAR_LOOKBACK_DAYS : int
+        The number of days of data to add before the first day.
+        This is used when a test needs to use history, in which case this
+        should be set to the largest history window that will be requested.
+    EQUITY_MINUTE_BAR_USE_FULL_CALENDAR : bool
+        If this flag is set the ``equity_daily_bar_days`` will be the full
+        set of trading days from the trading environment. This flag overrides
+        ``EQUITY_MINUTE_BAR_LOOKBACK_DAYS``.
+    EQUITY_MINUTE_BAR_START_DATE : Timestamp
+        The date at to which to start creating data. This defaults to
+        ``START_DATE``.
+    EQUITY_MINUTE_BAR_END_DATE = Timestamp
+        The end date up to which to create data. This defaults to ``END_DATE``.
+
+    Methods
+    -------
+    make_equity_minute_bar_data() -> iterable[(int, pd.DataFrame)]
+        A class method that returns a dict mapping sid to dataframe
+        which will be written to into the the format of the inherited
+        class which writes the minute bar data for use by a reader.
+        By default this creates some simple sythetic data with
+        :func:`~zipline.testing.create_minute_bar_data`
+
+    See Also
+    --------
+    WithEquityDailyBarData
+    zipline.testing.create_minute_bar_data
+    """
+
+    EQUITY_MINUTE_BAR_LOOKBACK_DAYS = 0
+    EQUITY_MINUTE_BAR_USE_FULL_CALENDAR = False
+    EQUITY_MINUTE_BAR_START_DATE = alias('START_DATE')
+    EQUITY_MINUTE_BAR_END_DATE = alias('END_DATE')
+
+    @classmethod
+    def make_equity_minute_bar_data(cls):
+        return create_minute_bar_data(
+            cls.trading_schedule.execution_minutes_for_days_in_range(
+                cls.equity_minute_bar_days[0],
+                cls.equity_minute_bar_days[-1],
+            ),
+            cls.asset_finder.sids,
+        )
+
+    @classmethod
+    def init_class_fixtures(cls):
+        super(WithEquityMinuteBarData, cls).init_class_fixtures()
+        if cls.EQUITY_MINUTE_BAR_USE_FULL_CALENDAR:
+            days = cls.trading_schedule.all_execution_days
+        else:
+            days = cls.trading_schedule.execution_days_in_range(
+                cls.trading_schedule.add_execution_days(
+                    -1 * cls.EQUITY_MINUTE_BAR_LOOKBACK_DAYS,
+                    cls.EQUITY_MINUTE_BAR_START_DATE,
+                ),
+                cls.EQUITY_MINUTE_BAR_END_DATE,
+            )
+        cls.equity_minute_bar_days = days
+
+
+class WithBcolzEquityMinuteBarReader(WithEquityMinuteBarData, WithTmpDir):
     """
     ZiplineTestCase mixin providing cls.bcolz_minute_bar_path,
-    cls.bcolz_minute_bar_ctable, and cls.bcolz_minute_bar_reader class level
-    fixtures.
+    cls.bcolz_minute_bar_ctable, and cls.bcolz_equity_minute_bar_reader
+    class level fixtures.
 
     After init_class_fixtures has been called:
     - `cls.bcolz_minute_bar_path` is populated with
       `cls.tmpdir.getpath(cls.BCOLZ_MINUTE_BAR_PATH)`.
     - `cls.bcolz_minute_bar_ctable` is populated with data returned from
-      `cls.make_minute_bar_data`. By default this calls
-      :func:`zipline.pipeline.loaders.synthetic.make_minute_bar_data`.
-    - `cls.bcolz_minute_bar_reader` is a minute bar reader pointing to the
-      directory that was just written to.
+      `cls.make_equity_minute_bar_data`. By default this calls
+      :func:`zipline.pipeline.loaders.synthetic.make_equity_minute_bar_data`.
+    - `cls.bcolz_equity_minute_bar_reader` is a minute bar reader
+       pointing to the directory that was just written to.
 
     Attributes
     ----------
     BCOLZ_MINUTE_BAR_PATH : str
         The path inside the tmpdir where this will be written.
-    BCOLZ_MINUTE_BAR_LOOKBACK_DAYS : int
+    EQUITY_MINUTE_BAR_LOOKBACK_DAYS : int
         The number of days of data to add before the first day.
         This is used when a test needs to use history, in which case this
         should be set to the largest history window that will be requested.
     BCOLZ_MINUTE_BAR_USE_FULL_CALENDAR : bool
-        If this flag is set the ``bcolz_daily_bar_days`` will be the full
+        If this flag is set the ``equity_daily_bar_days`` will be the full
         set of trading days from the trading environment. This flag overrides
-        ``BCOLZ_MINUTE_BAR_LOOKBACK_DAYS``.
+        ``EQUITY_MINUTE_BAR_LOOKBACK_DAYS``.
 
     Methods
     -------
-    make_minute_bar_data() -> iterable[(int, pd.DataFrame)]
-        A class method that returns a dict mapping sid to dataframe
-        which will be written to the bcolz files that the class's
-        ``BcolzMinuteBarReader`` will read from. By default this creates
-        some simple sythetic data with
-        :func:`~zipline.testing.create_minute_bar_data`
     make_bcolz_minute_bar_rootdir_path() -> string
         A class method that returns the path for the directory that contains
         the minute bar ctables. By default this is a subdirectory
@@ -787,25 +873,11 @@ class WithBcolzMinuteBarReader(WithTradingEnvironment, WithTmpDir):
 
     See Also
     --------
-    WithBcolzDailyBarReader
+    WithBcolzEquityDailyBarReader
     WithDataPortal
     zipline.testing.create_minute_bar_data
     """
     BCOLZ_MINUTE_BAR_PATH = 'minute_equity_pricing.bcolz'
-    BCOLZ_MINUTE_BAR_LOOKBACK_DAYS = 0
-    BCOLZ_MINUTE_BAR_USE_FULL_CALENDAR = False
-    BCOLZ_MINUTE_BAR_START_DATE = alias('START_DATE')
-    BCOLZ_MINUTE_BAR_END_DATE = alias('END_DATE')
-
-    @classmethod
-    def make_minute_bar_data(cls):
-        return create_minute_bar_data(
-            cls.trading_schedule.execution_minutes_for_days_in_range(
-                cls.bcolz_minute_bar_days[0],
-                cls.bcolz_minute_bar_days[-1],
-            ),
-            cls.asset_finder.sids,
-        )
 
     @classmethod
     def make_bcolz_minute_bar_rootdir_path(cls):
@@ -813,20 +885,10 @@ class WithBcolzMinuteBarReader(WithTradingEnvironment, WithTmpDir):
 
     @classmethod
     def init_class_fixtures(cls):
-        super(WithBcolzMinuteBarReader, cls).init_class_fixtures()
+        super(WithBcolzEquityMinuteBarReader, cls).init_class_fixtures()
         cls.bcolz_minute_bar_path = p = \
             cls.make_bcolz_minute_bar_rootdir_path()
-        if cls.BCOLZ_MINUTE_BAR_USE_FULL_CALENDAR:
-            days = cls.trading_schedule.all_execution_days
-        else:
-            days = cls.trading_schedule.execution_days_in_range(
-                cls.trading_schedule.add_execution_days(
-                    -1 * cls.BCOLZ_MINUTE_BAR_LOOKBACK_DAYS,
-                    cls.BCOLZ_MINUTE_BAR_START_DATE,
-                ),
-                cls.BCOLZ_MINUTE_BAR_END_DATE,
-            )
-        cls.bcolz_minute_bar_days = days
+        days = cls.equity_minute_bar_days
         writer = BcolzMinuteBarWriter(
             days[0],
             p,
@@ -834,12 +896,13 @@ class WithBcolzMinuteBarReader(WithTradingEnvironment, WithTmpDir):
             cls.trading_schedule.schedule.market_close.loc[days],
             US_EQUITIES_MINUTES_PER_DAY
         )
-        writer.write(cls.make_minute_bar_data())
+        writer.write(cls.make_equity_minute_bar_data())
 
-        cls.bcolz_minute_bar_reader = BcolzMinuteBarReader(p)
+        cls.bcolz_equity_minute_bar_reader = \
+            BcolzMinuteBarReader(p)
 
 
-class WithAdjustmentReader(WithBcolzDailyBarReader):
+class WithAdjustmentReader(WithBcolzEquityDailyBarReader):
     """
     ZiplineTestCase mixin providing cls.adjustment_reader as a class level
     fixture.
@@ -849,8 +912,8 @@ class WithAdjustmentReader(WithBcolzDailyBarReader):
     written can be passed by overriding `make_{field}_data` where field may
     be `splits`, `mergers` `dividends`, or `stock_dividends`.
     The daily bar reader used for this adjustment reader may be customized
-    by overriding `make_adjustment_writer_daily_bar_reader`. This is useful
-    to providing a `MockDailyBarReader`.
+    by overriding `make_adjustment_writer_equity_daily_bar_reader`.
+    This is useful to providing a `MockDailyBarReader`.
 
     Methods
     -------
@@ -870,12 +933,13 @@ class WithAdjustmentReader(WithBcolzDailyBarReader):
         A class method that returns the sqlite3 connection string for the
         database in to which the adjustments will be written. By default this
         is an in-memory database.
-    make_adjustment_writer_daily_bar_reader() -> pd.DataFrame
+    make_adjustment_writer_equity_daily_bar_reader() -> pd.DataFrame
         A class method that returns the daily bar reader to use for the class's
         adjustment writer. By default this is the class's actual
-        ``bcolz_daily_bar_reader`` as inherited from
-        ``WithBcolzDailyBarReader``. This should probably not be overridden;
-        however, some tests used a ``MockDailyBarReader`` for this.
+        ``bcolz_equity_daily_bar_reader`` as inherited from
+        ``WithBcolzEquityDailyBarReader``. This should probably not be
+          overridden; however, some tests used a ``MockDailyBarReader``
+         for this.
     make_adjustment_writer(conn: sqlite3.Connection) -> AdjustmentWriter
         A class method that constructs the adjustment which will be used
         to write the data into the connection to be used by the class's
@@ -900,13 +964,13 @@ class WithAdjustmentReader(WithBcolzDailyBarReader):
     def make_adjustment_writer(cls, conn):
         return SQLiteAdjustmentWriter(
             conn,
-            cls.make_adjustment_writer_daily_bar_reader(),
-            cls.bcolz_daily_bar_days,
+            cls.make_adjustment_writer_equity_daily_bar_reader(),
+            cls.equity_daily_bar_days,
         )
 
     @classmethod
-    def make_adjustment_writer_daily_bar_reader(cls):
-        return cls.bcolz_daily_bar_reader
+    def make_adjustment_writer_equity_daily_bar_reader(cls):
+        return cls.bcolz_equity_daily_bar_reader
 
     @classmethod
     def make_adjustment_db_conn_str(cls):
@@ -999,15 +1063,15 @@ class WithSeededRandomPipelineEngine(WithNYSETradingDays, WithAssetFinder):
 
 class WithDataPortal(WithAdjustmentReader,
                      # Ordered so that bcolz minute reader is used first.
-                     WithBcolzMinuteBarReader):
+                     WithBcolzEquityMinuteBarReader):
     """
     ZiplineTestCase mixin providing self.data_portal as an instance level
     fixture.
 
     After init_instance_fixtures has been called, `self.data_portal` will be
     populated with a new data portal created by passing in the class's
-    trading env, `cls.bcolz_minute_bar_reader`, `cls.bcolz_daily_bar_reader`,
-    and `cls.adjustment_reader`.
+    trading env, `cls.bcolz_equity_minute_bar_reader`,
+    `cls.bcolz_equity_daily_bar_reader`, and `cls.adjustment_reader`.
 
     Attributes
     ----------
@@ -1035,22 +1099,24 @@ class WithDataPortal(WithAdjustmentReader,
         if self.DATA_PORTAL_FIRST_TRADING_DAY is None:
             if self.DATA_PORTAL_USE_MINUTE_DATA:
                 self.DATA_PORTAL_FIRST_TRADING_DAY = (
-                    self.bcolz_minute_bar_reader.first_trading_day)
+                    self.bcolz_equity_minute_bar_reader.
+                    first_trading_day)
             elif self.DATA_PORTAL_USE_DAILY_DATA:
                 self.DATA_PORTAL_FIRST_TRADING_DAY = (
-                    self.bcolz_daily_bar_reader.first_trading_day)
+                    self.bcolz_equity_daily_bar_reader.
+                    first_trading_day)
 
         return DataPortal(
             self.env.asset_finder,
             self.trading_schedule,
             first_trading_day=self.DATA_PORTAL_FIRST_TRADING_DAY,
             equity_daily_reader=(
-                self.bcolz_daily_bar_reader
+                self.bcolz_equity_daily_bar_reader
                 if self.DATA_PORTAL_USE_DAILY_DATA else
                 None
             ),
             equity_minute_reader=(
-                self.bcolz_minute_bar_reader
+                self.bcolz_equity_minute_bar_reader
                 if self.DATA_PORTAL_USE_MINUTE_DATA else
                 None
             ),

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -129,16 +129,18 @@ def _run(handle_data,
                 str(bundle_data.asset_finder.engine.url),
             )
         env = TradingEnvironment(asset_db_path=connstr)
+        first_trading_day =\
+            bundle_data.equity_minute_bar_reader.first_trading_day
         data = DataPortal(
             env.asset_finder, default_nyse_schedule,
-            first_trading_day=bundle_data.minute_bar_reader.first_trading_day,
-            equity_minute_reader=bundle_data.minute_bar_reader,
-            equity_daily_reader=bundle_data.daily_bar_reader,
+            first_trading_day=first_trading_day,
+            equity_minute_reader=bundle_data.equity_minute_bar_reader,
+            equity_daily_reader=bundle_data.equity_daily_bar_reader,
             adjustment_reader=bundle_data.adjustment_reader,
         )
 
         pipeline_loader = USEquityPricingLoader(
-            bundle_data.daily_bar_reader,
+            bundle_data.equity_daily_bar_reader,
             bundle_data.adjustment_reader,
         )
 


### PR DESCRIPTION
In preparation of adding futures, add equity to the names of both the
classes and methods for writing bcolz data. Futures data will use a
different minutes per day with a separate reader. This change will allow
both equity and futures fixtures to be side by side.

Also, break out the method which generates the dataframes and trading
days member into fixtures (`EquityMinuteBarData` and
`EquityDailyBarData`) on which the `*BarReader` fixture depends.  This
fixture is separated out to enable reader/writers in different formats
to use the same data setup. (There is internal code which needs to write
minute and daily bar data in a database format.)