### PR TITLE
Fix daily bar writer

### DIFF
--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -24,7 +24,6 @@ from numpy.testing import (
 )
 from pandas import (
     DataFrame,
-    DatetimeIndex,
     Timestamp,
 )
 from pandas.util.testing import assert_index_equal
@@ -46,6 +45,7 @@ from zipline.testing.fixtures import (
     WithBcolzEquityDailyBarReader,
     ZiplineTestCase,
 )
+from zipline.utils.calendars import get_calendar
 
 TEST_CALENDAR_START = Timestamp('2015-06-01', tz='UTC')
 TEST_CALENDAR_STOP = Timestamp('2015-06-30', tz='UTC')
@@ -180,9 +180,14 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, ZiplineTestCase):
             result.attrs['calendar_offset'],
             expected_calendar_offset,
         )
+        cal = get_calendar(result.attrs['calendar_name'])
+        first_session = Timestamp(result.attrs['start_session_ns'], tz='UTC')
+        end_session = Timestamp(result.attrs['end_session_ns'], tz='UTC')
+        sessions = cal.sessions_in_range(first_session, end_session)
+
         assert_index_equal(
             self.sessions,
-            DatetimeIndex(result.attrs['calendar'], tz='UTC'),
+            sessions
         )
 
     def test_read_first_trading_day(self):

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -3424,9 +3424,10 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendar, ZiplineTestCase):
                 frequency=frequency
             )
             path = self.tmpdir.getpath("testdaily.bcolz")
-            BcolzDailyBarWriter(path, dates, self.trading_calendar).write(
-                iteritems(trade_data_by_sid),
+            writer = BcolzDailyBarWriter(
+                path, self.trading_calendar, dates[0], dates[-1]
             )
+            writer.write(iteritems(trade_data_by_sid))
             reader = BcolzDailyBarReader(path)
             data_portal = DataPortal(
                 env.asset_finder, self.trading_calendar,

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -255,7 +255,8 @@ class FinanceTestCase(WithLogger,
                 }
 
                 path = os.path.join(tempdir.path, "testdata.bcolz")
-                BcolzDailyBarWriter(path, days, self.trading_calendar).write(
+                BcolzDailyBarWriter(path, self.trading_calendar, days[0],
+                                    days[-1]).write(
                     assets.items()
                 )
 

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -333,7 +333,9 @@ def _make_bundle_core():
                 )).path
                 daily_bar_writer = BcolzDailyBarWriter(
                     daily_bars_path,
-                    bundle.calendar,
+                    nyse_cal,
+                    bundle.calendar[0],
+                    bundle.calendar[-1]
                 )
                 # Do an empty write to ensure that the daily ctables exist
                 # when we create the SQLiteAdjustmentWriter below. The

--- a/zipline/data/us_equity_loader.py
+++ b/zipline/data/us_equity_loader.py
@@ -387,7 +387,7 @@ class USEquityDailyHistoryLoader(USEquityHistoryLoader):
 
     @property
     def _calendar(self):
-        return self._reader._calendar
+        return self._reader._sessions
 
     def _array(self, dts, assets, field):
         return self._reader.load_raw_arrays(

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -40,7 +40,10 @@ class USEquityPricingLoader(PipelineLoader):
         self.raw_price_loader = raw_price_loader
         self.adjustments_loader = adjustments_loader
 
-        self._calendar = get_calendar("NYSE").all_sessions
+        cal = self.raw_price_loader.trading_calendar or \
+            get_calendar("NYSE")
+
+        self._all_sessions = cal.all_sessions
 
     @classmethod
     def from_files(cls, pricing_path, adjustments_path):
@@ -67,7 +70,7 @@ class USEquityPricingLoader(PipelineLoader):
         # known on day N is the data from day (N - 1), so we shift all query
         # dates back by a day.
         start_date, end_date = _shift_dates(
-            self._calendar, dates[0], dates[-1], shift=1,
+            self._all_sessions, dates[0], dates[-1], shift=1,
         )
         colnames = [c.name for c in columns]
         raw_arrays = self.raw_price_loader.load_raw_arrays(

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -462,7 +462,9 @@ def create_daily_bar_data(sessions, sids):
 
 def write_daily_data(tempdir, sim_params, sids, trading_calendar):
     path = os.path.join(tempdir.path, "testdaily.bcolz")
-    BcolzDailyBarWriter(path, sim_params.sessions, trading_calendar).write(
+    BcolzDailyBarWriter(path, trading_calendar,
+                        sim_params.start_session,
+                        sim_params.end_session).write(
         create_daily_bar_data(sim_params.sessions, sids),
     )
 
@@ -612,7 +614,12 @@ def create_data_portal_from_trade_history(asset_finder, trading_calendar,
                                           tempdir, sim_params, trades_by_sid):
     if sim_params.data_frequency == "daily":
         path = os.path.join(tempdir.path, "testdaily.bcolz")
-        BcolzDailyBarWriter(path, sim_params.sessions, trading_calendar).write(
+        writer = BcolzDailyBarWriter(
+            path, trading_calendar,
+            sim_params.start_session,
+            sim_params.end_session
+        )
+        writer.write(
             trades_by_sid_to_dfs(trades_by_sid, sim_params.sessions),
         )
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -746,7 +746,7 @@ class WithBcolzEquityDailyBarReader(WithEquityDailyBarData, WithTmpDir):
         days = cls.equity_daily_bar_days
 
         cls.bcolz_daily_bar_ctable = t = getattr(
-            BcolzDailyBarWriter(p, days, cls.trading_calendar),
+            BcolzDailyBarWriter(p, cls.trading_calendar, days[0], days[-1]),
             cls._write_method_name,
         )(cls.make_equity_daily_bar_data())
 


### PR DESCRIPTION
Make daily bar readers take advantage of the `TradingCalendar`.

Make `USEquityPricingLoader` use the same calendar.

Both the reader and writer were updated, but the reader maintains backwards compatibility.  The test examples have *not* had their data updated, to ensure that we can read old data.