### PR TITLE
BUG: Further corrections for days_at_time

### DIFF
--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -21,7 +21,6 @@ from pandas import (
     DataFrame,
     date_range,
     DatetimeIndex,
-    Timedelta,
     DateOffset
 )
 from pandas.tseries.offsets import CustomBusinessDay

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -21,7 +21,8 @@ from pandas import (
     DataFrame,
     date_range,
     DatetimeIndex,
-    Timedelta
+    Timedelta,
+    DateOffset
 )
 from pandas.tseries.offsets import CustomBusinessDay
 
@@ -677,11 +678,16 @@ def days_at_time(days, t, tz, day_offset=0):
     day_offset : int
         The number of days we want to offset @days by
     """
-    days = DatetimeIndex(days).tz_localize(None).tz_localize(tz)
-    days_offset = days + Timedelta(days=day_offset)
+
+    # Offset days without tz to avoid timezone issues.
+    days = DatetimeIndex(days).tz_localize(None)
+    days_offset = days + DateOffset(days=day_offset)
+
+    # Shift all days to the target time in the local timezone, then
+    # convert to UTC.
     return days_offset.shift(
-        1, freq=Timedelta(hours=t.hour, minutes=t.minute, seconds=t.second)
-    ).tz_convert('UTC')
+        1, freq=DateOffset(hour=t.hour, minute=t.minute, second=t.second)
+    ).tz_localize(tz).tz_convert('UTC')
 
 
 def holidays_at_time(calendar, start, end, time, tz):


### PR DESCRIPTION
- Revert to using DateOffset, as Timedelta doesn't handle offsetting by one day over a tz change properly:

    ```
    In [12]: pd.Timestamp('2004-04-05', tz='America/Chicago') + pd.Timedelta(days=-1)
    Out[12]: Timestamp('2004-04-03 23:00:00-0600', tz='America/Chicago')

    In [13]: pd.Timestamp('2004-04-05', tz='America/Chicago') + pd.DateOffset(days=-1)
    Out[13]: Timestamp('2004-04-04 00:00:00-0600', tz='America/Chicago')
```

  By creating a DateOffset using the `days` kwarg, the issue previously fixed in bcc867b is addressed.

- To preempt any other pandas issues around day offsets, changes to performing these with no timezone, then localizing to the local timezone when shifting the time.
- Adds unit test for `days_at_time`