### PR TITLE
ENH: Change daily mode to use last minute of session instead of session label

### DIFF
--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -26,6 +26,7 @@ from pandas import (
     Series,
     Timestamp,
 )
+from pandas.tseries.tools import normalize_date
 from six import iteritems, itervalues
 
 from zipline.algorithm import TradingAlgorithm
@@ -512,7 +513,7 @@ class PipelineAlgorithmTestCase(WithBcolzEquityDailyBarReaderFromCSVs,
             attach_pipeline(pipeline, 'test')
 
         def handle_data(context, data):
-            today = get_datetime()
+            today = normalize_date(get_datetime())
             results = pipeline_output('test')
             expect_over_300 = {
                 AAPL: today < self.AAPL_split_date,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -3723,12 +3723,18 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendar, ZiplineTestCase):
         transactions = output['transactions']
         initial_fills = transactions.iloc[1]
         self.assertEqual(len(initial_fills), len(assets))
+
+        last_minute_of_session = \
+            self.trading_calendar.open_and_close_for_session(
+                self.test_days[1]
+            )[1]
+
         for sid, txn in zip(sids, initial_fills):
             self.assertDictContainsSubset(
                 {
                     'amount': order_size,
                     'commission': None,
-                    'dt': self.test_days[1],
+                    'dt': last_minute_of_session,
                     'price': initial_fill_prices[sid],
                     'sid': sid,
                 },
@@ -3795,15 +3801,17 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendar, ZiplineTestCase):
                 context.portfolio.cash == context.portfolio.starting_cash
             )
 
-            now = context.get_datetime()
+            today_session = self.trading_calendar.minute_to_session_label(
+                context.get_datetime()
+            )
 
-            if now == first_asset_end_date:
+            if today_session == first_asset_end_date:
                 # Equity 0 will no longer exist tomorrow, so this order will
                 # never be filled.
                 assert len(context.get_open_orders()) == 0
                 context.order(context.sid(0), 10)
                 assert len(context.get_open_orders()) == 1
-            elif now == first_asset_auto_close_date:
+            elif today_session == first_asset_auto_close_date:
                 assert len(context.get_open_orders()) == 0
 
         algo = TradingAlgorithm(
@@ -3821,12 +3829,18 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendar, ZiplineTestCase):
 
         original_open_orders = orders_for_date(first_asset_end_date)
         assert len(original_open_orders) == 1
+
+        last_close_for_asset = \
+            algo.trading_calendar.open_and_close_for_session(
+                first_asset_end_date
+            )[1]
+
         self.assertDictContainsSubset(
             {
                 'amount': 10,
                 'commission': 0,
-                'created': first_asset_end_date,
-                'dt': first_asset_end_date,
+                'created': last_close_for_asset,
+                'dt': last_close_for_asset,
                 'sid': assets[0],
                 'status': ORDER_STATUS.OPEN,
                 'filled': 0,
@@ -3840,7 +3854,7 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendar, ZiplineTestCase):
             {
                 'amount': 10,
                 'commission': 0,
-                'created': first_asset_end_date,
+                'created': last_close_for_asset,
                 'dt': first_asset_auto_close_date,
                 'sid': assets[0],
                 'status': ORDER_STATUS.CANCELLED,

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -417,6 +417,7 @@ def handle_data(context, data):
 
             algocode = """
 from pandas import Timestamp
+from pandas.tseries.tools import normalize_date
 from zipline.api import fetch_csv, record, sid, get_datetime
 
 def initialize(context):
@@ -432,7 +433,7 @@ def initialize(context):
     context.bar_count = 0
 
 def handle_data(context, data):
-    expected = context.expected_sids[get_datetime()]
+    expected = context.expected_sids[normalize_date(get_datetime())]
     actual = data.fetcher_assets
     for stk in expected:
         if stk not in actual:

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -773,19 +773,20 @@ class DataPortal(object):
         if field not in BASE_FIELDS:
             raise KeyError("Invalid column: " + str(field))
 
+        session_label = self.trading_calendar.minute_to_session_label(dt)
+
         if dt < asset.start_date or \
-                (data_frequency == "daily" and dt > asset.end_date) or \
+                (data_frequency == "daily" and
+                    session_label > asset.end_date) or \
                 (data_frequency == "minute" and
-                 normalize_date(dt) > asset.end_date):
+                 session_label > asset.end_date):
             if field == "volume":
                 return 0
             elif field != "last_traded":
                 return np.NaN
 
         if data_frequency == "daily":
-            day_to_use = dt
-            day_to_use = normalize_date(day_to_use)
-            return self._get_daily_data(asset, field, day_to_use)
+            return self._get_daily_data(asset, field, session_label)
         else:
             if isinstance(asset, Future):
                 if field == "price":

--- a/zipline/gens/sim_engine.pyx
+++ b/zipline/gens/sim_engine.pyx
@@ -84,17 +84,3 @@ cdef class MinuteSimulationClock:
                     yield minute, MINUTE_END
 
             yield minutes[-1], DAY_END
-
-
-
-cdef class DailySimulationClock:
-    cdef object trading_days
-
-    def __init__(self, trading_days):
-        self.trading_days = trading_days
-
-    def __iter__(self):
-        for i, day in enumerate(self.trading_days):
-            yield day, DAY_START
-            yield day, BAR
-            yield day, DAY_END


### PR DESCRIPTION
Before this change, when a simulation runs with `data_frequency="daily"`, the algorithm's clock would emit session labels (midnight utc).  In other words, if the algorithm ever used `TradingAlgorithm.get_datetime()`, it would be midnight UTC.

This is misleading because at midnight UTC, the algorithm can get the daily bar for an asset that represents (on a NYSE calendar) data that hasn't technically happened yet (since the trading hours haven't started for that day yet).

As we're moving towards supporting various trading calendars, this problem has become trickier.  For example, `data.can_trade` is going to be extended to check if the asset's exchange is open at the moment of the order.  This is a lot easier to answer and reason about if the order's `dt` is a trading minute, not a trading session.

With this PR, daily backtests now run at the last minute of each trading session (for NYSE calendar, that means 4PM Eastern on most trading days).  All orders are timestamped at 4pm (and start getting filled the next day, just like before).

Users don't need to change anything about the data they provide (or via the Quandl, etc bundles).  Daily data is still timestamped midnight internally, and now we convert to the session label before fetching the data when we're in daily mode.

@richafrank this is the design we discussed.