### PR TITLE
Groupby rank top

### DIFF
--- a/docs/source/whatsnew/1.0.2.txt
+++ b/docs/source/whatsnew/1.0.2.txt
@@ -21,6 +21,11 @@ Enhancements
 - Filters have been made window_safe by default. Now they can be passed in as
   arguments to other Filters, Factors and Classifiers (:issue:`1338`).
 
+- Added an optional ``groupby`` parameter to
+  :meth:`~zipline.pipeline.factors.Factor.rank`,
+  :meth:`~zipline.pipeline.factors.Factor.top`, and
+  :meth:`~zipline.pipeline.factors.Factor.bottom`. (:issue:`1349`).
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/tests/pipeline/test_factor.py
+++ b/tests/pipeline/test_factor.py
@@ -336,6 +336,207 @@ class FactorTestCase(BasePipelineTestCase):
         for method in results:
             check_arrays(expected[method], results[method])
 
+    def test_grouped_rank_ascending(self, factor_dtype=float64_dtype):
+
+        f = F(dtype=factor_dtype)
+        c = C()
+        str_c = C(dtype=categorical_dtype, missing_value=None)
+
+        # Generated with:
+        # data = arange(25).reshape(5, 5).transpose() % 4
+        data = array([[0, 1, 2, 3, 0],
+                      [1, 2, 3, 0, 1],
+                      [2, 3, 0, 1, 2],
+                      [3, 0, 1, 2, 3],
+                      [0, 1, 2, 3, 0]], dtype=factor_dtype)
+
+        # Generated with:
+        # classifier_data = arange(25).reshape(5, 5).transpose() % 2
+        classifier_data = array([[0, 1, 0, 1, 0],
+                                 [1, 0, 1, 0, 1],
+                                 [0, 1, 0, 1, 0],
+                                 [1, 0, 1, 0, 1],
+                                 [0, 1, 0, 1, 0]], dtype=int64_dtype)
+        string_classifier_data = LabelArray(
+            classifier_data.astype(str).astype(object),
+            missing_value=None,
+        )
+
+        expected_grouped_ranks = {
+            'ordinal': array(
+                [[1., 1., 3., 2., 2.],
+                 [1., 2., 3., 1., 2.],
+                 [2., 2., 1., 1., 3.],
+                 [2., 1., 1., 2., 3.],
+                 [1., 1., 3., 2., 2.]]
+            ),
+            'average': array(
+                [[1.5, 1., 3., 2., 1.5],
+                 [1.5, 2., 3., 1., 1.5],
+                 [2.5, 2., 1., 1., 2.5],
+                 [2.5, 1., 1., 2., 2.5],
+                 [1.5, 1., 3., 2., 1.5]]
+            ),
+            'min': array(
+                [[1., 1., 3., 2., 1.],
+                 [1., 2., 3., 1., 1.],
+                 [2., 2., 1., 1., 2.],
+                 [2., 1., 1., 2., 2.],
+                 [1., 1., 3., 2., 1.]]
+            ),
+            'max': array(
+                [[2., 1., 3., 2., 2.],
+                 [2., 2., 3., 1., 2.],
+                 [3., 2., 1., 1., 3.],
+                 [3., 1., 1., 2., 3.],
+                 [2., 1., 3., 2., 2.]]
+            ),
+            'dense': array(
+                [[1., 1., 2., 2., 1.],
+                 [1., 2., 2., 1., 1.],
+                 [2., 2., 1., 1., 2.],
+                 [2., 1., 1., 2., 2.],
+                 [1., 1., 2., 2., 1.]]
+            ),
+        }
+
+        def check(terms):
+            graph = TermGraph(terms)
+            results = self.run_graph(
+                graph,
+                initial_workspace={
+                    f: data,
+                    c: classifier_data,
+                    str_c: string_classifier_data,
+                },
+                mask=self.build_mask(ones((5, 5))),
+            )
+
+            for method in terms:
+                check_arrays(results[method], expected_grouped_ranks[method])
+
+        # Not specifying the value of ascending param should default to True
+        check({
+            meth: f.rank(method=meth, groupby=c)
+            for meth in expected_grouped_ranks
+        })
+        check({
+            meth: f.rank(method=meth, groupby=str_c)
+            for meth in expected_grouped_ranks
+        })
+        check({
+            meth: f.rank(method=meth, groupby=c, ascending=True)
+            for meth in expected_grouped_ranks
+        })
+        check({
+            meth: f.rank(method=meth, groupby=str_c, ascending=True)
+            for meth in expected_grouped_ranks
+        })
+
+        # Not passing a method should default to ordinal
+        check({'ordinal': f.rank(groupby=c)})
+        check({'ordinal': f.rank(groupby=str_c)})
+        check({'ordinal': f.rank(groupby=c, ascending=True)})
+        check({'ordinal': f.rank(groupby=str_c, ascending=True)})
+
+    def test_grouped_rank_descending(self, factor_dtype=float64_dtype):
+
+        f = F(dtype=factor_dtype)
+        c = C()
+        str_c = C(dtype=categorical_dtype, missing_value=None)
+
+        # Generated with:
+        # data = arange(25).reshape(5, 5).transpose() % 4
+        data = array([[0, 1, 2, 3, 0],
+                      [1, 2, 3, 0, 1],
+                      [2, 3, 0, 1, 2],
+                      [3, 0, 1, 2, 3],
+                      [0, 1, 2, 3, 0]], dtype=factor_dtype)
+
+        # Generated with:
+        # classifier_data = arange(25).reshape(5, 5).transpose() % 2
+        classifier_data = array([[0, 1, 0, 1, 0],
+                                 [1, 0, 1, 0, 1],
+                                 [0, 1, 0, 1, 0],
+                                 [1, 0, 1, 0, 1],
+                                 [0, 1, 0, 1, 0]], dtype=int64_dtype)
+
+        string_classifier_data = LabelArray(
+            classifier_data.astype(str).astype(object),
+            missing_value=None,
+        )
+
+        expected_grouped_ranks = {
+            'ordinal': array(
+                [[2., 2., 1., 1., 3.],
+                 [2., 1., 1., 2., 3.],
+                 [1., 1., 3., 2., 2.],
+                 [1., 2., 3., 1., 2.],
+                 [2., 2., 1., 1., 3.]]
+            ),
+            'average': array(
+                [[2.5, 2., 1., 1., 2.5],
+                 [2.5, 1., 1., 2., 2.5],
+                 [1.5, 1., 3., 2., 1.5],
+                 [1.5, 2., 3., 1., 1.5],
+                 [2.5, 2., 1., 1., 2.5]]
+            ),
+            'min': array(
+                [[2., 2., 1., 1., 2.],
+                 [2., 1., 1., 2., 2.],
+                 [1., 1., 3., 2., 1.],
+                 [1., 2., 3., 1., 1.],
+                 [2., 2., 1., 1., 2.]]
+            ),
+            'max': array(
+                [[3., 2., 1., 1., 3.],
+                 [3., 1., 1., 2., 3.],
+                 [2., 1., 3., 2., 2.],
+                 [2., 2., 3., 1., 2.],
+                 [3., 2., 1., 1., 3.]]
+            ),
+            'dense': array(
+                [[2., 2., 1., 1., 2.],
+                 [2., 1., 1., 2., 2.],
+                 [1., 1., 2., 2., 1.],
+                 [1., 2., 2., 1., 1.],
+                 [2., 2., 1., 1., 2.]]
+            ),
+        }
+
+        def check(terms):
+            graph = TermGraph(terms)
+            results = self.run_graph(
+                graph,
+                initial_workspace={
+                    f: data,
+                    c: classifier_data,
+                    str_c: string_classifier_data,
+                },
+                mask=self.build_mask(ones((5, 5))),
+            )
+
+            for method in terms:
+                check_arrays(results[method], expected_grouped_ranks[method])
+
+        check({
+            meth: f.rank(method=meth, groupby=c, ascending=False)
+            for meth in expected_grouped_ranks
+        })
+        check({
+            meth: f.rank(method=meth, groupby=str_c, ascending=False)
+            for meth in expected_grouped_ranks
+        })
+
+        # Not passing a method should default to ordinal
+        check({'ordinal': f.rank(groupby=c, ascending=False)})
+        check({'ordinal': f.rank(groupby=str_c, ascending=False)})
+
+        # TODO finish this
+        # @for_each_factor_dtype
+        # def test_grouped_rank_after_mask(self, name, factor_dtype):
+        #     pass
+
     @parameterized.expand([
         # Test cases computed by doing:
         # from numpy.random import seed, randn

--- a/tests/pipeline/test_factor.py
+++ b/tests/pipeline/test_factor.py
@@ -336,7 +336,8 @@ class FactorTestCase(BasePipelineTestCase):
         for method in results:
             check_arrays(expected[method], results[method])
 
-    def test_grouped_rank_ascending(self, factor_dtype=float64_dtype):
+    @for_each_factor_dtype
+    def test_grouped_rank_ascending(self, name, factor_dtype=float64_dtype):
 
         f = F(dtype=factor_dtype)
         c = C()
@@ -439,7 +440,8 @@ class FactorTestCase(BasePipelineTestCase):
         check({'ordinal': f.rank(groupby=c, ascending=True)})
         check({'ordinal': f.rank(groupby=str_c, ascending=True)})
 
-    def test_grouped_rank_descending(self, factor_dtype=float64_dtype):
+    @for_each_factor_dtype
+    def test_grouped_rank_descending(self, name, factor_dtype):
 
         f = F(dtype=factor_dtype)
         c = C()
@@ -531,11 +533,6 @@ class FactorTestCase(BasePipelineTestCase):
         # Not passing a method should default to ordinal
         check({'ordinal': f.rank(groupby=c, ascending=False)})
         check({'ordinal': f.rank(groupby=str_c, ascending=False)})
-
-        # TODO finish this
-        # @for_each_factor_dtype
-        # def test_grouped_rank_after_mask(self, name, factor_dtype):
-        #     pass
 
     @parameterized.expand([
         # Test cases computed by doing:

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -400,6 +400,17 @@ class ObjectIdentityTestCase(TestCase):
             method = getattr(f, funcname)
             self.assertIs(method(), method())
 
+    def test_instance_caching_grouped_transforms(self):
+        f = SomeFactor()
+        c = GenericClassifier()
+        m = GenericFilter()
+
+        for meth in f.demean, f.zscore, f.rank:
+            self.assertIs(meth(), meth())
+            self.assertIs(meth(groupby=c), meth(groupby=c))
+            self.assertIs(meth(mask=m), meth(mask=m))
+            self.assertIs(meth(groupby=c, mask=m), meth(groupby=c, mask=m))
+
     class SomeFactorParameterized(SomeFactor):
         params = ('a', 'b')
 

--- a/zipline/lib/normalize.py
+++ b/zipline/lib/normalize.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 
-def naive_grouped_rowwise_apply(data, group_labels, func, out=None):
+def naive_grouped_rowwise_apply(data,
+                                group_labels,
+                                func,
+                                func_args=(),
+                                out=None):
     """
     Simple implementation of grouped row-wise function application.
 
@@ -14,6 +18,8 @@ def naive_grouped_rowwise_apply(data, group_labels, func, out=None):
         Should be the same shape as array.
     func : function[ndarray[ndim=1]] -> function[ndarray[ndim=1]]
         Function to apply to pieces of each row in array.
+    func_args : tuple
+        Additional positional arguments to provide to each row in array.
     out : ndarray, optional
         Array into which to write output.  If not supplied, a new array of the
         same shape as ``data`` is allocated and returned.
@@ -41,5 +47,5 @@ def naive_grouped_rowwise_apply(data, group_labels, func, out=None):
     for (row, label_row, out_row) in zip(data, group_labels, out):
         for label in np.unique(label_row):
             locs = (label_row == label)
-            out_row[locs] = func(row[locs])
+            out_row[locs] = func(row[locs], *func_args)
     return out

--- a/zipline/lib/rank.pyx
+++ b/zipline/lib/rank.pyx
@@ -37,6 +37,13 @@ cpdef is_missing(ndarray data, object missing_value):
     return (data == missing_value)
 
 
+def rankdata_1d_descending(ndarray data, str method):
+    """
+    1D descending version of scipy.stats.rankdata.
+    """
+    return rankdata(-(data.view(float64)), method=method)
+
+
 def masked_rankdata_2d(ndarray data,
                        ndarray mask,
                        object missing_value,

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -931,6 +931,9 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
         """
         Construct a Filter matching the top N asset values of self each day.
 
+        If ``groupby`` is supplied, returns a Filter matching the top N asset
+        values for each group.
+
         Parameters
         ----------
         N : int
@@ -951,6 +954,9 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
     def bottom(self, N, mask=NotSpecified, groupby=NotSpecified):
         """
         Construct a Filter matching the bottom N asset values of self each day.
+
+        If ``groupby`` is supplied, returns a Filter matching the bottom N
+        asset values for each group.
 
         Parameters
         ----------


### PR DESCRIPTION
Adds support for `groupby` to `top`, `bottom`, and `rank`.  Based on @andportnoy's work in https://github.com/quantopian/zipline/pull/1260, with a few small fixes for datetime dtypes and some more test coverage.