### PR TITLE
BUG: run_algorithm errors if market data passed as DataFrame

### DIFF
--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -12,7 +12,7 @@ try:
     PYGMENTS = True
 except:
     PYGMENTS = False
-from toolz import valfilter, concatv
+from toolz import concatv
 
 from zipline.algorithm import TradingAlgorithm
 from zipline.data.bundles.core import load
@@ -150,6 +150,9 @@ def _run(handle_data,
             raise ValueError(
                 "No PipelineLoader registered for column %s." % column
             )
+    else:
+        env = TradingEnvironment()
+        choose_loader = None
 
     perf = TradingAlgorithm(
         namespace=namespace,
@@ -313,10 +316,12 @@ def run_algorithm(start,
     """
     load_extensions(default_extension, extensions, strict_extensions, environ)
 
-    non_none_data = valfilter(bool, {
-        'data': data,
-        'bundle': bundle,
-    })
+    non_none_data = {}
+    if data is not None:
+        non_none_data['data'] = data
+    if bundle is not None:
+        non_none_data['bundle'] = bundle
+
     if not non_none_data:
         # if neither data nor bundle are passed use 'quantopian-quandl'
         bundle = 'quantopian-quandl'


### PR DESCRIPTION
- line 318, in run_algorithm:  ValueError: The truth value of a
DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or
a.all().
- line 159, in _run_algorithm: UnboundLocalError: local variable 'env'
referenced before assignment

The following code reproduces the error(s):

```python
from zipline import run_algorithm
from datetime import datetime
from pytz import UTC
from zipline.data.loader import load_from_yahoo
from zipline.api import order, symbol, record

def initialize(context):
    pass

def handle_data(context, data):
    order(symbol('AAPL'), 10)

if __name__ == '__main__':
    start = datetime(2000, 1, 1, tzinfo=UTC)
    end = datetime(2016, 1, 1, tzinfo=UTC)
    capital_base = 100000
    
    data = load_from_yahoo(stocks=['AAPL'], indexes={}, adjusted=True)
    
    results = run_algorithm(
                  start,
                  end,
                  initialize,
                  capital_base,
                  data=data,
                  bundle=None,
                  default_extension=False
                  )
```