### PR TITLE
PERF: lru-dict is a much faster LRU cache

### DIFF
--- a/conda/lru-dict/bld.bat
+++ b/conda/lru-dict/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda/lru-dict/build.sh
+++ b/conda/lru-dict/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda/lru-dict/meta.yaml
+++ b/conda/lru-dict/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: lru-dict
+  version: "1.1.4"
+
+source:
+  fn: lru-dict-1.1.4.tar.gz
+  url: https://files.pythonhosted.org/packages/c3/b7/4e5bcbdfdc2227001f897051d6f4c83f9d236fe89a9df74da07cc3d9bac8/lru-dict-1.1.4.tar.gz
+  md5: 95ed142416b32c4b03dd8e7dae924f38
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - lru-dict = lru-dict:main
+    #
+    # Would create an entry point called lru-dict that calls lru-dict.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - lru
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/amitdev/lru-dict
+  license: MIT License
+  summary: 'A fast and memory efficient LRU cache.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -64,6 +64,7 @@ sortedcontainers==1.4.4
 intervaltree==2.1.0
 
 cachetools==1.1.5
+lru-dict==1.1.4
 
 # For financial risk calculations
 empyrical==0.1.11

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -16,7 +16,7 @@ import os
 from os.path import join
 from textwrap import dedent
 
-from cachetools import LRUCache
+from lru import LRU
 import bcolz
 from bcolz import ctable
 from intervaltree import IntervalTree
@@ -788,7 +788,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
         self._minutes_per_day = metadata.minutes_per_day
 
         self._carrays = {
-            field: LRUCache(maxsize=sid_cache_size)
+            field: LRU(sid_cache_size)
             for field in self.FIELDS
         }
 

--- a/zipline/utils/calendars/_calendar_helpers.pyx
+++ b/zipline/utils/calendars/_calendar_helpers.pyx
@@ -72,3 +72,16 @@ def minutes_to_session_labels(ndarray[int64_t, ndim=1] minutes,
         current_idx = next_idx
 
     return results
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_session_nano(ndarray[int64_t, ndim=1] closes,
+               ndarray[int64_t, ndim=1] session_labels,
+               int64_t minute_val):
+    cdef int idx
+    cdef long current_or_next_session_nano
+
+    idx = searchsorted(closes, minute_val)
+    current_or_next_session_nano = session_labels[idx]
+
+    return current_or_next_session_nano

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -674,7 +674,6 @@ class TradingCalendar(with_metaclass(ABCMeta)):
 
         return DatetimeIndex(all_minutes).tz_localize("UTC")
 
-    @preprocess(dt=coerce(pd.Timestamp, attrgetter('value')))
     def minute_to_session_label(self, dt, direction="next"):
         """
         Given a minute, get the label of its containing session.
@@ -716,17 +715,17 @@ class TradingCalendar(with_metaclass(ABCMeta)):
                 self._minute_to_session_label_cache[dt.value] = answer
                 return answer
 
-        idx = searchsorted(self.market_closes_nanos, dt)
+        idx = searchsorted(self.market_closes_nanos, dt.value)
         current_or_next_session = self.schedule.index[idx]
 
         if direction == "previous":
             if not is_open(self.market_opens_nanos, self.market_closes_nanos,
-                           dt):
+                           dt.value):
                 # if the exchange is closed, use the previous session
                 return self.schedule.index[idx - 1]
         elif direction == "none":
             if not is_open(self.market_opens_nanos, self.market_closes_nanos,
-                           dt):
+                           dt.value):
                 # if the exchange is closed, blow up
                 raise ValueError("The given dt is not an exchange minute!")
         elif direction != "next":


### PR DESCRIPTION
Just opening for discussion.

On my machine, a simulation that buys a share of AAPL every minute takes ~102 seconds for a year.  This PR makes it take 77 seconds.

In that relatively artificial scenario, a ton of time is being spent in the LRUCache in `minute_bars._open_minute_file`.  

I switched to `lru-dict`, a C implementation of an LRU cache, and things speed up nicely.

EDIT: I added a second commit that puts that fast LRU cache in front of `trading_calendar.minute_to_session_label`, and the same simulation then went from 77 to 70 seconds.