### PR TITLE
Limit orders filled at limit price

### DIFF
--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -176,6 +176,14 @@ class VolumeShareSlippage(SlippageModel):
             if (order.direction > 0 and impacted_price > order.limit) or \
                     (order.direction < 0 and impacted_price < order.limit):
                 return None, None
+            else:
+                # since limit orders should be filled at the limit price and
+                # not at the market price, we will calculate slippage at the 
+                # limit price
+                simulated_impact = volume_share ** 2 \
+                    * math.copysign(self.price_impact, order.direction) \
+                    * order.limit
+                impacted_price = order.limit + simulated_impact
 
         return (
             impacted_price,


### PR DESCRIPTION
Made orders will fill at limit price, not at the market price of the current bar

This patch addresses #1369 