### PR TITLE
BUG: Need to set simulation_dt in before_trading_start

### DIFF
--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -229,7 +229,7 @@ class AlgorithmSimulator(object):
 
                     yield self._get_daily_message(dt, algo, algo.perf_tracker)
                 elif action == BEFORE_TRADING_START_BAR:
-                    # call before trading start
+                    self.simulation_dt = dt
                     algo.on_dt_changed(dt)
                     algo.before_trading_start(self.current_data)
                 elif action == MINUTE_END:


### PR DESCRIPTION
so that log lines in b_t_s have the proper dt.

Ideally we would get rid of the `simulation_dt` variable entirely in `tradesimulation`, but that can be done another day.