### PR TITLE
BUG: when limit price is crossed, fill at limit price (not market price)

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -240,7 +240,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         txn = orders_txns[0][1]
 
         expected_txn = {
-            'price': float(3.50021875),
+            'price': float(3.6),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 34, tzinfo=pytz.utc),
             # we ordered 100 shares, but default volume slippage only allows
@@ -326,7 +326,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         _, txn = orders_txns[0]
 
         expected_txn = {
-            'price': float(3.49978125),
+            'price': float(3.4),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 32, tzinfo=pytz.utc),
             'amount': int(-50),
@@ -638,7 +638,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         _, txn = orders_txns[0]
 
         expected_txn = {
-            'price': float(3.50021875),
+            'price': float(3.6),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 34, tzinfo=pytz.utc),
             'amount': int(50),
@@ -762,7 +762,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         _, txn = orders_txns[0]
 
         expected_txn = {
-            'price': float(3.49978125),
+            'price': float(3.4),
             'dt': datetime.datetime(
                 2006, 1, 5, 14, 32, tzinfo=pytz.utc),
             'amount': int(-50),


### PR DESCRIPTION
For "non-marketable" limit orders (limit price has been crossed)
the final price must be the limit price while for "marketable" limit orders
the market price must be used (as before)
To disinguish between marketable and non-marketable limit order we can use
the following check:
if both open and close price are below/above (buy/sell) the limit price
the order is markettable
if open price is above (or below for sell) limit price and close price is
below (or above for sell) limit price, then the order is non-marketable

This patch doesn't cover the scenario where the crossing of the limit
price happens between the close price of the previous minute and the
open price of the next minute. But in my understanding the close price
of any minute must be almost identical to the open price of the following
minute, so I don't believe this is a real issue.
