### PR TITLE
MAINT: Use TradingCalendar objects for bundles

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -261,6 +261,24 @@ Asset Metadata
 .. autoclass:: zipline.assets.AssetConvertible
    :members:
 
+
+Trading Calendar API
+~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: zipline.utils.calendars.get_calendar
+
+.. autoclass:: zipline.utils.calendars.TradingCalendar
+   :members:
+
+.. autofunction:: zipline.utils.calendars.register_calendar
+
+.. autofunction:: zipline.utils.calendars.register_calendar_type
+
+.. autofunction:: zipline.utils.calendars.deregister_calendar
+
+.. autofunction:: zipline.utils.calendars.clear_calendars
+
+
 Data API
 ~~~~~~~~
 
@@ -316,6 +334,7 @@ Bundles
    :func:`~zipline.data.bundles.unregister`.
 
 .. autofunction:: zipline.data.bundles.yahoo_equities
+
 
 
 Utilities

--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -302,20 +302,21 @@ have.
 ``calendar``
 ````````````
 
-``calendar`` is an instance of ``zipline.utils.calendars.TradingCalendar``. The
-calendar is provided to help some bundles generate queries for the days needed.
+``calendar`` is an instance of
+:class:`zipline.utils.calendars.TradingCalendar`. The calendar is provided to
+help some bundles generate queries for the days needed.
 
 ``start_session``
 ````````````
 
-``start_session`` is a ``pandas.Timestamp`` object indicating the first day
-that the bundle should load data for.
+``start_session`` is a :class:`pandas.Timestamp` object indicating the first
+day that the bundle should load data for.
 
 ``end_session``
 ````````````
 
-``end_session`` is a ``pandas.Timestamp`` object indicating the last day that
-the bundle should load data for.
+``end_session`` is a :class:`pandas.Timestamp` object indicating the last day
+that the bundle should load data for.
 
 ``cache``
 `````````

--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -216,6 +216,8 @@ The signature of the ingest function should be:
           daily_bar_writer,
           adjustment_writer,
           calendar,
+          start_session,
+          end_session,
           cache,
           show_progress,
           output_dir)
@@ -300,9 +302,20 @@ have.
 ``calendar``
 ````````````
 
-``calendar`` is a ``pandas.DatetimeIndex`` object holding all of the trading
-days that the bundle should load data for. The calendar is provided to help some
-bundles generate queries for the days needed.
+``calendar`` is an instance of ``zipline.utils.calendars.TradingCalendar``. The
+calendar is provided to help some bundles generate queries for the days needed.
+
+``calendar``
+````````````
+
+``start_session`` is a ``pandas.Timestamp`` object indicating the first day
+that the bundle should load data for.
+
+``end_session``
+````````````
+
+``end_session`` is a ``pandas.Timestamp`` object indicating the last day that
+the bundle should load data for.
 
 ``cache``
 `````````

--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -305,7 +305,7 @@ have.
 ``calendar`` is an instance of ``zipline.utils.calendars.TradingCalendar``. The
 calendar is provided to help some bundles generate queries for the days needed.
 
-``calendar``
+``start_session``
 ````````````
 
 ``start_session`` is a ``pandas.Timestamp`` object indicating the first day

--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -30,7 +30,7 @@ from zipline.testing.predicates import (
 )
 from zipline.utils.cache import dataframe_cache
 from zipline.utils.functional import apply
-from zipline.utils.calendars import get_calendar
+from zipline.utils.calendars import TradingCalendar, get_calendar
 import zipline.utils.paths as pth
 
 
@@ -96,6 +96,8 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
                           daily_bar_writer,
                           adjustment_writer,
                           calendar,
+                          start_session,
+                          end_session,
                           cache,
                           show_progress,
                           output_dir):
@@ -111,20 +113,19 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
     def test_ingest(self):
         start = pd.Timestamp('2014-01-06', tz='utc')
         end = pd.Timestamp('2014-01-10', tz='utc')
-        trading_days = get_calendar('NYSE').all_sessions
-        calendar = trading_days[trading_days.slice_indexer(start, end)]
-        minutes = get_calendar('NYSE').minutes_for_sessions_in_range(
-            calendar[0], calendar[-1]
-        )
+        calendar = get_calendar('NYSE')
+
+        sessions = calendar.sessions_in_range(start, end)
+        minutes = calendar.minutes_for_sessions_in_range(start, end)
 
         sids = tuple(range(3))
         equities = make_simple_equity_info(
             sids,
-            calendar[0],
-            calendar[-1],
+            start,
+            end,
         )
 
-        daily_bar_data = make_bar_data(equities, calendar)
+        daily_bar_data = make_bar_data(equities, sessions)
         minute_bar_data = make_bar_data(equities, minutes)
         first_split_ratio = 0.5
         second_split_ratio = 0.1
@@ -141,13 +142,11 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
             },
         ])
 
-        schedule = get_calendar('NYSE').schedule
-
         @self.register(
             'bundle',
             calendar=calendar,
-            opens=schedule.market_open[calendar[0]:calendar[-1]],
-            closes=schedule.market_close[calendar[0]: calendar[-1]],
+            start_session=start,
+            end_session=end,
         )
         def bundle_ingest(environ,
                           asset_db_writer,
@@ -155,6 +154,8 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
                           daily_bar_writer,
                           adjustment_writer,
                           calendar,
+                          start_session,
+                          end_session,
                           cache,
                           show_progress,
                           output_dir):
@@ -165,7 +166,7 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
             daily_bar_writer.write(daily_bar_data)
             adjustment_writer.write(splits=splits)
 
-            assert_is_instance(calendar, pd.DatetimeIndex)
+            assert_is_instance(calendar, TradingCalendar)
             assert_is_instance(cache, dataframe_cache)
             assert_is_instance(show_progress, bool)
 
@@ -192,19 +193,19 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
 
         actual = bundle.equity_daily_bar_reader.load_raw_arrays(
             columns,
-            calendar[0],
-            calendar[-1],
+            start,
+            end,
             sids,
         )
         for actual_column, colname in zip(actual, columns):
             assert_equal(
                 actual_column,
-                expected_bar_values_2d(calendar, equities, colname),
+                expected_bar_values_2d(sessions, equities, colname),
                 msg=colname,
             )
         adjustments_for_cols = bundle.adjustment_reader.load_adjustments(
             columns,
-            calendar,
+            sessions,
             pd.Index(sids),
         )
         for column, adjustments in zip(columns, adjustments_for_cols[:-1]):
@@ -291,13 +292,17 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
         """
         if not self.bundles:
             @self.register('bundle',
-                           calendar=pd.DatetimeIndex([pd.Timestamp('2014')]))
+                           calendar=get_calendar('NYSE'),
+                           start_session=pd.Timestamp('2014'),
+                           end_session=pd.Timestamp('2014'))
             def _(environ,
                   asset_db_writer,
                   minute_bar_writer,
                   daily_bar_writer,
                   adjustment_writer,
                   calendar,
+                  start_session,
+                  end_session,
                   cache,
                   show_progress,
                   output_dir):

--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -264,7 +264,7 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
         # register but do not ingest data
         self.register('bundle', lambda *args: None)
 
-        ts = pd.Timestamp('2014')
+        ts = pd.Timestamp('2014', tz='UTC')
 
         with assert_raises(ValueError) as e:
             self.load('bundle', timestamp=ts, environ=self.environ)
@@ -293,8 +293,8 @@ class BundleCoreTestCase(WithInstanceTmpDir, ZiplineTestCase):
         if not self.bundles:
             @self.register('bundle',
                            calendar=get_calendar('NYSE'),
-                           start_session=pd.Timestamp('2014'),
-                           end_session=pd.Timestamp('2014'))
+                           start_session=pd.Timestamp('2014', tz='UTC'),
+                           end_session=pd.Timestamp('2014', tz='UTC'))
             def _(environ,
                   asset_db_writer,
                   minute_bar_writer,

--- a/tests/data/bundles/test_quandl.py
+++ b/tests/data/bundles/test_quandl.py
@@ -27,9 +27,10 @@ class QuandlBundleTestCase(ZiplineTestCase):
     symbols = 'AAPL', 'BRK_A', 'MSFT', 'ZEN'
     asset_start = pd.Timestamp('2014-01', tz='utc')
     asset_end = pd.Timestamp('2015-01', tz='utc')
-    calendar = bundles['quandl'].calendar
-    start_date = calendar[0]
-    end_date = calendar[-1]
+    bundle = bundles['quandl']
+    calendar = bundle.calendar
+    start_date = bundle.start_session
+    end_date = bundle.end_session
     api_key = 'ayylmao'
     columns = 'open', 'high', 'low', 'close', 'volume'
 
@@ -87,7 +88,9 @@ class QuandlBundleTestCase(ZiplineTestCase):
                 yield vs
 
         # the first index our written data will appear in the files on disk
-        start_idx = self.calendar.get_loc(self.asset_start, 'ffill') + 1
+        start_idx = (
+            self.calendar.all_sessions.get_loc(self.asset_start, 'ffill') + 1
+        )
 
         # convert an index into the raw dataframe into an index into the
         # final data
@@ -215,11 +218,11 @@ class QuandlBundleTestCase(ZiplineTestCase):
             assert_equal(equity.start_date, self.asset_start, msg=equity)
             assert_equal(equity.end_date, self.asset_end, msg=equity)
 
-        cal = self.calendar
+        sessions = self.calendar.all_sessions
         actual = bundle.equity_daily_bar_reader.load_raw_arrays(
             self.columns,
-            cal[cal.get_loc(self.asset_start, 'bfill')],
-            cal[cal.get_loc(self.asset_end, 'ffill')],
+            sessions[sessions.get_loc(self.asset_start, 'bfill')],
+            sessions[sessions.get_loc(self.asset_end, 'ffill')],
             sids,
         )
         expected_pricing, expected_adjustments = self._expected_data(
@@ -229,7 +232,7 @@ class QuandlBundleTestCase(ZiplineTestCase):
 
         adjustments_for_cols = bundle.adjustment_reader.load_adjustments(
             self.columns,
-            cal,
+            sessions,
             pd.Index(sids),
         )
 

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -248,9 +248,13 @@ def _make_bundle_core():
             calendar. This defaults to 'NYSE', in which case we use the NYSE
             calendar.
         start_session : pd.Timestamp, optional
-            The first session for which we want data.
+            The first session for which we want data. If not provided,
+            or if the date lies outside the range supported by the
+            calendar, the first_session of the calendar is used.
         end_session : pd.Timestamp, optional
-            The last session for which we want data.
+            The last session for which we want data. If not provided,
+            or if the date lies outside the range supported by the
+            calendar, the last_session of the calendar is used.
         minutes_per_day : int, optional
             The number of minutes in each normal trading day.
         create_writers : bool, optional
@@ -281,9 +285,12 @@ def _make_bundle_core():
         if isinstance(calendar, str):
             calendar = get_calendar(calendar)
 
-        if start_session is None:
+        # If the start and end sessions are not provided or lie outside
+        # the bounds of the calendar being used, set them to the first
+        # and last sessions of the calendar.
+        if start_session is None or start_session < calendar.first_session:
             start_session = calendar.first_session
-        if end_session is None:
+        if end_session is None or end_session > calendar.last_session:
             end_session = calendar.last_session
 
         _bundles[name] = _BundlePayload(

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -234,11 +234,11 @@ def gen_symbol_data(api_key,
                     cache,
                     symbol_map,
                     calendar,
+                    start_session,
+                    end_session,
                     splits,
                     dividends,
                     retries):
-    start_date = calendar[0]
-    end_date = calendar[-1]
     for asset_id, symbol in symbol_map.iteritems():
         start_time = time()
         try:
@@ -250,16 +250,18 @@ def gen_symbol_data(api_key,
             raw_data = cache[symbol] = fetch_single_equity(
                 api_key,
                 symbol,
-                start_date=start_date,
-                end_date=end_date,
+                start_date=start_session,
+                end_date=end_session,
             )
             should_sleep = True
 
         _update_splits(splits, asset_id, raw_data)
         _update_dividends(dividends, asset_id, raw_data)
 
+        sessions = calendar.sessions_in_range(start_session, end_session)
+
         raw_data = raw_data.reindex(
-            calendar.tz_localize(None),
+            sessions.tz_localize(None),
             copy=False,
         ).fillna(0.0)
         yield asset_id, raw_data
@@ -277,6 +279,8 @@ def quandl_bundle(environ,
                   daily_bar_writer,
                   adjustment_writer,
                   calendar,
+                  start_session,
+                  end_session,
                   cache,
                   show_progress,
                   output_dir):
@@ -301,6 +305,8 @@ def quandl_bundle(environ,
             cache,
             symbol_map,
             calendar,
+            start_session,
+            end_session,
             splits,
             dividends,
             environ.get('QUANDL_DOWNLOAD_ATTEMPTS', 5),
@@ -378,6 +384,8 @@ def quantopian_quandl_bundle(environ,
                              daily_bar_writer,
                              adjustment_writer,
                              calendar,
+                             start_session,
+                             end_session,
                              cache,
                              show_progress,
                              output_dir):

--- a/zipline/data/bundles/yahoo.py
+++ b/zipline/data/bundles/yahoo.py
@@ -61,6 +61,8 @@ def yahoo_equities(symbols, start=None, end=None):
                daily_bar_writer,
                adjustment_writer,
                calendar,
+               start_session,
+               end_session,
                cache,
                show_progress,
                output_dir,
@@ -68,7 +70,7 @@ def yahoo_equities(symbols, start=None, end=None):
                start=start,
                end=end):
         if start is None:
-            start = calendar[0]
+            start = start_session
         if end is None:
             end = None
 


### PR DESCRIPTION
Instead of trading days, opens, and closes, register now takes a TradingCalendar object, along with a start_session and end_session. The ingest function is now passed these values instead as well.