### PR TITLE
ENH: Pass calendar instance to BcolzMinuteBarWriter

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -82,8 +82,7 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
         self.writer = BcolzMinuteBarWriter(
             TEST_CALENDAR_START,
             self.dest,
-            self.market_opens,
-            self.market_closes,
+            self.trading_calendar,
             US_EQUITIES_MINUTES_PER_DAY,
         )
         self.reader = BcolzMinuteBarReader(self.dest)

--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -80,9 +80,10 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
         self.dest = self.instance_tmpdir.getpath('minute_bars')
         os.makedirs(self.dest)
         self.writer = BcolzMinuteBarWriter(
-            TEST_CALENDAR_START,
             self.dest,
             self.trading_calendar,
+            TEST_CALENDAR_START,
+            TEST_CALENDAR_STOP,
             US_EQUITIES_MINUTES_PER_DAY,
         )
         self.reader = BcolzMinuteBarReader(self.dest)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -3532,12 +3532,6 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendars, ZiplineTestCase):
         sids = asset_info.index
 
         env = self.enter_instance_context(tmp_trading_env(equities=asset_info))
-        market_opens = self.trading_calendar.schedule.market_open.loc[
-            self.test_days
-        ]
-        market_closes = self.trading_calendar.schedule.market_close.loc[
-            self.test_days
-        ]
 
         if frequency == 'daily':
             dates = self.test_days
@@ -3571,8 +3565,7 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendars, ZiplineTestCase):
             writer = BcolzMinuteBarWriter(
                 self.test_days[0],
                 self.tmpdir.path,
-                market_opens,
-                market_closes,
+                self.trading_calendar,
                 US_EQUITIES_MINUTES_PER_DAY
             )
             trade_data_by_sid = make_trade_data_for_asset_info(

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -3563,9 +3563,10 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendars, ZiplineTestCase):
                 self.test_days[-1],
             )
             writer = BcolzMinuteBarWriter(
-                self.test_days[0],
                 self.tmpdir.path,
                 self.trading_calendar,
+                self.test_days[0],
+                self.test_days[-1],
                 US_EQUITIES_MINUTES_PER_DAY
             )
             trade_data_by_sid = make_trade_data_for_asset_info(

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -385,8 +385,7 @@ def _make_bundle_core():
                     wd.ensure_dir(*minute_equity_relative(
                         name, timestr, environ=environ)
                     ),
-                    bundle.calendar.schedule['market_open'],
-                    bundle.calendar.schedule['market_close'],
+                    bundle.calendar,
                     minutes_per_day=bundle.minutes_per_day,
                 )
                 asset_db_writer = AssetDBWriter(

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -381,11 +381,12 @@ def _make_bundle_core():
 
                 daily_bar_writer.write(())
                 minute_bar_writer = BcolzMinuteBarWriter(
-                    bundle.start_session,
                     wd.ensure_dir(*minute_equity_relative(
                         name, timestr, environ=environ)
                     ),
                     bundle.calendar,
+                    bundle.start_session,
+                    bundle.end_session,
                     minutes_per_day=bundle.minutes_per_day,
                 )
                 asset_db_writer = AssetDBWriter(

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -287,9 +287,6 @@ class BcolzMinuteBarMetadata(object):
         ohlc_ratio : int
              The factor by which the pricing data is multiplied so that the
              float data can be stored as an integer.
-        first_trading_day : string
-            'YYYY-MM-DD' formatted representation of the first trading day
-             available in the dataset.
         minutes_per_day : int
             The number of minutes per each period.
         calendar_name : str
@@ -301,6 +298,12 @@ class BcolzMinuteBarMetadata(object):
         end_session : datetime
             'YYYY-MM-DD' formatted representation of the last trading
             session in the data set.
+
+        Deprecated, but included for backwards compatibility:
+
+        first_trading_day : string
+            'YYYY-MM-DD' formatted representation of the first trading day
+             available in the dataset.
         market_opens : list
             List of int64 values representing UTC market opens as
             minutes since epoch.

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -802,12 +802,12 @@ class BcolzMinuteBarReader(MinuteBarReader):
         self._start_session = metadata.start_session
         self._end_session = metadata.end_session
 
-        calendar = metadata.calendar
-        slicer = calendar.schedule.index.slice_indexer(
+        self.calendar = metadata.calendar
+        slicer = self.calendar.schedule.index.slice_indexer(
             self._start_session,
             self._end_session,
         )
-        self._schedule = calendar.schedule[slicer]
+        self._schedule = self.calendar.schedule[slicer]
         self._market_opens = self._schedule.market_open
         self._market_open_values = self._market_opens.values.\
             astype('datetime64[m]').astype(np.int64)
@@ -832,7 +832,8 @@ class BcolzMinuteBarReader(MinuteBarReader):
 
     @lazyval
     def last_available_dt(self):
-        return self._market_closes[-1]
+        _, close = self.calendar.open_and_close_for_session(self._end_session)
+        return close
 
     @property
     def first_trading_day(self):

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -507,14 +507,10 @@ def create_data_portal(asset_finder, tempdir, sim_params, sids,
 
 
 def write_bcolz_minute_data(trading_calendar, days, path, data):
-    market_opens = trading_calendar.schedule.loc[days].market_open
-    market_closes = trading_calendar.schedule.loc[days].market_close
-
     BcolzMinuteBarWriter(
         days[0],
         path,
-        market_opens,
-        market_closes,
+        trading_calendar,
         US_EQUITIES_MINUTES_PER_DAY
     ).write(data)
 

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -508,9 +508,10 @@ def create_data_portal(asset_finder, tempdir, sim_params, sids,
 
 def write_bcolz_minute_data(trading_calendar, days, path, data):
     BcolzMinuteBarWriter(
-        days[0],
         path,
         trading_calendar,
+        days[0],
+        days[-1],
         US_EQUITIES_MINUTES_PER_DAY
     ).write(data)
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -994,9 +994,10 @@ class WithBcolzEquityMinuteBarReader(WithEquityMinuteBarData, WithTmpDir):
         days = cls.equity_minute_bar_days
 
         writer = BcolzMinuteBarWriter(
-            days[0],
             p,
             cls.trading_calendar,
+            days[0],
+            days[-1],
             US_EQUITIES_MINUTES_PER_DAY
         )
         writer.write(cls.make_equity_minute_bar_data())
@@ -1053,9 +1054,10 @@ class WithBcolzFutureMinuteBarReader(WithFutureMinuteBarData, WithTmpDir):
         days = cls.future_minute_bar_days
 
         writer = BcolzMinuteBarWriter(
-            days[0],
             p,
             trading_calendar,
+            days[0],
+            days[-1],
             FUTURES_MINUTES_PER_DAY,
         )
         writer.write(cls.make_future_minute_bar_data())

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -996,8 +996,7 @@ class WithBcolzEquityMinuteBarReader(WithEquityMinuteBarData, WithTmpDir):
         writer = BcolzMinuteBarWriter(
             days[0],
             p,
-            cls.trading_calendar.schedule.market_open.loc[days],
-            cls.trading_calendar.schedule.market_close.loc[days],
+            cls.trading_calendar,
             US_EQUITIES_MINUTES_PER_DAY
         )
         writer.write(cls.make_equity_minute_bar_data())
@@ -1056,8 +1055,7 @@ class WithBcolzFutureMinuteBarReader(WithFutureMinuteBarData, WithTmpDir):
         writer = BcolzMinuteBarWriter(
             days[0],
             p,
-            trading_calendar.schedule.market_open.loc[days],
-            trading_calendar.schedule.market_close.loc[days],
+            trading_calendar,
             FUTURES_MINUTES_PER_DAY,
         )
         writer.write(cls.make_future_minute_bar_data())


### PR DESCRIPTION
Updates `BcolzMinuteBarWriter` to take a `TradingCalendar`, start session, and end session. Previously used "first trading day" and `DatetimeIndex` objects of market opens and closes.