### PR TITLE
ENH: Add fast "vectorized" `minute_to_session_label` for DatetimeIndex

### DIFF
--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -432,6 +432,22 @@ class ExchangeCalendarTestBase(object):
                         direction="none"
                     )
 
+    @parameterized.expand([
+        (1, 0),
+        (2, 0),
+        (2, 1),
+    ])
+    def test_minute_index_to_session_labels(self, interval, offset):
+        minutes = self.calendar.minutes_for_sessions_in_range('2011-01-04',
+                                                              '2011-04-04')
+        minutes = minutes[range(offset, len(minutes), interval)]
+
+        np.testing.assert_array_equal(
+            np.array(minutes.map(self.calendar.minute_to_session_label),
+                     dtype='datetime64[ns]'),
+            self.calendar.minute_index_to_session_labels(minutes)
+        )
+
     def test_next_prev_session(self):
         session_labels = self.answers.index[1:-2]
         max_idx = len(session_labels) - 1


### PR DESCRIPTION
~~*Incomplete; "vectorized" `minute_to_session_label` is done so far*~~

The new TradingCalendar method is called `minute_index_to_session_labels`.
It takes a DatetimeIndex of in-order market minutes and returns a
DatetimeIndex of the corresponding sessions.

The new method is approximately 100x faster than mapping
`minute_to_session_label` over a large DatetimeIndex.