### PR TITLE
TST: Add coverage output to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ sdist
 develop-eggs
 .installed.cfg
 coverage.xml
+htmlcov
 nosetests.xml
 
 # C Extensions


### PR DESCRIPTION
Ignore `htmlcov` directory created by `coverage html`.