### PR TITLE
ENH: Adds QuantopianUSFuturesCalendar

### DIFF
--- a/zipline/utils/calendars/calendar_utils.py
+++ b/zipline/utils/calendars/calendar_utils.py
@@ -9,6 +9,9 @@ from zipline.utils.calendars.exchange_calendar_cme import CMEExchangeCalendar
 from zipline.utils.calendars.exchange_calendar_bmf import BMFExchangeCalendar
 from zipline.utils.calendars.exchange_calendar_lse import LSEExchangeCalendar
 from zipline.utils.calendars.exchange_calendar_tsx import TSXExchangeCalendar
+from zipline.utils.calendars.us_futures_calendar import (
+    QuantopianUSFuturesCalendar,
+)
 
 
 NYSE_CALENDAR_EXCHANGE_NAMES = frozenset([
@@ -31,6 +34,8 @@ BMF_CALENDAR_EXCHANGE_NAMES = frozenset(["BMF"])
 LSE_CALENDAR_EXCHANGE_NAMES = frozenset(["LSE"])
 TSX_CALENDAR_EXCHANGE_NAMES = frozenset(["TSX"])
 
+US_FUTURES_CALENDAR_NAMES = frozenset(["us_futures"])
+
 _default_calendar_factories = {
     NYSE_CALENDAR_EXCHANGE_NAMES: NYSEExchangeCalendar,
     CME_CALENDAR_EXCHANGE_NAMES: CMEExchangeCalendar,
@@ -39,6 +44,7 @@ _default_calendar_factories = {
     BMF_CALENDAR_EXCHANGE_NAMES: BMFExchangeCalendar,
     LSE_CALENDAR_EXCHANGE_NAMES: LSEExchangeCalendar,
     TSX_CALENDAR_EXCHANGE_NAMES: TSXExchangeCalendar,
+    US_FUTURES_CALENDAR_NAMES: QuantopianUSFuturesCalendar,
 }
 
 

--- a/zipline/utils/calendars/us_futures_calendar.py
+++ b/zipline/utils/calendars/us_futures_calendar.py
@@ -1,0 +1,60 @@
+from datetime import time
+
+from pandas.tseries.holiday import GoodFriday
+from pytz import timezone
+
+from zipline.utils.calendars import TradingCalendar
+from zipline.utils.calendars.trading_calendar import HolidayCalendar
+from zipline.utils.calendars.us_holidays import (
+    USNewYearsDay,
+    Christmas
+)
+
+
+class QuantopianUSFuturesCalendar(TradingCalendar):
+    """Synthetic calendar for trading US futures.
+
+    This calendar is a superset of all of the US futures exchange
+    calendars provided by Zipline (CFE, CME, ICE), and is intended for
+    trading across all of these exchanges.
+
+    Notes
+    -----
+    Open Time: 6:00 PM, US/Eastern
+    Close Time: 6:00 PM, US/Eastern
+
+    Regularly-Observed Holidays:
+    - New Years Day
+    - Good Friday
+    - Christmas
+
+    In order to align the hours of each session, we ignore the Sunday
+    CME Pre-Open hour (5-6pm).
+    """
+    @property
+    def name(self):
+        return "us_futures"
+
+    @property
+    def tz(self):
+        return timezone('US/Eastern')
+
+    @property
+    def open_time(self):
+        return time(18, 1)
+
+    @property
+    def close_time(self):
+        return time(18)
+
+    @property
+    def open_offset(self):
+        return -1
+
+    @property
+    def regular_holidays(self):
+        return HolidayCalendar([
+            USNewYearsDay,
+            GoodFriday,
+            Christmas,
+        ])


### PR DESCRIPTION
For trading US futures across the exchanges supported by Zipline.