### PR TITLE
BUG: Fixes BcolzMinuteBarMetadata to read the version correctly

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -36,6 +36,7 @@ from pandas import (
 )
 
 from zipline.data.minute_bars import (
+    BcolzMinuteBarMetadata,
     BcolzMinuteBarWriter,
     BcolzMinuteBarReader,
     BcolzMinuteOverlappingData,
@@ -87,6 +88,13 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
             US_EQUITIES_MINUTES_PER_DAY,
         )
         self.reader = BcolzMinuteBarReader(self.dest)
+
+    def test_version(self):
+        metadata = self.reader._get_metadata()
+        self.assertEquals(
+            metadata.version,
+            BcolzMinuteBarMetadata.FORMAT_VERSION,
+        )
 
     def test_write_one_ohlcv(self):
         minute = self.market_opens[self.test_calendar_start]

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -260,7 +260,7 @@ class BcolzMinuteBarMetadata(object):
                 start_session,
                 end_session,
                 minutes_per_day,
-                version,
+                version=version,
             )
 
     def __init__(
@@ -270,7 +270,7 @@ class BcolzMinuteBarMetadata(object):
         start_session,
         end_session,
         minutes_per_day,
-        version,
+        version=FORMAT_VERSION,
     ):
         self.calendar = calendar
         self.start_session = start_session
@@ -458,7 +458,6 @@ class BcolzMinuteBarWriter(object):
             self._start_session,
             self._end_session,
             self._minutes_per_day,
-            BcolzMinuteBarMetadata.FORMAT_VERSION,
         )
         metadata.write(self._rootdir)
 

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -223,7 +223,7 @@ class BcolzMinuteBarMetadata(object):
             raw_data = json.load(fp)
 
             try:
-                version = raw_data['minutes_per_day']
+                version = raw_data['version']
             except KeyError:
                 # Version was first written with version 1, assume 0,
                 # if version does not match.
@@ -260,6 +260,7 @@ class BcolzMinuteBarMetadata(object):
                 start_session,
                 end_session,
                 minutes_per_day,
+                version,
             )
 
     def __init__(
@@ -269,12 +270,14 @@ class BcolzMinuteBarMetadata(object):
         start_session,
         end_session,
         minutes_per_day,
+        version,
     ):
         self.calendar = calendar
         self.start_session = start_session
         self.end_session = end_session
         self.ohlc_ratio = ohlc_ratio
         self.minutes_per_day = minutes_per_day
+        self.version = version
 
     def write(self, rootdir):
         """
@@ -322,7 +325,7 @@ class BcolzMinuteBarMetadata(object):
         market_closes = schedule.market_close
 
         metadata = {
-            'version': self.FORMAT_VERSION,
+            'version': self.version,
             'ohlc_ratio': self.ohlc_ratio,
             'minutes_per_day': self.minutes_per_day,
             'calendar_name': self.calendar.name,
@@ -455,6 +458,7 @@ class BcolzMinuteBarWriter(object):
             self._start_session,
             self._end_session,
             self._minutes_per_day,
+            BcolzMinuteBarMetadata.FORMAT_VERSION,
         )
         metadata.write(self._rootdir)
 


### PR DESCRIPTION
We were mistakenly using the `minute_per_day field`.

We now expose from the metadata object the version from which the metadata was read. This allows a new test that verifies the version is read correctly.