### PR TITLE
MAINT: Standardize reader get value methods.

### DIFF
--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -512,7 +512,7 @@ class TestResampleSessionBars(WithBcolzFutureMinuteBarReader,
 
         self.assertEqual(self.END_DATE, session_bar_reader.last_available_dt)
 
-    def test_spot_price(self):
+    def test_get_value(self):
         calendar = self.trading_calendar
         session_bar_reader = MinuteResampleSessionBarReader(
             calendar,
@@ -523,7 +523,7 @@ class TestResampleSessionBars(WithBcolzFutureMinuteBarReader,
             for dt_str, values in expected.iterrows():
                 dt = pd.Timestamp(dt_str, tz='UTC')
                 for col in OHLCV:
-                    result = session_bar_reader.spot_price(sid, dt, col)
+                    result = session_bar_reader.get_value(sid, dt, col)
                     assert_almost_equal(values[col], result,
                                         err_msg="sid={0} col={1} dt={2}".
                                         format(sid, col, dt))

--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -285,45 +285,45 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, ZiplineTestCase):
                 end_date=self.asset_end(asset),
             )
 
-    def test_unadjusted_spot_price(self):
+    def test_unadjusted_get_value(self):
         reader = self.bcolz_equity_daily_bar_reader
         # At beginning
-        price = reader.spot_price(1, Timestamp('2015-06-01', tz='UTC'),
-                                  'close')
+        price = reader.get_value(1, Timestamp('2015-06-01', tz='UTC'),
+                                 'close')
         # Synthetic writes price for date.
         self.assertEqual(108630.0, price)
 
         # Middle
-        price = reader.spot_price(1, Timestamp('2015-06-02', tz='UTC'),
-                                  'close')
+        price = reader.get_value(1, Timestamp('2015-06-02', tz='UTC'),
+                                 'close')
         self.assertEqual(108631.0, price)
         # End
-        price = reader.spot_price(1, Timestamp('2015-06-05', tz='UTC'),
-                                  'close')
+        price = reader.get_value(1, Timestamp('2015-06-05', tz='UTC'),
+                                 'close')
         self.assertEqual(108634.0, price)
 
         # Another sid at beginning.
-        price = reader.spot_price(2, Timestamp('2015-06-22', tz='UTC'),
-                                  'close')
+        price = reader.get_value(2, Timestamp('2015-06-22', tz='UTC'),
+                                 'close')
         self.assertEqual(208651.0, price)
 
         # Ensure that volume does not have float adjustment applied.
-        volume = reader.spot_price(1, Timestamp('2015-06-02', tz='UTC'),
-                                   'volume')
+        volume = reader.get_value(1, Timestamp('2015-06-02', tz='UTC'),
+                                  'volume')
         self.assertEqual(109631, volume)
 
-    def test_unadjusted_spot_price_no_data(self):
+    def test_unadjusted_get_value_no_data(self):
         table = self.bcolz_daily_bar_ctable
         reader = BcolzDailyBarReader(table)
         # before
         with self.assertRaises(NoDataOnDate):
-            reader.spot_price(2, Timestamp('2015-06-08', tz='UTC'), 'close')
+            reader.get_value(2, Timestamp('2015-06-08', tz='UTC'), 'close')
 
         # after
         with self.assertRaises(NoDataOnDate):
-            reader.spot_price(4, Timestamp('2015-06-16', tz='UTC'), 'close')
+            reader.get_value(4, Timestamp('2015-06-16', tz='UTC'), 'close')
 
-    def test_unadjusted_spot_price_empty_value(self):
+    def test_unadjusted_get_value_empty_value(self):
         reader = self.bcolz_equity_daily_bar_reader
 
         # A sid, day and corresponding index into which to overwrite a zero.
@@ -338,7 +338,7 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, ZiplineTestCase):
             # This a little hacky, in lieu of changing the synthetic data set.
             reader._spot_col('close')[zero_ix] = 0
 
-            close = reader.spot_price(zero_sid, zero_day, 'close')
+            close = reader.get_value(zero_sid, zero_day, 'close')
             self.assertEqual(-1, close)
         finally:
             reader._spot_col('close')[zero_ix] = old

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -336,7 +336,7 @@ class MockDailyBarSpotReader(object):
     """
     A BcolzDailyBarReader which returns a constant value for spot price.
     """
-    def spot_price(self, sid, day, column):
+    def get_value(self, sid, day, column):
         return 100.0
 
 

--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -358,7 +358,7 @@ class TestMinuteBarData(WithBarDataChecks,
                     elif field == "last_traded":
                         self.assertEqual(last_trading_minute, asset_value)
 
-    def test_spot_price_is_unadjusted(self):
+    def test_get_value_is_unadjusted(self):
         # verify there is a split for SPLIT_ASSET
         splits = self.adjustment_reader.get_adjustments_for_sid(
             "splits",
@@ -385,7 +385,7 @@ class TestMinuteBarData(WithBarDataChecks,
                 bar_data.current(self.SPLIT_ASSET, "price")
             )
 
-    def test_spot_price_is_adjusted_if_needed(self):
+    def test_get_value_is_adjusted_if_needed(self):
         # on cls.days[1], the first 9 minutes of ILLIQUID_SPLIT_ASSET are
         # missing. let's get them.
         day0_minutes = self.trading_calendar.minutes_for_session(
@@ -420,7 +420,7 @@ class TestMinuteBarData(WithBarDataChecks,
                 bar_data.current(self.ILLIQUID_SPLIT_ASSET, "price")
             )
 
-    def test_spot_price_at_midnight(self):
+    def test_get_value_at_midnight(self):
         # make sure that if we try to get a minute price at a non-market
         # minute, we use the previous market close's timestamp
         day = self.equity_minute_bar_days[1]
@@ -872,12 +872,12 @@ class TestDailyBarData(WithBarDataChecks,
         ("merger", 2, 3, 3, 1.8),
         ("dividend", 2, 3, 3, 2.88)
     ])
-    def test_spot_price_adjustments(self,
-                                    adjustment_type,
-                                    liquid_day_0_price,
-                                    liquid_day_1_price,
-                                    illiquid_day_0_price,
-                                    illiquid_day_1_price_adjusted):
+    def test_get_value_adjustments(self,
+                                   adjustment_type,
+                                   liquid_day_0_price,
+                                   liquid_day_1_price,
+                                   illiquid_day_0_price,
+                                   illiquid_day_1_price_adjusted):
         """Test the behaviour of spot prices during adjustments."""
         table_name = adjustment_type + 's'
         liquid_asset = getattr(self, (adjustment_type.upper() + "_ASSET"))

--- a/tests/test_panel_bar_reader.py
+++ b/tests/test_panel_bar_reader.py
@@ -55,14 +55,14 @@ class WithPanelBarReader(WithAssetFinder):
 
         cls.reader = PanelBarReader(trading_calendar, cls.panel, cls.FREQUENCY)
 
-    def test_spot_price(self):
+    def test_get_value(self):
         panel = self.panel
         reader = self.reader
 
         for asset, date, field in product(*panel.axes):
             self.assertEqual(
                 panel.loc[asset, date, field],
-                reader.spot_price(asset, date, field),
+                reader.get_value(asset, date, field),
             )
 
     def test_duplicate_values(self):

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -521,7 +521,7 @@ class DataPortal(object):
         elif column in OHLCV_FIELDS:
             # don't forward fill
             try:
-                val = reader.spot_price(asset, dt, column)
+                val = reader.get_value(asset, dt, column)
                 if val == -1:
                     if column == "volume":
                         return 0
@@ -535,7 +535,7 @@ class DataPortal(object):
             found_dt = dt
             while True:
                 try:
-                    value = reader.spot_price(
+                    value = reader.get_value(
                         asset, found_dt, "close"
                     )
                     if value != -1:

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -476,7 +476,7 @@ class MinuteResampleSessionBarReader(SessionBarReader):
     def load_raw_arrays(self, columns, start_dt, end_dt, assets):
         return self._get_resampled(columns, start_dt, end_dt, assets).values
 
-    def spot_price(self, sid, session, colname):
+    def get_value(self, sid, session, colname):
         # WARNING: This will need caching or other optimization if used in a
         # tight loop.
         # This was developed to complete interface, but has not been tuned

--- a/zipline/data/session_bars.py
+++ b/zipline/data/session_bars.py
@@ -43,7 +43,7 @@ class SessionBarReader(with_metaclass(ABCMeta)):
         pass
 
     @abstractmethod
-    def spot_price(self, sid, session, colname):
+    def get_value(self, sid, session, colname):
         """
         Retrieve the value at the given coordinates.
 

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -686,7 +686,7 @@ class BcolzDailyBarReader(SessionBarReader):
                     day, sid))
         return ix
 
-    def spot_price(self, sid, day, colname):
+    def get_value(self, sid, day, colname):
         """
         Parameters
         ----------
@@ -787,7 +787,7 @@ class PanelBarReader(SessionBarReader):
             list(columns)
         ].reindex(major_axis=cal[cal.slice_indexer(start_dt, end_dt)]).values.T
 
-    def spot_price(self, sid, dt, colname):
+    def get_value(self, sid, dt, colname):
         """
         Parameters
         ----------
@@ -808,8 +808,6 @@ class PanelBarReader(SessionBarReader):
             0.
         """
         return self.panel.loc[sid, dt, colname]
-
-    get_value = spot_price
 
     def get_last_traded_dt(self, sid, dt):
         """
@@ -985,7 +983,7 @@ class SQLiteAdjustmentWriter(object):
             day_loc = calendar.get_loc(ex_date, method='bfill')
             prev_close_date = calendar[day_loc - 1]
             try:
-                prev_close = equity_daily_bar_reader.spot_price(
+                prev_close = equity_daily_bar_reader.get_value(
                     sid, prev_close_date, 'close')
                 if prev_close != 0.0:
                     ratio = 1.0 - amount / prev_close

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -959,7 +959,7 @@ def subtest(iterator, *_names):
 
 
 class MockDailyBarReader(object):
-    def spot_price(self, col, sid, dt):
+    def get_value(self, col, sid, dt):
         return 100
 
 


### PR DESCRIPTION
The daily/session bar reader's `spot_price` took the same parameters and
returned the same kind of output as the minute bar reader's `get_value`.

Standardize on one method to make a common interface, which may be
formally factored out in a later patch; to help enable writing reader
implementations or mixins which can be agnostic to the bar frequency.