### PR TITLE
ENH: Add asset dispatch to data portal.

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1076,6 +1076,7 @@ class TestBeforeTradingStart(WithDataPortal,
 
     DATA_PORTAL_FIRST_TRADING_DAY = pd.Timestamp("2016-01-05", tz='UTC')
     EQUITY_MINUTE_BAR_START_DATE = pd.Timestamp("2016-01-05", tz='UTC')
+    FUTURE_MINUTE_BAR_START_DATE = pd.Timestamp("2016-01-05", tz='UTC')
 
     data_start = ASSET_FINDER_EQUITY_START_DATE = pd.Timestamp(
         '2016-01-05',

--- a/zipline/data/dispatch_bar_reader.py
+++ b/zipline/data/dispatch_bar_reader.py
@@ -72,20 +72,20 @@ class AssetDispatchBarReader(with_metaclass(ABCMeta)):
 
     @lazyval
     def last_available_dt(self):
-        return min(r.last_available_dt for r in self._readers.values)
+        return min(r.last_available_dt for r in self._readers.values())
 
     @lazyval
     def first_trading_day(self):
-        return max(r.first_trading_day for r in self._readers.values)
+        return max(r.first_trading_day for r in self._readers.values())
 
     def get_value(self, sid, dt, field):
-        asset = self.asset_finder.retrieve_asset(sid)
+        asset = self._asset_finder.retrieve_asset(sid)
         r = self._readers[type(asset)]
         return r.get_value(sid, dt, field)
 
     def get_last_traded_dt(self, asset, dt):
         r = self._readers[type(asset)]
-        return r.get_value(asset, dt)
+        return r.get_last_traded_dt(asset, dt)
 
     def load_raw_arrays(self, fields, start_dt, end_dt, sids):
         asset_types = self._asset_types
@@ -128,3 +128,9 @@ class AssetDispatchSessionBarReader(AssetDispatchBarReader):
 
     def _dt_window_size(self, start_dt, end_dt):
         return len(self.trading_calendar.sessions_in_range(start_dt, end_dt))
+
+    @lazyval
+    def sessions(self):
+        return self.trading_calendar.sessions_in_range(
+            self.first_trading_day,
+            self.last_available_dt)

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -55,6 +55,12 @@ class BcolzMinuteWriterColumnMismatch(Exception):
 
 class MinuteBarReader(with_metaclass(ABCMeta)):
 
+    _data_frequency = 'minute'
+
+    @property
+    def data_frequency(self):
+        return self._data_frequency
+
     @abstractproperty
     def last_available_dt(self):
         """

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -523,6 +523,10 @@ class MinuteResampleSessionBarReader(SessionBarReader):
             self._minute_bar_reader.last_available_dt
         )
 
+    @property
+    def first_trading_day(self):
+        return self._minute_bar_reader.first_trading_day
+
 
 class ReindexBarReader(with_metaclass(ABCMeta)):
     """

--- a/zipline/data/session_bars.py
+++ b/zipline/data/session_bars.py
@@ -19,6 +19,12 @@ class SessionBarReader(with_metaclass(ABCMeta)):
     """
     Reader for OHCLV pricing data at a session frequency.
     """
+    _data_frequency = 'session'
+
+    @property
+    def data_frequency(self):
+        return self._data_frequency
+
     @abstractmethod
     def load_raw_arrays(self, columns, start_date, end_date, assets):
         """


### PR DESCRIPTION
Combine the equity and future readers into asset dispatch readers, so
that simulations that use both asset types can access data for each.

This patch enables `history` for future assets in algorithms; however,
it does not add extra coverage in the `test_data_portal` or `test_history`
to cover future assets. Those tests will follow, however putting this in
separately since it shows that the wrapping of the readers in the asset
dispatch reader does not break existing equity strategies.