### PR TITLE
ENH: Adds table_len method to BcolzMinuteBarReader

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -1008,6 +1008,10 @@ class BcolzMinuteBarReader(MinuteBarReader):
 
         return carray
 
+    def table_len(self, sid):
+        """Returns the length of the underlying table for this sid."""
+        return len(self._open_minute_file('close', sid))
+
     def get_sid_attr(self, sid, name):
         sid_subdir = _sid_subdir_path(sid)
         sid_path = os.path.join(self._rootdir, sid_subdir)


### PR DESCRIPTION
To get the length of the underlying table for a given sid.