### PR TITLE
PERF: Reduce calculations performed by empyrical

### DIFF
--- a/conda/empyrical/meta.yaml
+++ b/conda/empyrical/meta.yaml
@@ -1,27 +1,29 @@
 package:
   name: empyrical
-  version: "0.1.9"
+  version: "0.1.10"
 
 source:
-  fn: empyrical-0.1.9.tar.gz
-  url: https://pypi.python.org/packages/15/6b/de1d277d4342d2cecc8134f4935248853f32299cdd9b01728b0ec420c350/empyrical-0.1.9.tar.gz
-  md5: 2c8b928cae192fc9cb8b7104608eec56
+  fn: empyrical-0.1.10.tar.gz
+  url: https://pypi.python.org/packages/2c/b4/658f06c8bc05f847e9ccd6b8131e6e4589bbeb875e239d568a821fd1babc/empyrical-0.1.10.tar.gz
+  md5: cf4439bad083150639ae5b27698c64d4
+
 
 requirements:
   build:
     - python
     - setuptools
-    - numpy x.x
+    - numpy >=1.9.2
     - pandas >=0.16.1
     - scipy >=0.15.1
     - bottleneck >=1.0.0
 
   run:
     - python
-    - numpy x.x
+    - numpy >=1.9.2
     - pandas >=0.16.1
     - scipy >=0.15.1
     - bottleneck >=1.0.0
+
 
 about:
   home: https://github.com/quantopian/empyrical

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -66,4 +66,4 @@ intervaltree==2.1.0
 cachetools==1.1.5
 
 # For financial risk calculations
-empyrical==0.1.9
+empyrical==0.1.10

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -263,7 +263,8 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         )
         self.alpha[dt_loc] = alpha(
             algorithm_returns_series,
-            benchmark_returns_series
+            benchmark_returns_series,
+            _beta=self.beta[dt_loc]
         )
         self.sharpe[dt_loc] = sharpe_ratio(
             algorithm_returns_series,
@@ -275,7 +276,8 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         )
         self.sortino[dt_loc] = sortino_ratio(
             algorithm_returns_series,
-            benchmark_returns_series
+            benchmark_returns_series,
+            _downside_risk=self.downside_risk[dt_loc]
         )
         self.information[dt_loc] = information_ratio(
             algorithm_returns_series,

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -279,9 +279,11 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             risk_adj_returns,
             _downside_risk=self.downside_risk[dt_loc]
         )
+        # 0.0 for the second argument allows the passing of already-adjusted
+        # returns for the first argument.
         self.information[dt_loc] = information_ratio(
-            algorithm_returns_series,
-            benchmark_returns_series
+            risk_adj_returns,
+            0.0
         )
         self.max_drawdown = max_drawdown(
             algorithm_returns_series

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -257,6 +257,9 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         self.excess_returns[dt_loc] = (
             self.algorithm_cumulative_returns[dt_loc] -
             self.treasury_period_return)
+
+        risk_adj_returns = algorithm_returns_series - benchmark_returns_series
+
         self.beta[dt_loc] = beta(
             algorithm_returns_series,
             benchmark_returns_series
@@ -267,16 +270,13 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             _beta=self.beta[dt_loc]
         )
         self.sharpe[dt_loc] = sharpe_ratio(
-            algorithm_returns_series,
-            benchmark_returns_series
+            risk_adj_returns
         )
         self.downside_risk[dt_loc] = downside_risk(
-            algorithm_returns_series,
-            benchmark_returns_series
+            risk_adj_returns
         )
         self.sortino[dt_loc] = sortino_ratio(
-            algorithm_returns_series,
-            benchmark_returns_series,
+            risk_adj_returns,
             _downside_risk=self.downside_risk[dt_loc]
         )
         self.information[dt_loc] = information_ratio(

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -123,13 +123,12 @@ class RiskMetricsPeriod(object):
         # In the meantime, convert nan values to 0.0
         if pd.isnull(self.sharpe):
             self.sharpe = 0.0
+        risk_adj_returns = self.algorithm_returns - self.benchmark_returns
         self.downside_risk = downside_risk(
-            self.algorithm_returns,
-            self.benchmark_returns
+            risk_adj_returns
         )
         self.sortino = sortino_ratio(
-            self.algorithm_returns,
-            self.benchmark_returns,
+            risk_adj_returns,
             _downside_risk=self.downside_risk
         )
         self.information = information_ratio(

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -129,7 +129,8 @@ class RiskMetricsPeriod(object):
         )
         self.sortino = sortino_ratio(
             self.algorithm_returns,
-            self.benchmark_returns
+            self.benchmark_returns,
+            _downside_risk=self.downside_risk
         )
         self.information = information_ratio(
             self.algorithm_returns,
@@ -141,7 +142,8 @@ class RiskMetricsPeriod(object):
         )
         self.alpha = alpha(
             self.algorithm_returns,
-            self.benchmark_returns
+            self.benchmark_returns,
+            _beta=self.beta
         )
         self.excess_return = self.algorithm_period_returns - \
             self.treasury_period_return

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -131,9 +131,11 @@ class RiskMetricsPeriod(object):
             risk_adj_returns,
             _downside_risk=self.downside_risk
         )
+        # 0.0 for the second argument allows the passing of already-adjusted
+        # returns for the first argument.
         self.information = information_ratio(
-            self.algorithm_returns,
-            self.benchmark_returns
+            risk_adj_returns,
+            0.0
         )
         self.beta = beta(
             self.algorithm_returns,


### PR DESCRIPTION
Principally by ...

1. Passing things already computed (e.g. `beta`) into methods that require them (e.g. `alpha`) so they don't re-compute them.
2. Risk-adjust the return stream only once so that empyrical doesn't have to do it separately in each method.

(Opening PR to validate Travis; we need to release a new empyrical to pypi after https://github.com/quantopian/empyrical/pull/27 is merged)