### PR TITLE
ENH: Let event offsets be up to 12 hours.

### DIFF
--- a/tests/events/test_events.py
+++ b/tests/events/test_events.py
@@ -312,6 +312,19 @@ class StatelessRulesTests(RuleTestCase):
                 else:
                     self.assertTrue(should_trigger(minute))
 
+    def test_invalid_offset(self):
+        with self.assertRaises(ValueError):
+            AfterOpen(hours=12, minutes=1)
+
+        with self.assertRaises(ValueError):
+            AfterOpen(hours=0, minutes=0)
+
+        with self.assertRaises(ValueError):
+            BeforeClose(hours=12, minutes=1)
+
+        with self.assertRaises(ValueError):
+            BeforeClose(hours=0, minutes=0)
+
     def test_BeforeClose(self):
         minute_groups = minutes_for_days(self.cal, ordered_days=True)
         should_trigger = self.before_close.should_trigger

--- a/tests/events/test_events_cme.py
+++ b/tests/events/test_events_cme.py
@@ -15,7 +15,9 @@
 from unittest import TestCase
 import pandas as pd
 
-from test_events import StatefulRulesTests, StatelessRulesTests
+from test_events import StatefulRulesTests, StatelessRulesTests, \
+    minutes_for_days
+from zipline.utils.events import AfterOpen
 
 
 class TestStatelessRulesCME(StatelessRulesTests, TestCase):
@@ -23,6 +25,18 @@ class TestStatelessRulesCME(StatelessRulesTests, TestCase):
 
     HALF_SESSION = pd.Timestamp("2014-07-04", tz='UTC')
     FULL_SESSION = pd.Timestamp("2014-09-24", tz='UTC')
+
+    def test_far_after_open(self):
+        minute_groups = minutes_for_days(self.cal, ordered_days=True)
+        after_open = AfterOpen(hours=9, minutes=25)
+        after_open.cal = self.cal
+
+        for session_minutes in minute_groups:
+            for i, minute in enumerate(session_minutes):
+                if i != 564:
+                    self.assertFalse(after_open.should_trigger(minute))
+                else:
+                    self.assertTrue(after_open.should_trigger(minute))
 
 
 class TestStatefulRulesCME(StatefulRulesTests, TestCase):

--- a/zipline/utils/events.py
+++ b/zipline/utils/events.py
@@ -90,12 +90,12 @@ def _out_of_range_error(a, b=None, var='offset'):
 def _td_check(td):
     seconds = td.total_seconds()
 
-    # 23400 seconds is 6 hours and 30 minutes.
-    if 60 <= seconds <= 23400:
+    # 43200 seconds = 12 hours
+    if 60 <= seconds <= 43200:
         return td
     else:
-        raise ValueError('offset must be in between 1 minute and 6 hours and'
-                         ' 30 minutes inclusive')
+        raise ValueError('offset must be in between 1 minute and 12 hours, '
+                         'inclusive.')
 
 
 def _build_offset(offset, kwargs, default):


### PR DESCRIPTION
We used to cap at 6.5 hours, but that's not enough for longer trading sessions like the CME.