### PR TITLE
BUG: Use session label instead of date for 1d.

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -634,7 +634,8 @@ class DataPortal(object):
         Internal method that returns a dataframe containing history bars
         of daily frequency for the given sids.
         """
-        days_for_window = self._get_days_for_window(end_dt.date(), bar_count)
+        session = self.trading_calendar.minute_to_session_label(end_dt)
+        days_for_window = self._get_days_for_window(session, bar_count)
 
         if len(assets) == 0:
             return pd.DataFrame(None,

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -107,12 +107,12 @@ class DailyHistoryAggregator(object):
         self._one_min = pd.Timedelta('1 min').value
 
     def _prelude(self, dt, field):
-        date = dt.date()
+        session = self._trading_calendar.minute_to_session_label(dt)
         dt_value = dt.value
         cache = self._caches[field]
-        if cache is None or cache[0] != date:
-            market_open = self._market_opens.loc[date]
-            cache = self._caches[field] = (dt.date(), market_open, {})
+        if cache is None or cache[0] != session:
+            market_open = self._market_opens.loc[session]
+            cache = self._caches[field] = (session, market_open, {})
 
         _, market_open, entries = cache
         market_open = market_open.tz_localize('UTC')


### PR DESCRIPTION
`1d` history calls were failing on key errors when using the
`us_futures` calendar, because of timestamps occuring before a midnight
would present the wrong midnight (i.e. the midnight before the session,
instead of the following midnight, which is the label for the current
session.)

Tests will follow when bringing up coverage on resample and data portal
modules.