### PR TITLE
Empyrical version update

### DIFF
--- a/conda/empyrical/meta.yaml
+++ b/conda/empyrical/meta.yaml
@@ -1,27 +1,29 @@
 package:
   name: empyrical
-  version: "0.1.9"
+  version: "0.1.10"
 
 source:
-  fn: empyrical-0.1.9.tar.gz
-  url: https://pypi.python.org/packages/15/6b/de1d277d4342d2cecc8134f4935248853f32299cdd9b01728b0ec420c350/empyrical-0.1.9.tar.gz
-  md5: 2c8b928cae192fc9cb8b7104608eec56
+  fn: empyrical-0.1.10.tar.gz
+  url: https://pypi.python.org/packages/2c/b4/658f06c8bc05f847e9ccd6b8131e6e4589bbeb875e239d568a821fd1babc/empyrical-0.1.10.tar.gz
+  md5: cf4439bad083150639ae5b27698c64d4
+
 
 requirements:
   build:
     - python
     - setuptools
-    - numpy x.x
+    - numpy >=1.9.2
     - pandas >=0.16.1
     - scipy >=0.15.1
     - bottleneck >=1.0.0
 
   run:
     - python
-    - numpy x.x
+    - numpy >=1.9.2
     - pandas >=0.16.1
     - scipy >=0.15.1
     - bottleneck >=1.0.0
+
 
 about:
   home: https://github.com/quantopian/empyrical

--- a/conda/empyrical/meta.yaml
+++ b/conda/empyrical/meta.yaml
@@ -1,12 +1,11 @@
 package:
   name: empyrical
-  version: "0.1.10"
+  version: "0.1.11"
 
 source:
-  fn: empyrical-0.1.10.tar.gz
-  url: https://pypi.python.org/packages/2c/b4/658f06c8bc05f847e9ccd6b8131e6e4589bbeb875e239d568a821fd1babc/empyrical-0.1.10.tar.gz
-  md5: cf4439bad083150639ae5b27698c64d4
-
+  fn: empyrical-0.1.11.tar.gz
+  url: https://pypi.python.org/packages/df/82/c4050b0fe341db97430b2de7ae736d89a2ddb78636d3e0235aef1b7499d5/empyrical-0.1.11.tar.gz
+  md5: fbd543416d204688146f13f325ca8731
 
 requirements:
   build:

--- a/conda/empyrical/meta.yaml
+++ b/conda/empyrical/meta.yaml
@@ -12,14 +12,14 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.9.2
+    - numpy x.x
     - pandas >=0.16.1
     - scipy >=0.15.1
     - bottleneck >=1.0.0
 
   run:
     - python
-    - numpy >=1.9.2
+    - numpy x.x
     - pandas >=0.16.1
     - scipy >=0.15.1
     - bottleneck >=1.0.0

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -66,4 +66,4 @@ intervaltree==2.1.0
 cachetools==1.1.5
 
 # For financial risk calculations
-empyrical==0.1.9
+empyrical==0.1.10

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -66,4 +66,4 @@ intervaltree==2.1.0
 cachetools==1.1.5
 
 # For financial risk calculations
-empyrical==0.1.10
+empyrical==0.1.11

--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -61,7 +61,7 @@ NYSE_MINUTES = OrderedDict((
 ))
 
 
-CME_MINUTES = OrderedDict((
+FUT_MINUTES = OrderedDict((
     ('day_0_front', pd.date_range('2016-03-15 18:01',
                                   '2016-03-15 18:03',
                                   freq='min',
@@ -141,7 +141,7 @@ FUTURE_CASES = OrderedDict()
 
 for sid, combos in _FUTURE_CASES:
     frames = [DataFrame(SCENARIOS[s], columns=OHLCV).
-              set_index(CME_MINUTES[m])
+              set_index(FUT_MINUTES[m])
               for s, m in combos]
     FUTURE_CASES[sid] = pd.concat(frames)
 
@@ -463,8 +463,8 @@ class TestMinuteToSession(WithEquityMinuteBarData,
 class TestResampleSessionBars(WithBcolzFutureMinuteBarReader,
                               ZiplineTestCase):
 
-    TRADING_CALENDAR_STRS = ('CME',)
-    TRADING_CALENDAR_PRIMARY_CAL = 'CME'
+    TRADING_CALENDAR_STRS = ('us_futures',)
+    TRADING_CALENDAR_PRIMARY_CAL = 'us_futures'
 
     ASSET_FINDER_FUTURE_SIDS = 1001, 1002, 1003
 
@@ -540,8 +540,8 @@ class TestResampleSessionBars(WithBcolzFutureMinuteBarReader,
 class TestReindexMinuteBars(WithBcolzEquityMinuteBarReader,
                             ZiplineTestCase):
 
-    TRADING_CALENDAR_STRS = ('CME', 'NYSE')
-    TRADING_CALENDAR_PRIMARY_CAL = 'CME'
+    TRADING_CALENDAR_STRS = ('us_futures', 'NYSE')
+    TRADING_CALENDAR_PRIMARY_CAL = 'us_futures'
 
     ASSET_FINDER_EQUITY_SIDS = 1, 2, 3
 
@@ -609,12 +609,13 @@ class TestReindexMinuteBars(WithBcolzEquityMinuteBarReader,
 class TestReindexSessionBars(WithBcolzEquityDailyBarReader,
                              ZiplineTestCase):
 
-    TRADING_CALENDAR_STRS = ('CME', 'NYSE')
-    TRADING_CALENDAR_PRIMARY_CAL = 'CME'
+    TRADING_CALENDAR_STRS = ('us_futures', 'NYSE')
+    TRADING_CALENDAR_PRIMARY_CAL = 'us_futures'
 
     ASSET_FINDER_EQUITY_SIDS = 1, 2, 3
 
-    # Dates are chosen to span Thanksgiving, which is not a Holiday on CME.
+    # Dates are chosen to span Thanksgiving, which is not a Holiday on
+    # us_futures.
     START_DATE = pd.Timestamp('2015-11-01', tz='UTC')
     END_DATE = pd.Timestamp('2015-11-30', tz='UTC')
 
@@ -648,7 +649,7 @@ class TestReindexSessionBars(WithBcolzEquityDailyBarReader,
             "because Thanksgiving is a NYSE holiday.")
 
         # Thanksgiving, 2015-11-26.
-        # Is a holiday in NYSE, but not in CME.
+        # Is a holiday in NYSE, but not in us_futures.
         tday_loc = outer_sessions.get_loc(pd.Timestamp('2015-11-26', tz='UTC'))
 
         assert_almost_equal(

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -263,7 +263,8 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         )
         self.alpha[dt_loc] = alpha(
             algorithm_returns_series,
-            benchmark_returns_series
+            benchmark_returns_series,
+            _beta=self.beta[dt_loc]
         )
         self.sharpe[dt_loc] = sharpe_ratio(
             algorithm_returns_series,
@@ -275,7 +276,8 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         )
         self.sortino[dt_loc] = sortino_ratio(
             algorithm_returns_series,
-            benchmark_returns_series
+            benchmark_returns_series,
+            _downside_risk=self.downside_risk[dt_loc]
         )
         self.information[dt_loc] = information_ratio(
             algorithm_returns_series,

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -279,9 +279,11 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             risk_adj_returns,
             _downside_risk=self.downside_risk[dt_loc]
         )
+        # 0.0 for the second argument allows the passing of already-adjusted
+        # returns for the first argument.
         self.information[dt_loc] = information_ratio(
-            algorithm_returns_series,
-            benchmark_returns_series
+            risk_adj_returns,
+            0.0
         )
         self.max_drawdown = max_drawdown(
             algorithm_returns_series

--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -257,6 +257,9 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
         self.excess_returns[dt_loc] = (
             self.algorithm_cumulative_returns[dt_loc] -
             self.treasury_period_return)
+
+        risk_adj_returns = algorithm_returns_series - benchmark_returns_series
+
         self.beta[dt_loc] = beta(
             algorithm_returns_series,
             benchmark_returns_series
@@ -267,16 +270,13 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             _beta=self.beta[dt_loc]
         )
         self.sharpe[dt_loc] = sharpe_ratio(
-            algorithm_returns_series,
-            benchmark_returns_series
+            risk_adj_returns
         )
         self.downside_risk[dt_loc] = downside_risk(
-            algorithm_returns_series,
-            benchmark_returns_series
+            risk_adj_returns
         )
         self.sortino[dt_loc] = sortino_ratio(
-            algorithm_returns_series,
-            benchmark_returns_series,
+            risk_adj_returns,
             _downside_risk=self.downside_risk[dt_loc]
         )
         self.information[dt_loc] = information_ratio(

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -123,13 +123,12 @@ class RiskMetricsPeriod(object):
         # In the meantime, convert nan values to 0.0
         if pd.isnull(self.sharpe):
             self.sharpe = 0.0
+        risk_adj_returns = self.algorithm_returns - self.benchmark_returns
         self.downside_risk = downside_risk(
-            self.algorithm_returns,
-            self.benchmark_returns
+            risk_adj_returns
         )
         self.sortino = sortino_ratio(
-            self.algorithm_returns,
-            self.benchmark_returns,
+            risk_adj_returns,
             _downside_risk=self.downside_risk
         )
         self.information = information_ratio(

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -129,7 +129,8 @@ class RiskMetricsPeriod(object):
         )
         self.sortino = sortino_ratio(
             self.algorithm_returns,
-            self.benchmark_returns
+            self.benchmark_returns,
+            _downside_risk=self.downside_risk
         )
         self.information = information_ratio(
             self.algorithm_returns,
@@ -141,7 +142,8 @@ class RiskMetricsPeriod(object):
         )
         self.alpha = alpha(
             self.algorithm_returns,
-            self.benchmark_returns
+            self.benchmark_returns,
+            _beta=self.beta
         )
         self.excess_return = self.algorithm_period_returns - \
             self.treasury_period_return

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -131,9 +131,11 @@ class RiskMetricsPeriod(object):
             risk_adj_returns,
             _downside_risk=self.downside_risk
         )
+        # 0.0 for the second argument allows the passing of already-adjusted
+        # returns for the first argument.
         self.information = information_ratio(
-            self.algorithm_returns,
-            self.benchmark_returns
+            risk_adj_returns,
+            0.0
         )
         self.beta = beta(
             self.algorithm_returns,


### PR DESCRIPTION
Update to version 0.1.11 of empyrical. This version fixes the previous incorrect calculation of beta. Example data is rebuilt and the conda recipe has been updated.