### PR TITLE
Empyrical v update

### DIFF
--- a/conda/empyrical/meta.yaml
+++ b/conda/empyrical/meta.yaml
@@ -1,12 +1,11 @@
 package:
   name: empyrical
-  version: "0.1.10"
+  version: "0.1.11"
 
 source:
-  fn: empyrical-0.1.10.tar.gz
-  url: https://pypi.python.org/packages/2c/b4/658f06c8bc05f847e9ccd6b8131e6e4589bbeb875e239d568a821fd1babc/empyrical-0.1.10.tar.gz
-  md5: cf4439bad083150639ae5b27698c64d4
-
+  fn: empyrical-0.1.11.tar.gz
+  url: https://pypi.python.org/packages/df/82/c4050b0fe341db97430b2de7ae736d89a2ddb78636d3e0235aef1b7499d5/empyrical-0.1.11.tar.gz
+  md5: fbd543416d204688146f13f325ca8731
 
 requirements:
   build:

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -66,4 +66,4 @@ intervaltree==2.1.0
 cachetools==1.1.5
 
 # For financial risk calculations
-empyrical==0.1.10
+empyrical==0.1.11


### PR DESCRIPTION
Previous version of empyrical calculates beta incorrectly. Update the conda recipe, as well as the example data used in testing.