### PR TITLE
ENH: Simplified implementation of FutureChain object (not user-facing API)

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -726,9 +726,51 @@ def log_nyse_close(context, data):
         with self.assertRaises(TypeError):
             algo.future_symbol({'foo': 'bar'})
 
+    def test_future_chain_offset(self):
+        # November 2006         December 2006
+        # Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa
+        #           1  2  3  4                  1  2
+        #  5  6  7  8  9 10 11   3  4  5  6  7  8  9
+        # 12 13 14 15 16 17 18  10 11 12 13 14 15 16
+        # 19 20 21 22 23 24 25  17 18 19 20 21 22 23
+        # 26 27 28 29 30        24 25 26 27 28 29 30
+        #                       31
+
+        algo = TradingAlgorithm(env=self.env)
+        algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
+
+        self.assertEqual(
+            algo.future_chain('CL', offset=1).as_of_date,
+            pd.Timestamp("2006-12-04", tz='UTC')
+        )
+
+        self.assertEqual(
+            algo.future_chain("CL", offset=5).as_of_date,
+            pd.Timestamp("2006-12-08", tz='UTC')
+        )
+
+        self.assertEqual(
+            algo.future_chain("CL", offset=-10).as_of_date,
+            pd.Timestamp("2006-11-16", tz='UTC')
+        )
+
+        # September 2016
+        # Su Mo Tu We Th Fr Sa
+        #              1  2  3
+        #  4  5  6  7  8  9 10
+        # 11 12 13 14 15 16 17
+        # 18 19 20 21 22 23 24
+        # 25 26 27 28 29 30
+        self.assertEqual(
+            algo.future_chain(
+                "CL",
+                as_of_date=pd.Timestamp("2016-08-31", tz='UTC'),
+                offset=10
+            ).as_of_date,
+            pd.Timestamp("2016-09-15", tz='UTC')
+        )
+
     def test_future_chain(self):
-        """ Tests the future_chain API function.
-        """
         algo = TradingAlgorithm(env=self.env)
         algo.datetime = pd.Timestamp('2006-12-01', tz='UTC')
 

--- a/zipline/assets/futures.py
+++ b/zipline/assets/futures.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Quantopian, Inc.
+# Copyright 2016 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,173 +13,86 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pandas import Timestamp, Timedelta
-from pandas.tseries.tools import normalize_date
+from pandas import Timestamp
+
+from zipline.utils.input_validation import expect_types
 
 
 class FutureChain(object):
-    """ Allows users to look up future contracts.
+    """
+    Allows users to look up future contracts.
 
     Parameters
     ----------
-    asset_finder : AssetFinder
-        An AssetFinder for future contract lookups, in particular the
-        AssetFinder of the TradingAlgorithm instance.
-    get_datetime : function
-        A function that returns the simulation datetime, in particular
-        the get_datetime method of the TradingAlgorithm instance.
     root_symbol : str
         The root symbol of a future chain.
-    as_of_date : pandas.Timestamp, optional
+    as_of_date : pandas.Timestamp
         Date at which the chain determination is rooted. I.e. the
         existing contract whose notice date is first after this date is
-        the primary contract, etc. If not provided, the current
-        simulation date is used as the as_of_date.
+        the primary contract, etc.
+    chain: list
+        List of assets that represent the chain of contracts for the given
+        root symbol at the given as_of_date.
 
     Attributes
     ----------
     root_symbol : str
         The root symbol of the future chain.
-    as_of_date
+    as_of_date: Timestamp
         The current as-of date of this future chain.
-
-    Methods
-    -------
-    as_of(dt)
-    offset(time_delta)
-
-    Raises
-    ------
-    RootSymbolNotFound
-        Raised when the FutureChain is initialized with a root symbol for which
-        a future chain could not be found.
     """
-    def __init__(self, asset_finder, get_datetime, root_symbol,
-                 as_of_date=None):
-        self.root_symbol = root_symbol
-
-        # Reference to the algo's AssetFinder for contract lookups
-        self._asset_finder = asset_finder
-        # Reference to the algo's get_datetime to know the current dt
-        self._algorithm_get_datetime = get_datetime
-
-        # If an as_of_date is provided, self._as_of_date uses that
-        # value, otherwise None. This attribute backs the as_of_date property.
-        if as_of_date:
-            self._as_of_date = normalize_date(as_of_date)
-        else:
-            self._as_of_date = None
-
-        # Attribute to cache the most up-to-date chain, and the dt when it was
-        # last updated.
-        self._current_chain = []
-        self._last_updated = None
-
-        # Get the initial chain, since self._last_updated is None.
-        self._maybe_update_current_chain()
+    @expect_types(root_symbol=str, as_of_date=Timestamp)
+    def __init__(self, root_symbol, as_of_date, contracts):
+        self._root_symbol = root_symbol
+        self._as_of_date = as_of_date
+        self._contracts = contracts
 
     def __repr__(self):
-        # NOTE: The string returned cannot be used to instantiate this
-        # exact FutureChain, since we don't want to display the asset
-        # finder and get_datetime function to the user.
-        if self._as_of_date:
-            return "FutureChain(root_symbol='%s', as_of_date='%s')" % (
-                self.root_symbol, self.as_of_date)
-        else:
-            return "FutureChain(root_symbol='%s')" % self.root_symbol
+        return "FutureChain('%s', '%s')" % (
+            self.root_symbol, self.as_of_date.strftime('%Y-%m-%d'))
 
-    def _get_datetime(self):
+    @property
+    def root_symbol(self):
         """
-        Returns the normalized simulation datetime.
+        The root symbol for this future chain.
 
         Returns
         -------
-        pandas.Timestamp
-            The normalized datetime of FutureChain's TradingAlgorithm.
+        root_symbol: str
+            The root symbol for this chain.
         """
-        return normalize_date(
-            Timestamp(self._algorithm_get_datetime(), tz='UTC')
-        )
+        return self._root_symbol
 
     @property
     def as_of_date(self):
         """
-        The current as-of date of this future chain.
+        The as-of date of this future chain.
 
         Returns
         -------
-        pandas.Timestamp
-            The user-provided as_of_date if given, otherwise the
-            current datetime of the simulation.
+        as_of_date: pd.Timestamp
+            The as_of date for this chain.
         """
-        if self._as_of_date is not None:
-            return self._as_of_date
-        else:
-            return self._get_datetime()
+        return self._as_of_date
 
-    def _maybe_update_current_chain(self):
-        """ Updates the current chain if it's out of date, then returns
-            it.
-
-            Returns
-            -------
-            list
-                The up-to-date current chain, a list of Future objects.
+    @property
+    def contracts(self):
         """
-        if (self._last_updated is None)\
-                or (self._last_updated != self.as_of_date):
-            self._current_chain = self._asset_finder.lookup_future_chain(
-                self.root_symbol,
-                self.as_of_date
-            )
-            self._last_updated = self.as_of_date
-
-        return self._current_chain
+        Returns
+        -------
+        contracts: list
+            The contracts wrapped by this chain.
+        """
+        return list(self._contracts)
 
     def __getitem__(self, key):
-        return self._maybe_update_current_chain()[key]
+        return self._contracts[key]
 
     def __len__(self):
-        return len(self._maybe_update_current_chain())
+        return len(self._contracts)
 
     def __iter__(self):
-        return iter(self._maybe_update_current_chain())
-
-    def as_of(self, dt):
-        """ Get the future chain for this root symbol as of a specific date.
-
-        Parameters
-        ----------
-        dt : datetime.datetime or pandas.Timestamp or str, optional
-            The as_of_date for the new chain.
-
-        Returns
-        -------
-        FutureChain
-
-        """
-        return FutureChain(
-            asset_finder=self._asset_finder,
-            get_datetime=self._algorithm_get_datetime,
-            root_symbol=self.root_symbol,
-            as_of_date=Timestamp(dt, tz='UTC'),
-        )
-
-    def offset(self, time_delta):
-        """ Get the future chain for this root symbol with a given
-        offset from the current as_of_date.
-
-        Parameters
-        ----------
-        time_delta : datetime.timedelta or pandas.Timedelta or str
-            The offset from the current as_of_date for the new chain.
-
-        Returns
-        -------
-        FutureChain
-
-        """
-        return self.as_of(self.as_of_date + Timedelta(time_delta))
+        return iter(self._contracts)
 
 
 # http://www.cmegroup.com/product-codes-listing/month-codes.html


### PR DESCRIPTION
No longer auto-updates its internal as-of date, instead requires an explicit
as-of date from the consumer.

Take a static list of contracts (instead of needing an assetfinder).

Instead of the as_of method, the user-facing API now lets you pass in an
offset, which is defined as an integral number of sessions.