### PR TITLE
TST: Fix get_last_traded_dt on bcolz daily reader.

### DIFF
--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest import skip
-
 from collections import OrderedDict
 from numbers import Real
 
@@ -666,10 +664,6 @@ class TestReindexSessionBars(WithBcolzEquityDailyBarReader,
     def test_last_availabe_dt(self):
         self.assertEqual(self.reader.last_available_dt, self.END_DATE)
 
-    @skip("This test revealed a bug in BcolzDailyBarReader.get_last_traded_dt."
-          " When requesting data on the last session of an asset, the date is "
-          "overriden by the previous day. When that errant handling is this "
-          "test should be enabled.")
     def test_get_last_traded_dt(self):
         asset = self.asset_finder.retrieve_asset(1)
         self.assertEqual(self.reader.get_last_traded_dt(asset,

--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -30,7 +30,8 @@ from pandas.util.testing import assert_index_equal
 
 from zipline.data.us_equity_pricing import (
     BcolzDailyBarReader,
-    NoDataOnDate,
+    NoDataBeforeDate,
+    NoDataAfterDate,
 )
 from zipline.pipeline.loaders.synthetic import (
     OHLCV,
@@ -316,11 +317,11 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, ZiplineTestCase):
         table = self.bcolz_daily_bar_ctable
         reader = BcolzDailyBarReader(table)
         # before
-        with self.assertRaises(NoDataOnDate):
+        with self.assertRaises(NoDataBeforeDate):
             reader.get_value(2, Timestamp('2015-06-08', tz='UTC'), 'close')
 
         # after
-        with self.assertRaises(NoDataOnDate):
+        with self.assertRaises(NoDataAfterDate):
             reader.get_value(4, Timestamp('2015-06-16', tz='UTC'), 'close')
 
     def test_unadjusted_get_value_empty_value(self):


### PR DESCRIPTION
Remove special handling for the last session of an asset, which was
moving the last traded back a session.

If the asset has data on a session, `get_last_traded_dt` should always
return that session if it is the parameter to the method.