### PR TITLE
TST/BUG: Cover all reindex session public methods.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,5 @@
 omit =
     */python?.?/*
     */site-packages/nose/*
+exclude_lines =
+    raise NotImplementedError

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -15,11 +15,13 @@ from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
+from numpy import nan
 import pandas as pd
 from pandas import DataFrame
 from six import with_metaclass
 
 from zipline.data.minute_bars import MinuteBarReader
+from zipline.data.us_equity_pricing import NoDataOnDate
 from zipline.data.session_bars import SessionBarReader
 from zipline.utils.memoize import lazyval
 
@@ -584,15 +586,21 @@ class ReindexBarReader(with_metaclass(ABCMeta)):
         return self._reader.first_trading_day
 
     def get_value(self, sid, dt, field):
-        return self._reader.get_value(sid, dt, field)
+        try:
+            return self._reader.get_value(sid, dt, field)
+        except NoDataOnDate:
+            if field == 'volume':
+                return 0
+            else:
+                return nan
 
     @abstractmethod
     def _outer_dts(self, start_dt, end_dt):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def _inner_dts(self, start_dt, end_dt):
-        pass
+        raise NotImplementedError
 
     @property
     def trading_calendar(self):

--- a/zipline/data/session_bars.py
+++ b/zipline/data/session_bars.py
@@ -15,6 +15,21 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from six import with_metaclass
 
 
+class NoDataOnDate(Exception):
+    """
+    Raised when a spot price can be found for the sid and date.
+    """
+    pass
+
+
+class NoDataBeforeDate(Exception):
+    pass
+
+
+class NoDataAfterDate(Exception):
+    pass
+
+
 class SessionBarReader(with_metaclass(ABCMeta)):
     """
     Reader for OHCLV pricing data at a session frequency.

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -49,7 +49,12 @@ from six import (
     string_types,
 )
 
-from zipline.data.session_bars import SessionBarReader
+from zipline.data.session_bars import (
+    SessionBarReader,
+    NoDataAfterDate,
+    NoDataBeforeDate,
+    NoDataOnDate,
+)
 from zipline.utils.calendars import get_calendar
 from zipline.utils.functional import apply
 from zipline.utils.preprocess import call
@@ -97,21 +102,6 @@ SQLITE_STOCK_DIVIDEND_PAYOUT_COLUMN_DTYPES = {
     'ratio': float,
 }
 UINT32_MAX = iinfo(uint32).max
-
-
-class NoDataOnDate(Exception):
-    """
-    Raised when a spot price can be found for the sid and date.
-    """
-    pass
-
-
-class NoDataBeforeDate(Exception):
-    pass
-
-
-class NoDataAfterDate(Exception):
-    pass
 
 
 def check_uint32_safe(value, colname):


### PR DESCRIPTION
Increase coverage on `ReindexSessionBarReader` so that all methods which
are considered part of the interface are covered by `test_resample`.

Fix bug in `get_value`, exposed by increased coverage, where the
`NoDataOnDate` exception was bubbling from the bcolz reader all the way
up when a session which was a holidy on the underlying reader was passed
to the reindex reader. (The reindex reader should return nan/0 in that
case.)

Also, move location of data index exceptions so that they are agnostic
to bcolz/us_equity_pricing; since the exception is now used by the
resample module to fix aforementioned bug.