### PR TITLE
BUG/ENH: Fix behavior of 'target' capital changes

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -2167,7 +2167,7 @@ class TestCapitalChanges(WithLogger,
         )
 
     @parameterized.expand([
-        ('target', 153000.0), ('delta', 50000.0)
+        ('target', 127000.0), ('delta', 50000.0)
     ])
     def test_capital_changes_daily_mode(self, change_type, value):
         sim_params = factory.create_simulation_parameters(
@@ -2215,8 +2215,9 @@ def order_stuff(context, data):
             capital_change_packets[0],
             {'date': pd.Timestamp('2006-01-06', tz='UTC'),
              'type': 'cash',
-             'target': 153000.0 if change_type == 'target' else None,
-             'delta': 50000.0})
+             'target': value if change_type == 'target' else None,
+             'delta': 50000.0
+            })
 
         # 1/03: price = 10, place orders
         # 1/04: orders execute at price = 11, place orders
@@ -2320,10 +2321,10 @@ def order_stuff(context, data):
         )
 
     @parameterized.expand([
-        ('interday_target', [('2006-01-04', 2388.0)]),
+        ('interday_target', [('2006-01-04', 1899.0)]),
         ('interday_delta', [('2006-01-04', 1000.0)]),
-        ('intraday_target', [('2006-01-04 17:00', 2186.0),
-                             ('2006-01-04 18:00', 2806.0)]),
+        ('intraday_target', [('2006-01-04 17:00', 908.0),
+                             ('2006-01-04 18:00', 1408.0)]),
         ('intraday_delta', [('2006-01-04 17:00', 500.0),
                             ('2006-01-04 18:00', 500.0)]),
     ])
@@ -2486,10 +2487,10 @@ def order_stuff(context, data):
             )
 
     @parameterized.expand([
-        ('interday_target', [('2006-01-04', 2388.0)]),
+        ('interday_target', [('2006-01-04', 1899.0)]),
         ('interday_delta', [('2006-01-04', 1000.0)]),
-        ('intraday_target', [('2006-01-04 17:00', 2186.0),
-                             ('2006-01-04 18:00', 2806.0)]),
+        ('intraday_target', [('2006-01-04 17:00', 908.0),
+                             ('2006-01-04 18:00', 1408.0)]),
         ('intraday_delta', [('2006-01-04 17:00', 500.0),
                             ('2006-01-04 18:00', 500.0)]),
     ])

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -2217,7 +2217,7 @@ def order_stuff(context, data):
              'type': 'cash',
              'target': value if change_type == 'target' else None,
              'delta': 50000.0
-            })
+             })
 
         # 1/03: price = 10, place orders
         # 1/04: orders execute at price = 11, place orders

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -825,12 +825,17 @@ class TradingAlgorithm(object):
 
         return daily_stats
 
-    def calculate_capital_changes(self, dt, emission_rate, is_interday):
+    def calculate_capital_changes(self, dt, emission_rate, is_interday,
+                                  portfolio_value_adjustment=0.0):
         """
         If there is a capital change for a given dt, this means the the change
         occurs before `handle_data` on the given dt. In the case of the
         change being a target value, the change will be computed on the
         portfolio value according to prices at the given dt
+
+        `portfolio_value_adjustment`, if specified, will be removed from the
+        portfolio_value of the cumulative performance when calculating deltas
+        from target capital changes.
         """
         try:
             capital_change = self.capital_changes[dt]
@@ -852,13 +857,12 @@ class TradingAlgorithm(object):
                 False,
                 self.data_portal
             )
-
         self.perf_tracker.prepare_capital_change(is_interday)
 
         if capital_change['type'] == 'target':
             target = capital_change['value']
             capital_change_amount = target - \
-                self.updated_portfolio().cash
+                (self.updated_portfolio().cash - portfolio_value_adjustment)
             self.portfolio_needs_update = True
 
             log.info('Processing capital change to target %s at %s. Capital '

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -858,7 +858,7 @@ class TradingAlgorithm(object):
         if capital_change['type'] == 'target':
             target = capital_change['value']
             capital_change_amount = target - \
-                self.updated_portfolio().portfolio_value
+                self.updated_portfolio().cash
             self.portfolio_needs_update = True
 
             log.info('Processing capital change to target %s at %s. Capital '


### PR DESCRIPTION
The calculation of the "delta" from a given "target" value for a capital change was doing `delta = target - portfolio_value`. That's not right - the value of any portfolio holdings is irrelevant when adding or removing real cash from the algorithm. I corrected it to `delta = target - cash`; this broke a number of tests. I modified the 'target' input values so that it matched the behavior of the corresponding 'delta' test.

Also adds a new parameter that can be passed to `calculate_capital_changes` to remove additional value from the cash value pulled from the current cumulative performance period. (In case there are additional influences on the cash value that need to be removed to get an accurate calculation)