### PR TITLE
TST/BUG: Full coverage on resample module.

### DIFF
--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -248,7 +248,7 @@ class DailyHistoryAggregator(object):
                             dt,
                             [asset],
                         )[0].T
-                        val = max(last_max, np.nanmax(window))
+                        val = np.nanmax(np.append(window, last_max))
                         entries[asset] = (dt_value, val)
                         highs.append(val)
                         continue
@@ -312,11 +312,7 @@ class DailyHistoryAggregator(object):
                             dt,
                             [asset],
                         )[0].T
-                        window_min = np.nanmin(window)
-                        if pd.isnull(window_min):
-                            val = last_min
-                        else:
-                            val = min(last_min, window_min)
+                        val = np.nanmin(np.append(window, last_min))
                         entries[asset] = (dt_value, val)
                         lows.append(val)
                         continue


### PR DESCRIPTION
test_resample now fully covers the resample module.

Fix a bug exposed by increased coverage, where daily aggregation on
`high` would return `nan` for an asset instead of 1) during the
course of day `1d` history was called on non-consecutive minutes and 2)
either, a) the value for the previously inspected dt was `nan` or b)
there were only `nan`s between the previous and current dt.

`low` had a similar bug which was only triggered if the value for the
previously inspected dt was `nan`.