### PR TITLE
Symbol lookup raises

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -648,7 +648,7 @@ class AssetFinder(object):
 
         if not options:
             # no equity owned the fuzzy symbol on the date requested
-            SymbolNotFound(symbol=symbol)
+            raise SymbolNotFound(symbol=symbol)
 
         if len(options) == 1:
             # there was only one owner, return it
@@ -703,6 +703,10 @@ class AssetFinder(object):
             there are multiple candidates for the given ``symbol`` on the
             ``as_of_date``.
         """
+        if symbol is None:
+            raise TypeError("Cannot lookup symbol of type NoneType for "
+                            "as of date %s" % as_of_date)
+
         if fuzzy:
             return self._lookup_symbol_fuzzy(symbol, as_of_date)
         return self._lookup_symbol_strict(symbol, as_of_date)

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -650,7 +650,7 @@ class AssetFinder(object):
             # no equity owned the fuzzy symbol on the date requested
             raise SymbolNotFound(symbol=symbol)
 
-        sid_keys = options.keys()
+        sid_keys = list(options.keys())
         # If there was only one owner, or there is a fuzzy and non-fuzzy which
         # map to the same sid, return it.
         if len(options) == 1:


### PR DESCRIPTION
- Correctly raises SymbolNotFound in fuzzy symbol lookup.
- Adds checking against NoneType (useful in case someone vectorizes across a series, one of which is a None)
- If asset file has two symbols which map to the same sid (SYM_B, and SYMB), should not raise a MultipleSymbolError, should just return the correct equity object for the sid.