### PR TITLE
BUG: Do not adjust returns for sharpe and sortino

### DIFF
--- a/zipline/finance/risk/cumulative.py
+++ b/zipline/finance/risk/cumulative.py
@@ -258,8 +258,6 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             self.algorithm_cumulative_returns[dt_loc] -
             self.treasury_period_return)
 
-        risk_adj_returns = algorithm_returns_series - benchmark_returns_series
-
         self.beta[dt_loc] = beta(
             algorithm_returns_series,
             benchmark_returns_series
@@ -270,20 +268,18 @@ algorithm_returns ({algo_count}) in range {start} : {end} on {dt}"
             _beta=self.beta[dt_loc]
         )
         self.sharpe[dt_loc] = sharpe_ratio(
-            risk_adj_returns
+            algorithm_returns_series
         )
         self.downside_risk[dt_loc] = downside_risk(
-            risk_adj_returns
+            algorithm_returns_series
         )
         self.sortino[dt_loc] = sortino_ratio(
-            risk_adj_returns,
+            algorithm_returns_series,
             _downside_risk=self.downside_risk[dt_loc]
         )
-        # 0.0 for the second argument allows the passing of already-adjusted
-        # returns for the first argument.
         self.information[dt_loc] = information_ratio(
-            risk_adj_returns,
-            0.0
+            algorithm_returns_series,
+            benchmark_returns_series
         )
         self.max_drawdown = max_drawdown(
             algorithm_returns_series

--- a/zipline/finance/risk/period.py
+++ b/zipline/finance/risk/period.py
@@ -123,19 +123,16 @@ class RiskMetricsPeriod(object):
         # In the meantime, convert nan values to 0.0
         if pd.isnull(self.sharpe):
             self.sharpe = 0.0
-        risk_adj_returns = self.algorithm_returns - self.benchmark_returns
         self.downside_risk = downside_risk(
-            risk_adj_returns
+            self.algorithm_returns
         )
         self.sortino = sortino_ratio(
-            risk_adj_returns,
+            self.algorithm_returns,
             _downside_risk=self.downside_risk
         )
-        # 0.0 for the second argument allows the passing of already-adjusted
-        # returns for the first argument.
         self.information = information_ratio(
-            risk_adj_returns,
-            0.0
+            self.algorithm_returns,
+            self.benchmark_returns
         )
         self.beta = beta(
             self.algorithm_returns,


### PR DESCRIPTION
Remove variable `risk_adj_returns`. Neither sharpe nor sortino require risk adjusted returns. Information ratio can create adjusted returns as necessary.