### PR TITLE
Revert "BUG: Capital change deltas rely on cash, not portfolio_value"

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -2167,7 +2167,7 @@ class TestCapitalChanges(WithLogger,
         )
 
     @parameterized.expand([
-        ('target', 127000.0), ('delta', 50000.0)
+        ('target', 153000.0), ('delta', 50000.0)
     ])
     def test_capital_changes_daily_mode(self, change_type, value):
         sim_params = factory.create_simulation_parameters(
@@ -2215,9 +2215,8 @@ def order_stuff(context, data):
             capital_change_packets[0],
             {'date': pd.Timestamp('2006-01-06', tz='UTC'),
              'type': 'cash',
-             'target': value if change_type == 'target' else None,
-             'delta': 50000.0
-             })
+             'target': 153000.0 if change_type == 'target' else None,
+             'delta': 50000.0})
 
         # 1/03: price = 10, place orders
         # 1/04: orders execute at price = 11, place orders
@@ -2321,10 +2320,10 @@ def order_stuff(context, data):
         )
 
     @parameterized.expand([
-        ('interday_target', [('2006-01-04', 1899.0)]),
+        ('interday_target', [('2006-01-04', 2388.0)]),
         ('interday_delta', [('2006-01-04', 1000.0)]),
-        ('intraday_target', [('2006-01-04 17:00', 908.0),
-                             ('2006-01-04 18:00', 1408.0)]),
+        ('intraday_target', [('2006-01-04 17:00', 2186.0),
+                             ('2006-01-04 18:00', 2806.0)]),
         ('intraday_delta', [('2006-01-04 17:00', 500.0),
                             ('2006-01-04 18:00', 500.0)]),
     ])
@@ -2487,10 +2486,10 @@ def order_stuff(context, data):
             )
 
     @parameterized.expand([
-        ('interday_target', [('2006-01-04', 1899.0)]),
+        ('interday_target', [('2006-01-04', 2388.0)]),
         ('interday_delta', [('2006-01-04', 1000.0)]),
-        ('intraday_target', [('2006-01-04 17:00', 908.0),
-                             ('2006-01-04 18:00', 1408.0)]),
+        ('intraday_target', [('2006-01-04 17:00', 2186.0),
+                             ('2006-01-04 18:00', 2806.0)]),
         ('intraday_delta', [('2006-01-04 17:00', 500.0),
                             ('2006-01-04 18:00', 500.0)]),
     ])

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -862,7 +862,8 @@ class TradingAlgorithm(object):
         if capital_change['type'] == 'target':
             target = capital_change['value']
             capital_change_amount = target - \
-                (self.updated_portfolio().cash - portfolio_value_adjustment)
+                (self.updated_portfolio().portfolio_value -
+                 portfolio_value_adjustment)
             self.portfolio_needs_update = True
 
             log.info('Processing capital change to target %s at %s. Capital '


### PR DESCRIPTION
This reverts commit 5b1aa5ec55c70660103206e99e5f13fa6ed8f332.

The paradigm is: we're calculating a new capital base for the
performance period. We are therefore using the total
portfolio_value, not just the cash, to calculate the
difference from the specified target as the algorithm
has meaningful holdings.