### PR TITLE
ENH: Don't forward fill non-ffillable fields during non-market-hours

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -43,6 +43,7 @@ from zipline.data.minute_bars import (
     US_EQUITIES_MINUTES_PER_DAY,
     BcolzMinuteWriterColumnMismatch
 )
+from zipline.data.session_bars import NoDataOnDate
 
 from zipline.testing.fixtures import (
     WithInstanceTmpDir,
@@ -854,18 +855,19 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
                 'open'),
             780)
 
-        self.assertEqual(
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-06-02', tz='UTC'),
-                'open'),
-            390)
-        self.assertEqual(
+                'open',
+            )
+
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-06-02 20:01:00', tz='UTC'),
-                'open'),
-            780)
+                'open'
+            )
 
     def test_adjust_non_trading_minutes_half_days(self):
         # half day
@@ -908,18 +910,18 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
                 Timestamp('2015-11-27 18:01:00', tz='UTC'),
                 'open'),
             210)
-        self.assertEqual(
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-11-30', tz='UTC'),
-                'open'),
-            210)
-        self.assertEqual(
+                'open'
+            )
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-11-30 21:01:00', tz='UTC'),
-                'open'),
-            600)
+                'open'
+            )
 
     def test_set_sid_attrs(self):
         """Confirm that we can set the attributes of a sid's file correctly.

--- a/zipline/data/_minute_bar_internal.pyx
+++ b/zipline/data/_minute_bar_internal.pyx
@@ -41,7 +41,7 @@ def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
                             ndarray[long_t, ndim=1] market_closes,
                             int minute_val,
                             int minutes_per_day,
-                            bool raise_if_no_data_on_date):
+                            bool forward_fill):
     """
     Finds the position of a given minute in the given array of market opens.
     If not a market minute, adjusts to the last market minute.
@@ -60,9 +60,10 @@ def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
     minutes_per_day: int
         The number of minutes per day (e.g. 390 for NYSE).
 
-    raise_if_no_data_on_date: bool
-        Whether to raise NoDataOnDate if `minute_val` is not between a market
-        open and a market close.
+    forward_fill: bool
+        If `minute_val` is not between a market open and market close,
+        the previous market minute is used if this value is True.  Otherwise,
+        NoDataOnDate is raised.
 
     Returns
     -------
@@ -80,7 +81,8 @@ def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
     market_open = market_opens[market_open_loc]
     market_close = market_closes[market_open_loc]
 
-    if raise_if_no_data_on_date and minute_val > market_close:
+    if not forward_fill and \
+            ((minute_val - market_open) >= minutes_per_day):
         raise NoDataOnDate()
 
     delta = int_min(minute_val - market_open, market_close - market_open)

--- a/zipline/data/bar_reader.py
+++ b/zipline/data/bar_reader.py
@@ -1,0 +1,80 @@
+from abc import ABCMeta, abstractproperty, abstractmethod
+
+from six import with_metaclass
+
+
+class BarReader(with_metaclass(ABCMeta)):
+    @property
+    def data_frequency(self):
+        return self._data_frequency
+
+    @abstractproperty
+    def trading_calendar(self):
+        """
+        Returns the zipline.utils.calendar.trading_calendar used to read
+        the data.  Can be None (if the writer didn't specify it).
+        """
+        pass
+
+    @abstractproperty
+    def last_available_dt(self):
+        """
+        Returns
+        -------
+        dt : pd.Timestamp
+            The last session for which the reader can provide data.
+        """
+        pass
+
+    @abstractmethod
+    def get_value(self, sid, dt, colname):
+        """
+        Retrieve the value at the given coordinates.
+
+        Parameters
+        ----------
+        sid : int
+            The asset identifier.
+        dt : pd.Timestamp
+            The timestamp for the desired data point.  Could be a minute,
+            or a session label.
+        colname : string
+            The OHLVC name for the desired data point.
+
+        Returns
+        -------
+        value : float|int
+            The value at the given coordinates, ``float`` for OHLC, ``int``
+            for 'volume'.
+        """
+        pass
+
+    @abstractmethod
+    def load_raw_arrays(self, columns, start_dt, end_dt, sids):
+        """
+        Parameters
+        ----------
+        fields : list of str
+           'open', 'high', 'low', 'close', or 'volume'
+        start_dt: Timestamp
+           Beginning of the window range.
+        end_dt: Timestamp
+           End of the window range.
+        sids : list of int
+           The asset identifiers in the window.
+
+        Returns
+        -------
+        list of np.ndarray
+            A list with an entry per field of ndarrays with shape
+            (minutes in range, sids) with a dtype of float64, containing the
+            values for the respective field over start and end dt range.
+        """
+        pass
+
+
+class NoDataOnDate(Exception):
+    """
+    Raised when a spot price can be found for the sid and date.
+    """
+    pass

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -532,7 +532,14 @@ class DataPortal(object):
         return spot_value
 
     def _get_minute_spot_value(self, asset, column, dt, ffill=False):
+        if not ffill and not asset.is_exchange_open(dt):
+            if column == "volume":
+                return 0
+            else:
+                return np.nan
+
         reader = self._get_pricing_reader('minute')
+
         result = reader.get_value(
             asset.sid, dt, column
         )

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -532,12 +532,6 @@ class DataPortal(object):
         return spot_value
 
     def _get_minute_spot_value(self, asset, column, dt, ffill=False):
-        if not ffill and not asset.is_exchange_open(dt):
-            if column == "volume":
-                return 0
-            else:
-                return np.nan
-
         reader = self._get_pricing_reader('minute')
 
         result = reader.get_value(

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -534,9 +534,13 @@ class DataPortal(object):
     def _get_minute_spot_value(self, asset, column, dt, ffill=False):
         reader = self._get_pricing_reader('minute')
 
-        result = reader.get_value(
-            asset.sid, dt, column
-        )
+        try:
+            result = reader.get_value(
+                asset.sid, dt, column
+            )
+        except:
+            import pdb; pdb.set_trace()
+            z = 5
 
         if not ffill:
             return result

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -33,6 +33,7 @@ from zipline.data._minute_bar_internal import (
 )
 
 from zipline.gens.sim_engine import NANOS_IN_MINUTE
+
 from zipline.utils.calendars import get_calendar
 from zipline.utils.cli import maybe_show_progress
 from zipline.utils.memoize import lazyval
@@ -1154,6 +1155,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
             self._market_close_values,
             minute_dt.value / NANOS_IN_MINUTE,
             self._minutes_per_day,
+            True
         )
 
     def load_raw_arrays(self, fields, start_dt, end_dt, sids):

--- a/zipline/data/session_bars.py
+++ b/zipline/data/session_bars.py
@@ -11,15 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABCMeta, abstractmethod, abstractproperty
-from six import with_metaclass
+from abc import abstractproperty
 
-
-class NoDataOnDate(Exception):
-    """
-    Raised when a spot price can be found for the sid and date.
-    """
-    pass
+from zipline.data.bar_reader import BarReader
 
 
 class NoDataBeforeDate(Exception):
@@ -30,68 +24,11 @@ class NoDataAfterDate(Exception):
     pass
 
 
-class SessionBarReader(with_metaclass(ABCMeta)):
+class SessionBarReader(BarReader):
     """
     Reader for OHCLV pricing data at a session frequency.
     """
     _data_frequency = 'session'
-
-    @property
-    def data_frequency(self):
-        return self._data_frequency
-
-    @abstractmethod
-    def load_raw_arrays(self, columns, start_date, end_date, assets):
-        """
-        Parameters
-        ----------
-        fields : list of str
-           'open', 'high', 'low', 'close', or 'volume'
-        start_dt: Timestamp
-           Beginning of the window range.
-        end_dt: Timestamp
-           End of the window range.
-        sids : list of int
-           The asset identifiers in the window.
-
-        Returns
-        -------
-        list of np.ndarray
-            A list with an entry per field of ndarrays with shape
-            (minutes in range, sids) with a dtype of float64, containing the
-            values for the respective field over start and end dt range.
-        """
-        pass
-
-    @abstractmethod
-    def get_value(self, sid, session, colname):
-        """
-        Retrieve the value at the given coordinates.
-
-        This function shares the same input and semantics as the
-        ``MinuteBarReaders``'s ``get_value``, in the future, the names may be
-        made consistent.
-
-        Parameters
-        ----------
-        sid : int
-            The asset identifier.
-        session : pd.Timestamp
-            The session label for the desired data point.
-        colname : string
-            The OHLVC name for the desired data point.
-
-        Returns
-        -------
-        value : float|int
-            The value at the given coordinates, ``float`` for OHLC, ``int``
-            for 'volume'.
-
-        See Also
-        --------
-        zipline.minute_bars.MinuteBarReader.get_value
-        """
-        pass
 
     @abstractproperty
     def sessions(self):
@@ -104,20 +41,3 @@ class SessionBarReader(with_metaclass(ABCMeta)):
         """
         pass
 
-    @abstractproperty
-    def last_available_dt(self):
-        """
-        Returns
-        -------
-        dt : pd.Timestamp
-            The last session for which the reader can provide data.
-        """
-        pass
-
-    @abstractproperty
-    def trading_calendar(self):
-        """
-        Returns the zipline.utils.calendar.trading_calendar used to read
-        the data.  Can be None (if the writer didn't specify it).
-        """
-        pass

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -684,13 +684,13 @@ class BcolzDailyBarReader(SessionBarReader):
                     day, sid))
         return ix
 
-    def get_value(self, sid, day, colname):
+    def get_value(self, sid, dt, colname):
         """
         Parameters
         ----------
         sid : int
             The asset identifier.
-        day : datetime64-like
+        dt : datetime64-like
             Midnight of the day for which data is requested.
         colname : string
             The price field. e.g. ('open', 'high', 'low', 'close', 'volume')
@@ -704,7 +704,7 @@ class BcolzDailyBarReader(SessionBarReader):
             Returns -1 if the day is within the date range, but the price is
             0.
         """
-        ix = self.sid_day_index(sid, day)
+        ix = self.sid_day_index(sid, dt)
         price = self._spot_col(colname)[ix]
         if price == 0:
             return -1

--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -371,26 +371,19 @@ class PositionTracker(object):
 
     def sync_last_sale_prices(self, dt, handle_non_market_minutes,
                               data_portal):
-        if not handle_non_market_minutes:
-            for asset, position in iteritems(self.positions):
-                last_sale_price = data_portal.get_spot_value(
-                    asset, 'price', dt, self.data_frequency
-                )
 
-                if not np.isnan(last_sale_price):
-                    position.last_sale_price = last_sale_price
-        else:
-            for asset, position in iteritems(self.positions):
-                last_sale_price = data_portal.get_adjusted_value(
-                    asset,
-                    'price',
-                    data_portal.trading_calendar.previous_minute(dt),
-                    dt,
-                    self.data_frequency
-                )
+        dt_to_use = dt
 
-                if not np.isnan(last_sale_price):
-                    position.last_sale_price = last_sale_price
+        if not data_portal.trading_calendar.is_open_on_minute(dt):
+            dt_to_use = data_portal.trading_calendar.previous_close(dt)
+
+        for asset, position in iteritems(self.positions):
+            last_sale_price = data_portal.get_spot_value(
+                asset, 'price', dt_to_use, self.data_frequency
+            )
+
+            if not np.isnan(last_sale_price):
+                position.last_sale_price = last_sale_price
 
     def stats(self):
         amounts = []

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -293,7 +293,7 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         Returns
         -------
         pd.Timestamp
-            The UTC imestamp of the previous open.
+            The UTC timestamp of the previous open.
         """
         idx = previous_divider_idx(self.market_opens_nanos, dt.value)
         return pd.Timestamp(self.market_opens_nanos[idx], tz='UTC')


### PR DESCRIPTION
When `data.current` is called on an asset for a minute that is not in the asset's exchange's calendar, we were using the last market minute's value for every field (instead of just for `price`).

Now, OHLC return `np.nan`, volume returns `0`, and price gets you the last close.