### PR TITLE
DOC: Update testpypi install command

### DIFF
--- a/docs/source/release-process.rst
+++ b/docs/source/release-process.rst
@@ -154,7 +154,7 @@ create a new virtualenv, ``cd`` into a clean directory and then run:
 
 .. code-block:: bash
 
-   $ pip install -i https://testpypi.python.org/pypi zipline
+   $ pip install --extra-index-url https://testpypi.python.org/pypi zipline
    $ python -c 'import zipline;print(zipline.__version__)'
 
 


### PR DESCRIPTION
When following the release guide, installing from testpypi using the
`-i` flag failed on my, and at least one other's, development machines.
The cause of the failure appears to be that pip would look for packages,
such as `LogBook` or `pandas` on `testpypi`. However many dependencies
do not have versions that meet our version criteria. (e.g. pandas does
not have a version between 0.16.0 and 0.18.0 on testpypi.)

Instead, use `--extra-index-url` so that other packages can use `pypi`
as a fallback server, instead of being limited to `testpypi`.
