### PR TITLE
BUG: run_algorithm with no data source should default

### DIFF
--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -329,13 +329,13 @@ def run_algorithm(start,
         # if neither data nor bundle are passed use 'quantopian-quandl'
         bundle = 'quantopian-quandl'
 
-    if len(non_none_data) != 1:
+    elif len(non_none_data) != 1:
         raise ValueError(
             'must specify one of `data`, `data_portal`, or `bundle`,'
             ' got: %r' % non_none_data,
         )
 
-    if 'bundle' not in non_none_data and bundle_timestamp is not None:
+    elif 'bundle' not in non_none_data and bundle_timestamp is not None:
         raise ValueError(
             'cannot specify `bundle_timestamp` without passing `bundle`',
         )


### PR DESCRIPTION
to 'quantopian-quandl' bundle

For https://github.com/quantopian/zipline/issues/1374

I considered adding a unit test.  Because of its dependence on the global `load` of a bundle, it would depend on ingesting the real quantopian-quandl bundle first, or we'd need to register a replacement bundle globally for the span of the test.  So I haven't included a unit test here.