### PR TITLE
MAINT: Add additional fields to __getitem__ for Order

### DIFF
--- a/zipline/protocol.py
+++ b/zipline/protocol.py
@@ -125,6 +125,11 @@ class Order(Event):
             'stop',
             'limit',
             'id',
+            'filled',
+            'commission',
+            'stop_reached',
+            'limit_reached',
+            'created',
         },
     )
 


### PR DESCRIPTION
CC: @llllllllll 

These were previously available like the other deprecated attributes here. Not sure where the discrepancy from the list you had here vs. the list in the API docs came from - might be something else we need to update?