### PR TITLE
PERF: Release unneeded pipeline terms.

### DIFF
--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -382,7 +382,8 @@ class SimplePipelineEngine(object):
                 else:
                     assert workspace[term].shape == (mask.shape[0], 1)
 
-                # Decref dependencies of ``term``, and clear any terms whose refcounts hit 0.
+                # Decref dependencies of ``term``, and clear any terms whose
+                # refcounts hit 0.
                 for garbage_term in graph.decref_dependencies(term, refcounts):
                     del workspace[garbage_term]
 

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -119,9 +119,14 @@ class TermGraph(DiGraph):
     def _repr_png_(self):
         return self.png.data
 
-    def initial_refcounts(self, initial_workspace):
+    def initial_refcounts(self, initial_terms):
         """
         Calculate initial refcounts for execution of this graph.
+
+        Parameters
+        ----------
+        initial_terms : iterable[Term]
+            An iterable of terms that were pre-computed before graph execution.
 
         Each node starts with a refcount equal to its outdegree, and output
         nodes get one extra reference to ensure that they're still in the graph
@@ -131,7 +136,7 @@ class TermGraph(DiGraph):
         for t in self.outputs.values():
             refcounts[t] += 1
 
-        for t in initial_workspace:
+        for t in initial_terms:
             self.decref_dependencies(t, refcounts)
 
         return refcounts

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -119,6 +119,19 @@ class TermGraph(DiGraph):
     def _repr_png_(self):
         return self.png.data
 
+    def initial_refcounts(self):
+        """
+        Calculate initial refcounts for execution of this graph.
+
+        Each node starts with a refcount equal to its outdegree, and output
+        nodes get one extra reference to ensure that they're still in the graph
+        at the end of execution.
+        """
+        refcounts = self.out_degree()
+        for t in self.outputs.values():
+            refcounts[t] += 1
+        return refcounts
+
 
 class ExecutionPlan(TermGraph):
     """

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -119,7 +119,7 @@ class TermGraph(DiGraph):
     def _repr_png_(self):
         return self.png.data
 
-    def initial_refcounts(self):
+    def initial_refcounts(self, initial_workspace):
         """
         Calculate initial refcounts for execution of this graph.
 
@@ -130,7 +130,37 @@ class TermGraph(DiGraph):
         refcounts = self.out_degree()
         for t in self.outputs.values():
             refcounts[t] += 1
+
+        for t in initial_workspace:
+            self.decref_dependencies(t, refcounts)
+
         return refcounts
+
+    def decref_dependencies(self, term, refcounts):
+        """
+        Decrement in-edges for ``term`` after computation.
+
+        Parameters
+        ----------
+        term : zipline.pipeline.Term
+            The term whose parents should be decref'ed.
+        refcounts : dict[Term -> int]
+            Dictionary of refcounts.
+
+        Return
+        ------
+        garbage : set[Term]
+            Terms whose refcounts hit zero after decrefing.
+        """
+        garbage = set()
+        # Edges are tuple of (from, to).
+        for parent, _ in self.in_edges([term]):
+            refcounts[parent] -= 1
+            # No one else depends on this term. Remove it from the
+            # workspace to conserve memory.
+            if refcounts[parent] == 0:
+                garbage.add(parent)
+        return garbage
 
 
 class ExecutionPlan(TermGraph):


### PR DESCRIPTION
Refcount pipeline terms during execution and release terms once they're
no longer needed.

This dramatically reduces memory usage on large pipelines.