### PR TITLE
ENH: Make reader.get_value raise NoDataOnDate if the date is not in the calendar.

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -35,6 +35,7 @@ from pandas import (
     date_range,
 )
 
+from zipline.data.bar_reader import NoDataOnDate
 from zipline.data.minute_bars import (
     BcolzMinuteBarMetadata,
     BcolzMinuteBarWriter,
@@ -854,18 +855,19 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
                 'open'),
             780)
 
-        self.assertEqual(
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-06-02', tz='UTC'),
-                'open'),
-            390)
-        self.assertEqual(
+                'open'
+            )
+
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-06-02 20:01:00', tz='UTC'),
-                'open'),
-            780)
+                'open'
+            )
 
     def test_adjust_non_trading_minutes_half_days(self):
         # half day
@@ -908,18 +910,20 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
                 Timestamp('2015-11-27 18:01:00', tz='UTC'),
                 'open'),
             210)
-        self.assertEqual(
+
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-11-30', tz='UTC'),
-                'open'),
-            210)
-        self.assertEqual(
+                'open'
+            )
+
+        with self.assertRaises(NoDataOnDate):
             self.reader.get_value(
                 sid,
                 Timestamp('2015-11-30 21:01:00', tz='UTC'),
-                'open'),
-            600)
+                'open'
+            )
 
     def test_set_sid_attrs(self):
         """Confirm that we can set the attributes of a sid's file correctly.

--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -21,6 +21,7 @@ import pandas as pd
 from pandas import DataFrame
 from six import iteritems
 
+from zipline.data.bar_reader import NoDataOnDate
 from zipline.data.resample import (
     minute_to_session,
     DailyHistoryAggregator,
@@ -803,12 +804,12 @@ class TestReindexSessionBars(WithBcolzEquityDailyBarReader,
                             err_msg="The open of the fixture data on the "
                             "first session should be 10.")
         tday = pd.Timestamp('2015-11-26', tz='UTC')
-        assert_almost_equal(self.reader.get_value(1, tday, 'close'), nan,
-                            err_msg="Thanksgiving is a NYSE holiday, but "
-                            "futures trading is open. Result should be nan.")
-        assert_almost_equal(self.reader.get_value(1, tday, 'volume'), 0,
-                            err_msg="Thanksgiving is a NYSE holiday, but "
-                            "futures trading is open. Result should be 0.")
+
+        with self.assertRaises(NoDataOnDate):
+            self.reader.get_value(1, tday, 'close')
+
+        with self.assertRaises(NoDataOnDate):
+            self.reader.get_value(1, tday, 'volume')
 
     def test_last_availabe_dt(self):
         self.assertEqual(self.reader.last_available_dt, self.END_DATE)

--- a/zipline/data/bar_reader.py
+++ b/zipline/data/bar_reader.py
@@ -17,7 +17,7 @@ from six import with_metaclass
 
 class NoDataOnDate(Exception):
     """
-    Raised when a spot price can be found for the sid and date.
+    Raised when a spot price cannot be found for the sid and date.
     """
     pass
 
@@ -106,6 +106,12 @@ class BarReader(with_metaclass(ABCMeta, object)):
         value : float|int
             The value at the given coordinates, ``float`` for OHLC, ``int``
             for 'volume'.
+
+        Raises
+        ------
+        NoDataOnDate
+            If the given dt is not a valid market minute (in minute mode) or
+            session (in daily mode) according to this reader's tradingcalendar.
         """
         pass
 

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -533,9 +533,16 @@ class DataPortal(object):
 
     def _get_minute_spot_value(self, asset, column, dt, ffill=False):
         reader = self._get_pricing_reader('minute')
-        result = reader.get_value(
-            asset.sid, dt, column
-        )
+        try:
+            result = reader.get_value(
+                asset.sid, dt, column
+            )
+        except NoDataOnDate:
+            if not ffill:
+                if column == 'volume':
+                    return 0
+                else:
+                    return np.nan
 
         if not ffill:
             return result

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -32,7 +32,7 @@ from zipline.data._minute_bar_internal import (
 
 from zipline.gens.sim_engine import NANOS_IN_MINUTE
 
-from zipline.data.bar_reader import BarReader
+from zipline.data.bar_reader import BarReader, NoDataOnDate
 from zipline.utils.calendars import get_calendar
 from zipline.utils.cli import maybe_show_progress
 from zipline.utils.memoize import lazyval
@@ -964,7 +964,11 @@ class BcolzMinuteBarReader(MinuteBarReader):
         if self._last_get_value_dt_value == dt.value:
             minute_pos = self._last_get_value_dt_position
         else:
-            minute_pos = self._find_position_of_minute(dt)
+            try:
+                minute_pos = self._find_position_of_minute(dt)
+            except ValueError:
+                raise NoDataOnDate()
+
             self._last_get_value_dt_value = dt.value
             self._last_get_value_dt_position = minute_pos
 
@@ -1058,6 +1062,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
             self._market_close_values,
             minute_dt.value / NANOS_IN_MINUTE,
             self._minutes_per_day,
+            False,
         )
 
     def load_raw_arrays(self, fields, start_dt, end_dt, sids):

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -15,13 +15,11 @@ from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-from numpy import nan
 import pandas as pd
 from pandas import DataFrame
 from six import with_metaclass
 
 from zipline.data.minute_bars import MinuteBarReader
-from zipline.data.us_equity_pricing import NoDataOnDate
 from zipline.data.session_bars import SessionBarReader
 from zipline.utils.memoize import lazyval
 
@@ -585,13 +583,7 @@ class ReindexBarReader(with_metaclass(ABCMeta)):
         return self._reader.first_trading_day
 
     def get_value(self, sid, dt, field):
-        try:
-            return self._reader.get_value(sid, dt, field)
-        except NoDataOnDate:
-            if field == 'volume':
-                return 0
-            else:
-                return nan
+        return self._reader.get_value(sid, dt, field)
 
     @abstractmethod
     def _outer_dts(self, start_dt, end_dt):


### PR DESCRIPTION
Previously, at least the minute bar reader was forward filling (using the previous market minute).

DataPortal now catches the NoDataOnDate exception and returns nan for OHLC and 0 for V.

Price is still forward filled, unchanged.