### PR TITLE
MAiNT: Use load_adjustments for history.

### DIFF
--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -20,12 +20,11 @@ from abc import (
 
 from cachetools import LRUCache
 from numpy import around, hstack
-from pandas.tslib import normalize_date
+from pandas import Int64Index
 
 from six import with_metaclass
 
 from zipline.lib._float64window import AdjustedArrayWindow as Float64Window
-from zipline.lib.adjustment import Float64Multiply
 from zipline.utils.cache import ExpiringCache
 from zipline.utils.memoize import lazyval
 from zipline.utils.numpy_utils import float64_dtype
@@ -141,79 +140,10 @@ class HistoryLoader(with_metaclass(ABCMeta)):
         -------
         out : The adjustments as a dict of loc -> Float64Multiply
         """
-        sid = int(asset)
-        start = normalize_date(dts[0])
-        end = normalize_date(dts[-1])
-        adjs = {}
-        if field != 'volume':
-            mergers = self._adjustments_reader.get_adjustments_for_sid(
-                'mergers', sid)
-            for m in mergers:
-                dt = m[0]
-                if start < dt <= end:
-                    end_loc = dts.searchsorted(dt)
-                    adj_loc = end_loc
-                    if is_perspective_after:
-                        # Set adjustment pop location so that it applies
-                        # to last value if adjustment occurs immediately after
-                        # the last slot.
-                        adj_loc -= 1
-                    mult = Float64Multiply(0,
-                                           end_loc - 1,
-                                           0,
-                                           0,
-                                           m[1])
-                    try:
-                        adjs[adj_loc].append(mult)
-                    except KeyError:
-                        adjs[adj_loc] = [mult]
-            divs = self._adjustments_reader.get_adjustments_for_sid(
-                'dividends', sid)
-            for d in divs:
-                dt = d[0]
-                if start < dt <= end:
-                    end_loc = dts.searchsorted(dt)
-                    adj_loc = end_loc
-                    if is_perspective_after:
-                        # Set adjustment pop location so that it applies
-                        # to last value if adjustment occurs immediately after
-                        # the last slot.
-                        adj_loc -= 1
-                    mult = Float64Multiply(0,
-                                           end_loc - 1,
-                                           0,
-                                           0,
-                                           d[1])
-                    try:
-                        adjs[adj_loc].append(mult)
-                    except KeyError:
-                        adjs[adj_loc] = [mult]
-        splits = self._adjustments_reader.get_adjustments_for_sid(
-            'splits', sid)
-        for s in splits:
-            dt = s[0]
-            if start < dt <= end:
-                if field == 'volume':
-                    ratio = 1.0 / s[1]
-                else:
-                    ratio = s[1]
-                end_loc = dts.searchsorted(dt)
-                adj_loc = end_loc
-                if is_perspective_after:
-                    # Set adjustment pop location so that it applies
-                    # to last value if adjustment occurs immediately after
-                    # the last slot.
-                    adj_loc -= 1
-                mult = Float64Multiply(0,
-                                       end_loc - 1,
-                                       0,
-                                       0,
-                                       ratio)
-                try:
-                    adjs[adj_loc].append(mult)
-                except KeyError:
-                    adjs[adj_loc] = [mult]
-        return adjs
+        end_offset = -1
+        date_offset = -1 if is_perspective_after else 0
+        return self._adjustments_reader.load_adjustments(
+            [field], dts, Int64Index([asset]), end_offset, date_offset)[0]
 
     def _ensure_sliding_windows(self, assets, dts, field,
                                 is_perspective_after):

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -1230,12 +1230,15 @@ class SQLiteAdjustmentReader(object):
     def __init__(self, conn):
         self.conn = conn
 
-    def load_adjustments(self, columns, dates, assets):
+    def load_adjustments(self, columns, dates, assets,
+                         end_offset=0, date_offset=0):
         return load_adjustments_from_sqlite(
             self.conn,
             list(columns),
             dates,
             assets,
+            end_offset,
+            date_offset
         )
 
     def get_adjustments_for_sid(self, table_name, sid):


### PR DESCRIPTION
Instead of `HistoryLoader` containing separate adjustment calculation
logic, use `SQLiteAdjustmentReader.load_adjustments`.

This change required the addition of two offset parameters to
`load_adjustments` since the perspective on the data from within
`schedule_function` is skewed from how Pipeline looks at historical
data.

This is working towards creating an `AdjustmentReader` abc which
`SQLiteAdjustmentReader` and a upcoming continuous future adjustment
reader will share.