### PR TITLE
PERF: vectorize earnings estimates

### DIFF
--- a/zipline/pipeline/loaders/blaze/estimates.py
+++ b/zipline/pipeline/loaders/blaze/estimates.py
@@ -16,6 +16,7 @@ from zipline.pipeline.loaders.earnings_estimates import (
     NextEarningsEstimatesLoader,
     PreviousEarningsEstimatesLoader,
     required_estimates_fields,
+    metadata_columns,
 )
 from zipline.pipeline.loaders.utils import (
     check_data_query_args,
@@ -104,17 +105,20 @@ class BlazeEstimatesLoader(PipelineLoader):
         self._checkpoints = checkpoints
 
     def load_adjusted_array(self, columns, dates, assets, mask):
-        raw = load_raw_data(assets,
-                            dates,
-                            self._data_query_time,
-                            self._data_query_tz,
-                            self._expr,
-                            self._odo_kwargs,
-                            checkpoints=self._checkpoints)
+        column_names = [column.name for column in columns]
+        raw = load_raw_data(
+            assets,
+            dates,
+            self._data_query_time,
+            self._data_query_tz,
+            self._expr[sorted(metadata_columns.union(column_names))],
+            self._odo_kwargs,
+            checkpoints=self._checkpoints,
+        )
 
         return self.loader(
             raw,
-            self._columns,
+            {k: self._columns[k] for k in column_names}
         ).load_adjusted_array(
             columns,
             dates,

--- a/zipline/pipeline/loaders/earnings_estimates.py
+++ b/zipline/pipeline/loaders/earnings_estimates.py
@@ -50,23 +50,24 @@ def split_normalized_quarters(normalized_quarters):
     return years, quarters + 1
 
 
+# These metadata columns are used to align event indexers.
+metadata_columns = frozenset({
+    TS_FIELD_NAME,
+    SID_FIELD_NAME,
+    EVENT_DATE_FIELD_NAME,
+    FISCAL_QUARTER_FIELD_NAME,
+    FISCAL_YEAR_FIELD_NAME,
+})
+
+
 def required_estimates_fields(columns):
     """
     Compute the set of resource columns required to serve
     `columns`.
     """
-    # These metadata columns are used to align event indexers.
-    return {
-        TS_FIELD_NAME,
-        SID_FIELD_NAME,
-        EVENT_DATE_FIELD_NAME,
-        FISCAL_QUARTER_FIELD_NAME,
-        FISCAL_YEAR_FIELD_NAME
-    }.union(
-        # We also expect any of the field names that our loadable columns
-        # are mapped to.
-        viewvalues(columns),
-    )
+    # We also expect any of the field names that our loadable columns
+    # are mapped to.
+    return metadata_columns.union(viewvalues(columns))
 
 
 def validate_column_specs(events, columns):

--- a/zipline/pipeline/loaders/utils.py
+++ b/zipline/pipeline/loaders/utils.py
@@ -276,7 +276,11 @@ def check_data_query_args(data_query_time, data_query_tz):
         )
 
 
-def last_in_date_group(df, dates, assets, reindex=True, have_sids=True,
+def last_in_date_group(df,
+                       dates,
+                       assets,
+                       reindex=True,
+                       have_sids=True,
                        extra_groupers=[]):
     """
     Determine the last piece of information known on each date in the date


### PR DESCRIPTION
big performance improvement on larger data sets. This also fixes what I think is a bug where the data is not sorted on event_date in `get_requested_quarter_data` but I haven't written a test for that yet.