### PR TITLE
PERF: Remove or defer calls to get_loc on large indices.

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -213,12 +213,6 @@ class DataPortal(object):
             self.trading_calendar.all_sessions.get_loc(self._first_trading_day)
             if self._first_trading_day is not None else None
         )
-        self._first_trading_minute_loc = (
-            self.trading_calendar.all_minutes.get_loc(
-                self._first_trading_minute
-            )
-            if self._first_trading_minute is not None else None
-        )
 
     def _ensure_reader_aligned(self, reader):
         if reader is None:
@@ -703,10 +697,17 @@ class DataPortal(object):
 
             return daily_data
 
-    def _handle_history_out_of_bounds(self, bar_count):
+    def _handle_minute_history_out_of_bounds(self, bar_count):
+        first_trading_minute_loc = (
+            self.trading_calendar.all_minutes.get_loc(
+                self._first_trading_minute
+            )
+            if self._first_trading_minute is not None else None
+        )
+
         suggested_start_day = (
             self.trading_calendar.all_minutes[
-                self._first_trading_minute_loc + bar_count
+                first_trading_minute_loc + bar_count
             ] + self.trading_calendar.day
         ).date()
 
@@ -728,10 +729,10 @@ class DataPortal(object):
                 end_dt, -bar_count
             )
         except KeyError:
-            self._handle_history_out_of_bounds(bar_count)
+            self._handle_minute_history_out_of_bounds(bar_count)
 
         if minutes_for_window[0] < self._first_trading_minute:
-            self._handle_history_out_of_bounds(bar_count)
+            self._handle_minute_history_out_of_bounds(bar_count)
 
         asset_minute_data = self._get_minute_window_for_assets(
             assets,

--- a/zipline/utils/calendars/us_futures_calendar.py
+++ b/zipline/utils/calendars/us_futures_calendar.py
@@ -1,10 +1,13 @@
 from datetime import time
 
+from pandas import Timestamp
 from pandas.tseries.holiday import GoodFriday
 from pytz import timezone
 
 from zipline.utils.calendars import TradingCalendar
-from zipline.utils.calendars.trading_calendar import HolidayCalendar
+from zipline.utils.calendars.trading_calendar import (
+    HolidayCalendar, end_default
+)
 from zipline.utils.calendars.us_holidays import (
     USNewYearsDay,
     Christmas
@@ -31,6 +34,15 @@ class QuantopianUSFuturesCalendar(TradingCalendar):
     In order to align the hours of each session, we ignore the Sunday
     CME Pre-Open hour (5-6pm).
     """
+    # XXX: Override the default TradingCalendar start and end dates with ones
+    # further in the future. This is a stopgap for memory issues caused by
+    # upgrading to pandas 18. This calendar is the most severely affected,
+    # since it has the most total minutes of any of the zipline calendars.
+    def __init__(self,
+                 start=Timestamp('2000-01-01', tz='UTC'),
+                 end=end_default):
+        super(QuantopianUSFuturesCalendar, self).__init__(start=start, end=end)
+
     @property
     def name(self):
         return "us_futures"


### PR DESCRIPTION
Mitigation for https://github.com/quantopian/zipline/issues/1503.

This was debugged primarily by adding the following lines to `zipline/tests/__init__.py`:

```python
+import os
+from unittest import TestCase
+
+import psutil
+import humanize
+import __builtin__
+
+pid = os.getpid()
+proc = psutil.Process(pid)
+
+def get_mem_usage():
+    return humanize.naturalsize(proc.memory_full_info().uss)
+__builtin__.gmem = get_mem_usage
+
+
+real_doCleanups = TestCase.doCleanups
+
+OUTPUT_FILE = open('/home/ssanderson/pandas18_memory_usage.txt', 'w')
+
+
+def patched_doCleanups(self, *args, **kwargs):
+    OUTPUT_FILE.write("{} {}\n".format(get_mem_usage(), self))
+    OUTPUT_FILE.flush()
+    return real_doCleanups(self, *args, **kwargs)
+
+TestCase.doCleanups = patched_doCleanups
```