### PR TITLE
ENH: Add slippage models to execute at limit, open prices

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -24,13 +24,15 @@ from nose_parameterized import parameterized
 
 import pandas as pd
 from pandas.tslib import normalize_date
+from numpy import arange
 
-from zipline.finance.slippage import VolumeShareSlippage
+from zipline.finance.slippage import VolumeShareSlippage,\
+    ConservativeCloseSlippage
 
 from zipline.protocol import DATASOURCE_TYPE
 from zipline.finance.blotter import Order
 
-from zipline.data.data_portal import DataPortal
+from zipline.data.data_portal import DataPortal, BASE_FIELDS
 from zipline.protocol import BarData
 from zipline.testing import tmp_bcolz_equity_minute_bar_reader
 from zipline.testing.fixtures import (
@@ -38,6 +40,33 @@ from zipline.testing.fixtures import (
     WithSimParams,
     ZiplineTestCase,
 )
+
+
+class SimpleQuotes(tmp_bcolz_equity_minute_bar_reader):
+    def __init__(self, ohlc):
+        dc = dict(zip(['open', 'high', 'low', 'close'], zip(ohlc)))
+        dc['volume'] = 200
+        assets = (
+            (133, pd.DataFrame(dc, index=[SlippageTestCase.minutes[0]],)),
+        )
+        days = pd.date_range(
+            start=normalize_date(SlippageTestCase.minutes[0]),
+            end=normalize_date(SlippageTestCase.minutes[-1])
+        )
+        super(SimpleQuotes, self). \
+            __init__(SlippageTestCase.trading_calendar, days, assets)
+
+    def __enter__(self):
+        reader = tmp_bcolz_equity_minute_bar_reader.__enter__(self)
+        data_portal = DataPortal(
+            SlippageTestCase.env.asset_finder,
+            SlippageTestCase.trading_calendar,
+            first_trading_day=reader.first_trading_day,
+            equity_minute_reader=reader
+        )
+        return BarData(data_portal,
+                       lambda: SlippageTestCase.minutes[0],
+                       SlippageTestCase.sim_params.data_frequency)
 
 
 class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
@@ -60,10 +89,10 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
     def make_equity_minute_bar_data(cls):
         yield 133, pd.DataFrame(
             {
-                'open': [3.0, 3.0, 3.5, 4.0, 3.5],
-                'high': [3.15, 3.15, 3.15, 3.15, 3.15],
-                'low': [2.85, 2.85, 2.85, 2.85, 2.85],
-                'close': [3.0, 3.5, 4.0, 3.5, 3.0],
+                'open':   [3.0,  3.0,  3.5,  4.0,  3.5],
+                'high':   [3.7,  3.7,  4.2,  4.2,  3.7],
+                'low':    [2.85, 2.85, 2.85, 2.85, 2.85],
+                'close':  [3.0,  3.5,  4.0,  3.5,  3.0],
                 'volume': [2000, 2000, 2000, 2000, 2000],
             },
             index=cls.minutes,
@@ -91,8 +120,8 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
             start=normalize_date(self.minutes[0]),
             end=normalize_date(self.minutes[-1])
         )
-        with tmp_bcolz_equity_minute_bar_reader(self.trading_calendar, days, assets) \
-                as reader:
+        with tmp_bcolz_equity_minute_bar_reader(self.trading_calendar, days,
+                                                assets) as reader:
             data_portal = DataPortal(
                 self.env.asset_finder, self.trading_calendar,
                 first_trading_day=reader.first_trading_day,
@@ -181,6 +210,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[3],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -190,6 +220,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         self.assertEquals(len(orders_txns), 0)
 
         # long, does not trade - impacted price worse than limit price
+        # TODO: this seems duplicate to above?
         open_orders = [
             Order(**{
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
@@ -203,6 +234,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[3],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -225,6 +257,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[3],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -264,6 +297,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[0],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -273,6 +307,8 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
         self.assertEquals(len(orders_txns), 0)
 
         # short, does not trade - impacted price worse than limit price
+        # TODO: this seems duplicate to above?
+
         open_orders = [
             Order(**{
                 'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
@@ -286,6 +322,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[0],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -308,6 +345,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[1],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -481,8 +519,8 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
             start=normalize_date(self.minutes[0]),
             end=normalize_date(self.minutes[-1])
         )
-        with tmp_bcolz_equity_minute_bar_reader(self.trading_calendar, days, assets) \
-                as reader:
+        with tmp_bcolz_equity_minute_bar_reader(self.trading_calendar, days,
+                                                assets) as reader:
             data_portal = DataPortal(
                 self.env.asset_finder, self.trading_calendar,
                 first_trading_day=reader.first_trading_day,
@@ -512,6 +550,12 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                 for key, value in expected['transaction'].items():
                     self.assertEquals(value, txn[key])
 
+    def print_quotes(self, data, order):
+        qt = data.current(self.ASSET133, list(BASE_FIELDS))
+        print('order: qty %d stop %.2g limit %.2g' %
+              (order.amount, order.stop or 0, order.limit or 0) +
+              ', bar data OHLC: %(open)g %(high)g %(low)g %(close)g' % qt)
+
     def test_orders_stop_limit(self):
         slippage_model = VolumeShareSlippage()
         slippage_model.data_portal = self.data_portal
@@ -531,6 +575,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[2],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -543,6 +588,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[3],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -566,6 +612,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[2],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -578,6 +625,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[3],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -601,6 +649,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[2],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -613,6 +662,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[3],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -649,6 +699,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[0],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -684,6 +735,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[0],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -719,6 +771,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[0],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -731,6 +784,7 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
                            lambda: self.minutes[1],
                            self.sim_params.data_frequency)
 
+        self.print_quotes(bar_data, open_orders[0])
         orders_txns = list(slippage_model.simulate(
             bar_data,
             self.ASSET133,
@@ -750,3 +804,106 @@ class SlippageTestCase(WithSimParams, WithDataPortal, ZiplineTestCase):
 
         for key, value in expected_txn.items():
             self.assertEquals(value, txn[key])
+
+        # test when limit can be executed in the same bar as stop
+        self.print_quotes(bar_data, open_orders[0])
+        open_orders = [
+            Order(**{
+                'dt': datetime.datetime(2006, 1, 5, 14, 30, tzinfo=pytz.utc),
+                'amount': 100,
+                'sid': self.ASSET133,
+                'stop': 3.1,
+                'limit': 3.6})
+        ]
+
+        bar_data = BarData(self.data_portal,
+                           lambda: self.minutes[1],
+                           self.sim_params.data_frequency)
+
+        self.print_quotes(bar_data, open_orders[0])
+        orders_txns = list(slippage_model.simulate(
+            bar_data,
+            self.ASSET133,
+            open_orders
+        ))
+        txn = orders_txns[0][1]
+        self.assert_(txn['amount'] > 0 and
+                     abs(txn['price'] - 3.5) < 0.01)
+
+    def testConservativeMulti(self):
+        slippage = ConservativeCloseSlippage()
+        templates = '+lLOCH.', '+LlOCHx', '-LOCHl.', '-LOClHx', '+LOCslHx', \
+            '-LOClsHx', '+LOClsH.', '-LOCslH.'
+        for t in templates:
+            self.verifyTemplate(t, slippage)
+
+        t = '+LOCsHx'
+        txn = self.verifyTemplate(t, slippage)
+        prices = template_to_num(t)
+        print('impacted price %g' % txn.price)
+        assert prices['s'] < txn.price < prices['H'], \
+            'expect applied slippage at stop price'
+
+        t = '-LsOCHx'
+        txn = self.verifyTemplate(t, slippage)
+        prices = template_to_num(t)
+        print('impacted price %g' % txn.price)
+        assert prices['L'] < txn.price < prices['s'], \
+            'expect applied slippage at stop price'
+
+    def verifyTemplate(self, template, slippage):
+        params = template_to_num(template)
+        ohlc = [params[f] for f in 'OHLC']
+        stop = params.get('s', None)
+        limit = params.get('l', None)
+
+        def _format(f):
+            return 'None' if f is None else '%g' % f
+        print(template + ' stop ' + _format(stop) + ' limit ' +
+              _format(limit) + ' quotes %s' % ohlc)
+        amount = (1 if template[0] == '+' else -1) * 100
+        with SimpleQuotes(ohlc) as data:
+            assert params['L'] <= params['H'], 'invalid bar: H < L'
+            order = Order(datetime.datetime.now(), self.ASSET133, amount,
+                          limit=limit,
+                          stop=stop)
+            txns = list(slippage.simulate(data, self.ASSET133, [order]))
+            if len(txns):
+                txn = txns[0][1]
+                print('executed txn', txn.amount)
+            else:
+                txn = None
+            check_template(template, txn)
+            return txn
+
+
+def template_to_num(tmpl):
+    """Produce real OHLC quotes from a testing template:
+        Order of characters does matter, latter chars produce higher numbers
+        'l' - order.limit
+        's' - order.stop
+        'O', 'H', 'L', 'C' - bar components
+        '+' is discarded for numbers generation but later means a positive
+                amount (buy order)
+        '-' is sell order
+        'x' - expected result is 'having a transaction'
+        '.' - extected result is 'no action, pass...'
+    """
+    step = 0.5
+    return dict(zip(tmpl, arange(3, 3 + len(tmpl)*step, step)))
+
+
+def check_template(template, txn):
+    assert "+-".index(template[0]) >= 0, 'templace must match with + or -'
+    if template[-1] == 'x':
+        assert txn is not None, 'expected to have transation ' + template
+        assert (txn.amount > 0) == (template[0] == '+'), \
+            'unexpected transaction direction'
+    else:
+        assert template[-1] == '.', 'only x or . accepted at end of template'
+        assert txn is None, 'no transaction expected'
+
+if __name__ == '__main__':
+    import nose
+    test = 'tests.finance.test_slippage:SlippageTestCase.testConservativeMulti'
+    nose.run(argv=['nosetests', '-s', test])

--- a/zipline/finance/order.py
+++ b/zipline/finance/order.py
@@ -42,8 +42,9 @@ class Order(object):
     # Order objects and we keep them all in memory, so it's worthwhile trying
     # to cut down on the memory footprint of this object.
     __slots__ = ["id", "dt", "reason", "created", "sid", "amount", "filled",
-                 "commission", "_status", "stop", "limit", "stop_reached",
-                 "limit_reached", "direction", "type", "broker_order_id"]
+                 "commission", "_status", "stop", "stop_ghost", "limit",
+                 "stop_reached", "limit_reached", "direction", "type",
+                 "broker_order_id"]
 
     def __init__(self, dt, sid, amount, stop=None, limit=None, filled=0,
                  commission=0, id=None):
@@ -68,6 +69,7 @@ class Order(object):
         self.commission = commission
         self._status = ORDER_STATUS.OPEN
         self.stop = stop
+        self.stop_ghost = None
         self.limit = limit
         self.stop_reached = False
         self.limit_reached = False
@@ -107,6 +109,8 @@ class Order(object):
         self.stop_reached = stop_reached
         self.limit_reached = limit_reached
         if sl_stop_reached:
+            # limit can execute at stop_ghost in the same bar
+            self.stop_ghost = self.stop
             # Change the STOP LIMIT order into a LIMIT order
             self.stop = None
 

--- a/zipline/finance/order.py
+++ b/zipline/finance/order.py
@@ -34,7 +34,8 @@ BUY = 1 << 1
 STOP = 1 << 2
 LIMIT = 1 << 3
 
-ORDER_FIELDS_TO_IGNORE = {'type', 'direction', '_status'}
+ORDER_FIELDS_TO_IGNORE = {'type', 'direction', '_status', 'stop_ghost',
+                          'stop_stage'}
 
 
 class Order(object):
@@ -42,7 +43,7 @@ class Order(object):
     # Order objects and we keep them all in memory, so it's worthwhile trying
     # to cut down on the memory footprint of this object.
     __slots__ = ["id", "dt", "reason", "created", "sid", "amount", "filled",
-                 "commission", "_status", "stop", "stop_ghost", "limit",
+                 "commission", "_status", "stop", "stop_ghost", "stop_stage", "limit",
                  "stop_reached", "limit_reached", "direction", "type",
                  "broker_order_id"]
 
@@ -109,7 +110,7 @@ class Order(object):
         self.stop_reached = stop_reached
         self.limit_reached = limit_reached
         if sl_stop_reached:
-            # limit can execute at stop_ghost in the same bar
+            # limit can execute at stop_ghost in the same bar_stage
             self.stop_ghost = self.stop
             # Change the STOP LIMIT order into a LIMIT order
             self.stop = None


### PR DESCRIPTION
Generalize SlippageModel with the idea of bar stage.            
3 bar stages are defined: Open, HighLow and Close. The behavior
until now corresponds to using only Close stage.
The first added slippage model HLCVolumeSlippage executes limit
orders at limit price instead of close price, but still using
close price for market orders.
The second slippage model OHLVolumeSlippage takes advantage of
all the OHLC prices in the bar, executing limit orders either 
at open or limit depending on marketability.
Default behaviour is not changed. To use the new functionality:
 
def initialize(context):
        context.set_slippage(HLCVolumeSlippage())
