### PR TITLE
Docker build failure - Add Tini and set version range for numpy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ RUN mkdir ${PROJECT_DIR} \
 WORKDIR /ta-lib
 
 RUN pip install 'numpy>=1.11.1,<2.0.0' \
-  && pip install scipy==0.15.1 \
-  && pip install pandas==0.16.1 \
+  && pip install 'scipy>=0.17.1,<1.0.0' \
+  && pip install 'pandas>=0.18.1,<1.0.0' \
   && ./configure --prefix=/usr \
   && make \
   && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ FROM python:2.7
 #
 # set up environment
 #
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 ENV PROJECT_DIR=/projects \
     NOTEBOOK_PORT=8888 \
     SSL_CERT_PEM=/root/.jupyter/jupyter.pem \
@@ -49,13 +54,14 @@ RUN mkdir ${PROJECT_DIR} \
 
 WORKDIR /ta-lib
 
-RUN pip install numpy==1.9.2 \
+RUN pip install 'numpy>=1.11.1,<2.0.0' \
   && pip install scipy==0.15.1 \
   && pip install pandas==0.16.1 \
   && ./configure --prefix=/usr \
   && make \
   && make install \
   && pip install TA-Lib \
+  && pip install matplotlib \
   && pip install jupyter
 
 #


### PR DESCRIPTION
First time user, I spent some time setting it up and I ran into a few issues, the purpose of this pull request is to bring it to your attention, maybe it will help somebody else. Please close it if it doesn't apply.

### Background:
- First time user.
- OS X El Capitan + VirtualBox
- Docker version 1.9.1,

### Docker build failure:

```
Obtaining file:///zipline
    Complete output from command python setup.py egg_info:
    warning: no files found matching '*.pyx' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.h' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Utility'
    Unable to find pgen, not compiling formal grammar.
    
    Installed /zipline/.eggs/Cython-0.24.1-py2.7-linux-x86_64.egg
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/zipline/setup.py", line 300, in <module>
        **conditional_arguments
      File "/usr/local/lib/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/local/lib/python2.7/site-packages/setuptools/dist.py", line 315, in __init__
        self.fetch_build_eggs(attrs['setup_requires'])
      File "/usr/local/lib/python2.7/site-packages/setuptools/dist.py", line 361, in fetch_build_eggs
        replace_conflicting=True,
      File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 851, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1116, in best_match
        dist = working_set.find(req)
      File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 720, in find
        raise VersionConflict(dist, req)
    pkg_resources.VersionConflict: (numpy 1.9.2 (/usr/local/lib/python2.7/site-packages), Requirement.parse('numpy>=1.11.1'))
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /zipline/
```

### Possible solution / workaround:

- Set numpy version range. _(included in commit)._

### Jupyter notebooks: Dead kernels / automatic restart failures.

- Please see https://github.com/ipython/ipython/issues/7062 for details.
- Possible solution: Add Tini - https://github.com/krallin/tini. _(included in commit)._

Thank you for your work.