### PR TITLE
MAINT: Perspective offset for load adjustments.

### DIFF
--- a/tests/pipeline/test_adjusted_array.py
+++ b/tests/pipeline/test_adjusted_array.py
@@ -215,7 +215,7 @@ def _gen_multiplicative_adjustment_cases(dtype):
         adjustments,
         buffer_as_of,
         nrows,
-        perspective_offsets=(0, 1, 2, 1000),
+        perspective_offsets=(0, 1),
     )
 
 
@@ -318,7 +318,7 @@ def _gen_overwrite_adjustment_cases(dtype):
         adjustments,
         buffer_as_of,
         nrows=6,
-        perspective_offsets=(0, 1, 2, 1000),
+        perspective_offsets=(0, 1),
     )
 
 
@@ -421,7 +421,7 @@ def _gen_overwrite_1d_array_adjustment_case(dtype):
         adjustments,
         buffer_as_of,
         nrows=6,
-        perspective_offsets=(0, 1, 2, 1000),
+        perspective_offsets=(0, 1),
     )
 
 

--- a/tests/pipeline/test_adjusted_array.py
+++ b/tests/pipeline/test_adjusted_array.py
@@ -434,7 +434,7 @@ def _gen_expectations(baseline,
 
     for windowlen, perspective_offset in product(valid_window_lengths(nrows),
                                                  perspective_offsets):
-        # How long an an iterator of length-N windows on this buffer?
+        # How long is an iterator of length-N windows on this buffer?
         # For example, for a window of length 3 on a buffer of length 6, there
         # are four valid windows.
         num_legal_windows = num_windows_of_length_M_on_buffers_of_length_N(

--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -107,8 +107,7 @@ class HistoryLoader(with_metaclass(ABCMeta)):
     def _array(self, start, end, assets, field):
         pass
 
-    def _get_adjustments_in_range(self, asset, dts, field,
-                                  is_perspective_after):
+    def _get_adjustments_in_range(self, asset, dts, field):
         """
         Get the Float64Multiply objects to pass to an AdjustedArrayWindow.
 
@@ -154,11 +153,6 @@ class HistoryLoader(with_metaclass(ABCMeta)):
                 if start < dt <= end:
                     end_loc = dts.searchsorted(dt)
                     adj_loc = end_loc
-                    if is_perspective_after:
-                        # Set adjustment pop location so that it applies
-                        # to last value if adjustment occurs immediately after
-                        # the last slot.
-                        adj_loc -= 1
                     mult = Float64Multiply(0,
                                            end_loc - 1,
                                            0,
@@ -175,11 +169,6 @@ class HistoryLoader(with_metaclass(ABCMeta)):
                 if start < dt <= end:
                     end_loc = dts.searchsorted(dt)
                     adj_loc = end_loc
-                    if is_perspective_after:
-                        # Set adjustment pop location so that it applies
-                        # to last value if adjustment occurs immediately after
-                        # the last slot.
-                        adj_loc -= 1
                     mult = Float64Multiply(0,
                                            end_loc - 1,
                                            0,
@@ -200,11 +189,6 @@ class HistoryLoader(with_metaclass(ABCMeta)):
                     ratio = s[1]
                 end_loc = dts.searchsorted(dt)
                 adj_loc = end_loc
-                if is_perspective_after:
-                    # Set adjustment pop location so that it applies
-                    # to last value if adjustment occurs immediately after
-                    # the last slot.
-                    adj_loc -= 1
                 mult = Float64Multiply(0,
                                        end_loc - 1,
                                        0,
@@ -284,7 +268,7 @@ class HistoryLoader(with_metaclass(ABCMeta)):
             for i, asset in enumerate(needed_assets):
                 if self._adjustments_reader:
                     adjs = self._get_adjustments_in_range(
-                        asset, prefetch_dts, field, is_perspective_after)
+                        asset, prefetch_dts, field)
                 else:
                     adjs = {}
                 window = window_type(
@@ -292,7 +276,8 @@ class HistoryLoader(with_metaclass(ABCMeta)):
                     view_kwargs,
                     adjs,
                     offset,
-                    size
+                    size,
+                    int(is_perspective_after)
                 )
                 sliding_window = SlidingWindow(window, size, start_ix, offset)
                 asset_windows[asset] = sliding_window

--- a/zipline/lib/_windowtemplate.pxi
+++ b/zipline/lib/_windowtemplate.pxi
@@ -67,7 +67,7 @@ cdef class AdjustedArrayWindow:
         if len(self.adjustment_indices) > 0:
             return self.adjustment_indices.pop()
         else:
-            return -1
+            return self.max_anchor + self.perspective_offset
 
     def __iter__(self):
         return self
@@ -86,9 +86,7 @@ cdef class AdjustedArrayWindow:
         # Apply any adjustments that occured before our current anchor.
         # Equivalently, apply any adjustments known **on or before** the date
         # for which we're calculating a window.
-        while (self.next_adj != -1
-               and
-               self.next_adj - self.perspective_offset < anchor):
+        while self.next_adj < anchor + self.perspective_offset:
 
             for adjustment in self.adjustments[self.next_adj]:
                 adjustment.mutate(self.data)

--- a/zipline/lib/_windowtemplate.pxi
+++ b/zipline/lib/_windowtemplate.pxi
@@ -53,6 +53,15 @@ cdef class AdjustedArrayWindow:
         self.adjustment_indices = sorted(adjustments, reverse=True)
         self.window_length = window_length
         self.anchor = window_length + offset
+        if perspective_offset > 1:
+            # Limit perspective_offset to 1.
+            # To support an offset greater than 1, work must be done to
+            # ensure that adjustments are retrieved for the datetimes between
+            # the end of the window and the vantage point defined by the
+            # perspective offset.
+            raise Exception("perspective_offset should not exceed 1, value "
+                            "is perspective_offset={0}".format(
+                                perspective_offset))
         self.perspective_offset = perspective_offset
         self.next_anchor = self.anchor
         self.max_anchor = data.shape[0]

--- a/zipline/lib/adjusted_array.py
+++ b/zipline/lib/adjusted_array.py
@@ -152,16 +152,22 @@ class AdjustedArray(object):
     missing_value : object
         A value to use to fill missing data in yielded windows.
         Should be a value coercible to `data.dtype`.
+    perspective_offset : int
+        The number of rows after the current end of the window, from which the
+        data is being viewed. This value is used so that adjustments that occur
+        between the end of the window and the vantage point are applied.
     """
     __slots__ = (
         '_data',
         '_view_kwargs',
         'adjustments',
         'missing_value',
+        'perspective_offset',
         '__weakref__',
     )
 
-    def __init__(self, data, mask, adjustments, missing_value):
+    def __init__(self, data, mask, adjustments, missing_value,
+                 perspective_offset=0):
         self._data, self._view_kwargs = _normalize_array(data, missing_value)
 
         self.adjustments = adjustments
@@ -176,6 +182,8 @@ class AdjustedArray(object):
                     (mask.shape, data.shape),
                 )
             self._data[~mask] = self.missing_value
+
+        self.perspective_offset = perspective_offset
 
     @lazyval
     def data(self):
@@ -220,6 +228,7 @@ class AdjustedArray(object):
             self.adjustments,
             offset,
             window_length,
+            self.perspective_offset
         )
 
     def inspect(self):


### PR DESCRIPTION
Add a perspective offset to `AdjustedArrayWindow` and `AdjustedArray`,
so that `HistoryLoader` does not need to twiddle with offsets to support
viewing the data from the bar after end of the window, (Which is the
case when a '1d' history window is retrieved in minute mode, which is
explained in the docstring for `HistoryLoader.history`)

Presently, this simplifies the logic in
`HistoryLoader._get_adjustments_in_range`, and other incoming
AdjustmentReader's, (e.g. the roll based adjustment reader for continous
futures.) This patch should also make it easier for history and pipeline
to converge on a singular `load_adjustments` method.