### PR TITLE
MAINT: Pass through asset instead of sid.

### DIFF
--- a/zipline/data/dispatch_bar_reader.py
+++ b/zipline/data/dispatch_bar_reader.py
@@ -96,7 +96,7 @@ class AssetDispatchBarReader(with_metaclass(ABCMeta)):
 
         for i, asset in enumerate(assets):
             t = type(asset)
-            sid_groups[t].append(asset.sid)
+            sid_groups[t].append(asset)
             out_pos[t].append(i)
 
         batched_arrays = {


### PR DESCRIPTION
When dispatching to sub readers in dispatch reader, pass along the asset
object, instead of extracting the sid.

The in development reader for continuous futures values besides `sid`
are needed from the `ContinuousFuture` object.