### PR TITLE
MAINT: Use perspective_offset in more tests.

### DIFF
--- a/tests/pipeline/test_adjusted_array.py
+++ b/tests/pipeline/test_adjusted_array.py
@@ -434,7 +434,7 @@ def _gen_expectations(baseline,
 
     for windowlen, perspective_offset in product(valid_window_lengths(nrows),
                                                  perspective_offsets):
-        # How long an an iterator of length-N windows on this buffer?
+        # How long is an iterator of length-N windows on this buffer?
         # For example, for a window of length 3 on a buffer of length 6, there
         # are four valid windows.
         num_legal_windows = num_windows_of_length_M_on_buffers_of_length_N(

--- a/zipline/lib/_windowtemplate.pxi
+++ b/zipline/lib/_windowtemplate.pxi
@@ -67,7 +67,7 @@ cdef class AdjustedArrayWindow:
         if len(self.adjustment_indices) > 0:
             return self.adjustment_indices.pop()
         else:
-            return -1
+            return self.max_anchor + self.perspective_offset
 
     def __iter__(self):
         return self
@@ -86,9 +86,7 @@ cdef class AdjustedArrayWindow:
         # Apply any adjustments that occured before our current anchor.
         # Equivalently, apply any adjustments known **on or before** the date
         # for which we're calculating a window.
-        while (self.next_adj != -1
-               and
-               self.next_adj - self.perspective_offset < anchor):
+        while self.next_adj < anchor + self.perspective_offset:
 
             for adjustment in self.adjustments[self.next_adj]:
                 adjustment.mutate(self.data)


### PR DESCRIPTION
- Refactor `test_adjusted_array` to test a range of perspective_offsets in
  all tests.

- Make perspective_offset a parameter to `AdjustedArray.traverse`
  instead of `AdjustedArray`.