### PR TITLE
BUG: create adjustments based on ordered assets instead of set

### DIFF
--- a/zipline/pipeline/loaders/earnings_estimates.py
+++ b/zipline/pipeline/loaders/earnings_estimates.py
@@ -424,7 +424,6 @@ class EarningsEstimatesLoader(PipelineLoader):
         out = {}
         # To optimize performance, only work below on assets that are
         # actually in the raw data.
-        import pdb; pdb.set_trace()
         assets_with_data = set(assets) & set(self.estimates[SID_FIELD_NAME])
         last_per_qtr, stacked_last_per_qtr = self.get_last_data_per_qtr(
             assets_with_data,
@@ -452,7 +451,7 @@ class EarningsEstimatesLoader(PipelineLoader):
                 requested_qtr_data,
                 last_per_qtr,
                 dates,
-                requested_qtr_data.columns.levels[1],
+                assets,
                 columns
             )
 

--- a/zipline/pipeline/loaders/earnings_estimates.py
+++ b/zipline/pipeline/loaders/earnings_estimates.py
@@ -424,6 +424,7 @@ class EarningsEstimatesLoader(PipelineLoader):
         out = {}
         # To optimize performance, only work below on assets that are
         # actually in the raw data.
+        import pdb; pdb.set_trace()
         assets_with_data = set(assets) & set(self.estimates[SID_FIELD_NAME])
         last_per_qtr, stacked_last_per_qtr = self.get_last_data_per_qtr(
             assets_with_data,
@@ -446,12 +447,14 @@ class EarningsEstimatesLoader(PipelineLoader):
 
             # Calculate all adjustments for the given quarter and accumulate
             # them for each column.
-            col_to_adjustments = self.get_adjustments(zero_qtr_data,
-                                                      requested_qtr_data,
-                                                      last_per_qtr,
-                                                      dates,
-                                                      assets_with_data,
-                                                      columns)
+            col_to_adjustments = self.get_adjustments(
+                zero_qtr_data,
+                requested_qtr_data,
+                last_per_qtr,
+                dates,
+                requested_qtr_data.columns.levels[1],
+                columns
+            )
 
             # Lookup the asset indexer once, this is so we can reindex
             # the assets returned into the assets requested for each column.


### PR DESCRIPTION
This fixes a bug where we create adjustments for estimates based on where assets happen to fall in a set rather than using ordered assets. Not sure if this necessitates a test or what kind.