### PR TITLE
MAINT: Prevent hiding of KeyError in adjustments.

### DIFF
--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -415,11 +415,15 @@ class HistoryLoader(with_metaclass(ABCMeta)):
                 array = array.astype(float64_dtype)
 
             for i, asset in enumerate(needed_assets):
+                adj_reader = None
                 try:
                     adj_reader = self._adjustment_readers[type(asset)]
+                except KeyError:
+                    adj_reader = None
+                if adj_reader is not None:
                     adjs = adj_reader.load_adjustments(
                         [field], prefetch_dts, [asset])[0]
-                except KeyError:
+                else:
                     adjs = {}
                 window = window_type(
                     array[:, i].reshape(prefetch_len, 1),


### PR DESCRIPTION
If a KeyError occurred in the adjustment logic, the exception would be
swallowed by the try block, which was intended to just check whether or
not there was an adjustment reader adjusted.

Discovered when some logic in a futures adjustment reader were failing
because of a mismatch of minute and session labels, which resulted in no
adjustments during windows when there should have been.