### PR TITLE
BUG: Fix session from minute reader's last traded.

### DIFF
--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -604,9 +604,7 @@ class TestResampleSessionBars(WithBcolzFutureMinuteBarReader,
         )
 
         self.assertEqual(
-            self.trading_calendar.open_and_close_for_session(
-                self.trading_calendar.previous_session_label(self.END_DATE)
-            )[1],
+            self.trading_calendar.previous_session_label(self.END_DATE),
             self.session_bar_reader.get_last_traded_dt(future, self.END_DATE)
         )
 

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -562,7 +562,8 @@ class MinuteResampleSessionBarReader(SessionBarReader):
         return self._minute_bar_reader.first_trading_day
 
     def get_last_traded_dt(self, asset, dt):
-        return self._minute_bar_reader.get_last_traded_dt(asset, dt)
+        return self.trading_calendar.minute_to_session_label(
+            self._minute_bar_reader.get_last_traded_dt(asset, dt))
 
 
 class ReindexBarReader(with_metaclass(ABCMeta)):


### PR DESCRIPTION
The last traded dt provided from the session bar reader which resamples
from minutes should provide a dt that is a session label, not one that
is at the minute frequency.