### PR TITLE
MAINT: Return nan from daily bcolz get_value.

### DIFF
--- a/tests/data/test_us_equity_pricing.py
+++ b/tests/data/test_us_equity_pricing.py
@@ -18,6 +18,7 @@ from nose_parameterized import parameterized
 from numpy import (
     arange,
     datetime64,
+    nan,
 )
 from numpy.testing import (
     assert_array_equal,
@@ -340,7 +341,7 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, ZiplineTestCase):
             reader._spot_col('close')[zero_ix] = 0
 
             close = reader.get_value(zero_sid, zero_day, 'close')
-            self.assertEqual(-1, close)
+            assert_array_equal(nan, close)
         finally:
             reader._spot_col('close')[zero_ix] = old
 

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -19,6 +19,7 @@ from logbook import Logger
 import numpy as np
 from numpy import float64, int64
 import pandas as pd
+from pandas import isnull
 from pandas.tslib import normalize_date
 from six import iteritems
 from six.moves import reduce
@@ -632,14 +633,7 @@ class DataPortal(object):
         elif column in OHLCV_FIELDS:
             # don't forward fill
             try:
-                val = reader.get_value(asset, dt, column)
-                if val == -1:
-                    if column == "volume":
-                        return 0
-                    else:
-                        return np.nan
-                else:
-                    return val
+                return reader.get_value(asset, dt, column)
             except NoDataOnDate:
                 return np.nan
         elif column == "price":
@@ -649,7 +643,7 @@ class DataPortal(object):
                     value = reader.get_value(
                         asset, found_dt, "close"
                     )
-                    if value != -1:
+                    if not isnull(value):
                         if dt == found_dt:
                             return value
                         else:

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -36,6 +36,7 @@ from numpy import (
     uint32,
 )
 from pandas import (
+    isnull,
     DataFrame,
     read_csv,
     Timestamp,
@@ -706,10 +707,11 @@ class BcolzDailyBarReader(SessionBarReader):
         """
         ix = self.sid_day_index(sid, dt)
         price = self._spot_col(field)[ix]
-        if price == 0:
-            return -1
         if field != 'volume':
-            return price * 0.001
+            if price == 0:
+                return nan
+            else:
+                return price * 0.001
         else:
             return price
 
@@ -1001,7 +1003,7 @@ class SQLiteAdjustmentWriter(object):
             try:
                 prev_close = equity_daily_bar_reader.get_value(
                     sid, prev_close_date, 'close')
-                if prev_close != 0.0:
+                if not isnull(prev_close):
                     ratio = 1.0 - amount / prev_close
                     ratios[i] = ratio
                     # only assign effective_date when data is found


### PR DESCRIPTION
Match the behavior of the minute bar reader, now that the session and
minute bar readers share a common interface.

isnull is slightly slower than checking against -1; however, n cases
where we check against illiquid trades in a tight loop, volume is
checked which is not using nan. The change here should be marginal with
regards to performance.