### PR TITLE
ENH: Volume based rolls for futures.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -129,7 +129,8 @@ SID_TYPE_IDS = {
 }
 
 CONTINUOUS_FUTURE_ROLL_STYLE_IDS = {
-    'calendar': 0
+    'calendar': 0,
+    'volume': 1,
 }
 
 CONTINUOUS_FUTURE_ADJUSTMENT_STYLE_IDS = {

--- a/zipline/assets/continuous_futures.pyx
+++ b/zipline/assets/continuous_futures.pyx
@@ -297,7 +297,7 @@ cdef class OrderedContracts(object):
                 break
         return self.contract_sids[i]
 
-    cpdef long_t contract_at_offset(self, long_t sid, Py_ssize_t offset):
+    cpdef contract_at_offset(self, long_t sid, Py_ssize_t offset, int64_t start_cap):
         """
         Get the sid which is the given sid plus the offset distance.
         An offset of 0 should be reflexive.
@@ -305,9 +305,13 @@ cdef class OrderedContracts(object):
         cdef Py_ssize_t i
         cdef long_t[:] sids
         sids = self.contract_sids
+        start_dates = self.start_dates
         for i in range(self._size):
             if sid == sids[i]:
-                return sids[i + offset]
+                if start_dates[i + offset] < start_cap:
+                    return sids[i + offset]
+                else:
+                    return None
 
     cpdef long_t[:] active_chain(self, long_t starting_sid, long_t dt_value):
         cdef Py_ssize_t left, right, i, j

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -29,7 +29,10 @@ from zipline.data.continuous_future_reader import (
     ContinuousFutureSessionBarReader,
     ContinuousFutureMinuteBarReader
 )
-from zipline.assets.roll_finder import CalendarRollFinder
+from zipline.assets.roll_finder import (
+    CalendarRollFinder,
+    VolumeRollFinder
+)
 from zipline.data.dispatch_bar_reader import (
     AssetDispatchMinuteBarReader,
     AssetDispatchSessionBarReader
@@ -164,11 +167,6 @@ class DataPortal(object):
         else:
             self._last_trading_session = None
 
-        self._roll_finders = {
-            'calendar': CalendarRollFinder(self.trading_calendar,
-                                           self.asset_finder)
-        }
-
         aligned_equity_minute_reader = self._ensure_reader_aligned(
             equity_minute_reader)
         aligned_equity_session_reader = self._ensure_reader_aligned(
@@ -177,6 +175,11 @@ class DataPortal(object):
             future_minute_reader)
         aligned_future_session_reader = self._ensure_reader_aligned(
             future_daily_reader)
+
+        self._roll_finders = {
+            'calendar': CalendarRollFinder(self.trading_calendar,
+                                           self.asset_finder),
+        }
 
         aligned_minute_readers = {}
         aligned_session_readers = {}
@@ -196,6 +199,11 @@ class DataPortal(object):
 
         if aligned_future_session_reader is not None:
             aligned_session_readers[Future] = aligned_future_session_reader
+            self._roll_finders['volume'] = VolumeRollFinder(
+                self.trading_calendar,
+                self.asset_finder,
+                aligned_future_session_reader,
+            )
             aligned_session_readers[ContinuousFuture] = \
                 ContinuousFutureSessionBarReader(
                     aligned_future_session_reader,


### PR DESCRIPTION
Add roll style which takes the volume of the contracts into account.
If the volume moves from the front to the back before the auto close
date, the roll is put at that session.

Also, factors out some of the common logic shared with calendar based rolls.