### PR TITLE
DEV delete old *.c and *.so files with rebuild-cython.sh for Darwin/OSX

### DIFF
--- a/etc/rebuild-cython.sh
+++ b/etc/rebuild-cython.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
-find zipline tests -regex '.*\.\(c\|so\)' -exec rm {} +
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    find -E zipline tests -regex '.*\.(c|so)' -exec rm {} +
+else
+    find zipline tests -regex '.*\.\(c\|so\)' -exec rm {} +
+fi
 python setup.py build_ext --inplace


### PR DESCRIPTION
OSX's find supports a different syntax for `-regex`. As a result the original regex doesn't match any files and successfully does nothing.

I've confirmed that this change works with and without `brew install findutils --with-default-names`