### PR TITLE
MAINT: Restore @property decorator

### DIFF
--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -237,6 +237,7 @@ class TradingCalendar(with_metaclass(ABCMeta)):
 
     # -----
 
+    @property
     def opens(self):
         return self.schedule.market_open
 


### PR DESCRIPTION
This will keep `opens`, `closes`, `early_closes`, etc to the
same pattern.