### PR TITLE
MAINT: Rename `SpecificAssets` to `StaticAssets`.

### DIFF
--- a/tests/pipeline/test_filter.py
+++ b/tests/pipeline/test_filter.py
@@ -30,7 +30,7 @@ from zipline.errors import BadPercentileBounds
 from zipline.pipeline import Filter, Factor, Pipeline
 from zipline.pipeline.classifiers import Classifier
 from zipline.pipeline.factors import CustomFactor
-from zipline.pipeline.filters import All, Any, AtLeastN, SpecificAssets
+from zipline.pipeline.filters import All, Any, AtLeastN, StaticAssets
 from zipline.testing import parameter_space, permute_rows, ZiplineTestCase
 from zipline.testing.fixtures import WithSeededRandomPipelineEngine
 from zipline.testing.predicates import assert_equal
@@ -844,10 +844,10 @@ class SpecificAssetsTestCase(WithSeededRandomPipelineEngine,
         pipe = Pipeline(
             columns={
                 'sid': SidFactor(),
-                'evens': SpecificAssets(assets[::2]),
-                'odds': SpecificAssets(assets[1::2]),
-                'first_five': SpecificAssets(assets[:5]),
-                'last_three': SpecificAssets(assets[-3:]),
+                'evens': StaticAssets(assets[::2]),
+                'odds': StaticAssets(assets[1::2]),
+                'first_five': StaticAssets(assets[:5]),
+                'last_three': StaticAssets(assets[-3:]),
             },
         )
 

--- a/zipline/pipeline/filters/__init__.py
+++ b/zipline/pipeline/filters/__init__.py
@@ -8,7 +8,7 @@ from .filter import (
     NumExprFilter,
     PercentileFilter,
     SingleAsset,
-    SpecificAssets,
+    StaticAssets,
 )
 from .smoothing import All, Any, AtLeastN
 
@@ -25,5 +25,5 @@ __all__ = [
     'NumExprFilter',
     'PercentileFilter',
     'SingleAsset',
-    'SpecificAssets',
+    'StaticAssets',
 ]

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -501,11 +501,11 @@ class SingleAsset(Filter):
         return out
 
 
-class SpecificAssets(Filter):
+class StaticAssets(Filter):
     """
     A Filter that computes True for a specific set of predetermined assets.
 
-    ``SpecificAssets`` is mostly useful for debugging or for interactively
+    ``StaticAssets`` is mostly useful for debugging or for interactively
     computing pipeline terms for a fixed set of assets that are known ahead of
     time.
 
@@ -520,7 +520,7 @@ class SpecificAssets(Filter):
 
     def __new__(cls, assets):
         sids = frozenset(asset.sid for asset in assets)
-        return super(SpecificAssets, cls).__new__(cls, sids=sids)
+        return super(StaticAssets, cls).__new__(cls, sids=sids)
 
     def _compute(self, arrays, dates, sids, mask):
         my_columns = sids.isin(self.params['sids'])


### PR DESCRIPTION
This better reflects the intended usage of accepting a fixed set of
predetermined assets.