### PR TITLE
STY: Add space between import and open parens.

### DIFF
--- a/zipline/utils/calendars/exchange_calendar_bmf.py
+++ b/zipline/utils/calendars/exchange_calendar_bmf.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from datetime import time
-from pandas.tseries.holiday import(
+from pandas.tseries.holiday import (
     Holiday,
     Easter,
     Day,

--- a/zipline/utils/calendars/exchange_calendar_lse.py
+++ b/zipline/utils/calendars/exchange_calendar_lse.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from datetime import time
-from pandas.tseries.holiday import(
+from pandas.tseries.holiday import (
     Holiday,
     DateOffset,
     MO,

--- a/zipline/utils/calendars/exchange_calendar_nyse.py
+++ b/zipline/utils/calendars/exchange_calendar_nyse.py
@@ -16,7 +16,7 @@
 from datetime import time
 from itertools import chain
 
-from pandas.tseries.holiday import(
+from pandas.tseries.holiday import (
     GoodFriday,
     USLaborDay,
     USPresidentsDay,

--- a/zipline/utils/calendars/exchange_calendar_tsx.py
+++ b/zipline/utils/calendars/exchange_calendar_tsx.py
@@ -1,5 +1,5 @@
 from datetime import time
-from pandas.tseries.holiday import(
+from pandas.tseries.holiday import (
     Holiday,
     DateOffset,
     MO,


### PR DESCRIPTION
For compliance with newer flake8 versions.

Should be no functional change.