### PR TITLE
BUG: Fix `data.history` with a single continuous future.

### DIFF
--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -24,7 +24,7 @@ from six import iteritems, PY2, string_types
 from cpython cimport bool
 from collections import Iterable
 
-from zipline.assets import Asset, Future
+from zipline.assets import Asset, AssetConvertible, Future
 from zipline.assets.continuous_futures import ContinuousFuture
 from zipline.zipline_warnings import ZiplineDeprecationWarning
 
@@ -637,7 +637,7 @@ cdef class BarData:
         last market close instead.
         """
         if isinstance(fields, string_types):
-            single_asset = isinstance(assets, Asset)
+            single_asset = isinstance(assets, AssetConvertible)
 
             if single_asset:
                 asset_list = [assets]
@@ -670,7 +670,7 @@ cdef class BarData:
                 # columns are the assets, indexed by dt.
                 return df
         else:
-            if isinstance(assets, Asset):
+            if isinstance(assets, AssetConvertible):
                 # one asset, multiple fields. for now, just make multiple
                 # history calls, one per field, then stitch together the
                 # results. this can definitely be optimized!

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -1218,6 +1218,7 @@ class AssetConvertible(with_metaclass(ABCMeta)):
 
 AssetConvertible.register(Integral)
 AssetConvertible.register(Asset)
+AssetConvertible.register(ContinuousFuture)
 # Use six.string_types for Python2/3 compatibility
 for _type in string_types:
     AssetConvertible.register(_type)


### PR DESCRIPTION
Allow `ContinuousFuture` when checking for a single "asset".

This could be further improved by:

- Defininng a tuple of the `Asset`-like types OR making
`ContinuousFuture` and `Asset` share a common type (whether that is
`ContinuousFuture` inheriting from `Asset` or making `Asset` and
`ContinuousFuture` share a common type.)

- Make a `history` test which uses `BarData` + `ContinuousFuture`,
instead of just using the history loader directly from tests.