### PR TITLE
MAiNT: Add a pricing data shared abc.

### DIFF
--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -24,7 +24,10 @@ from six import iteritems, PY2, string_types
 from cpython cimport bool
 from collections import Iterable
 
-from zipline.assets import Asset, AssetConvertible, Future
+from zipline.assets import (Asset,
+                            AssetConvertible,
+                            PricingDataAssociable,
+                            Future)
 from zipline.assets.continuous_futures import ContinuousFuture
 from zipline.zipline_warnings import ZiplineDeprecationWarning
 
@@ -637,7 +640,7 @@ cdef class BarData:
         last market close instead.
         """
         if isinstance(fields, string_types):
-            single_asset = isinstance(assets, AssetConvertible)
+            single_asset = isinstance(assets, PricingDataAssociable)
 
             if single_asset:
                 asset_list = [assets]
@@ -670,7 +673,7 @@ cdef class BarData:
                 # columns are the assets, indexed by dt.
                 return df
         else:
-            if isinstance(assets, AssetConvertible):
+            if isinstance(assets, PricingDataAssociable):
                 # one asset, multiple fields. for now, just make multiple
                 # history calls, one per field, then stitch together the
                 # results. this can definitely be optimized!

--- a/zipline/assets/__init__.py
+++ b/zipline/assets/__init__.py
@@ -23,6 +23,7 @@ from ._assets import (
 from .assets import (
     AssetFinder,
     AssetConvertible,
+    PricingDataAssociable,
 )
 from .asset_db_schema import ASSET_DB_VERSION
 from .asset_writer import AssetDBWriter
@@ -35,6 +36,7 @@ __all__ = [
     'Future',
     'AssetFinder',
     'AssetConvertible',
+    'PricingDataAssociable',
     'make_asset_array',
     'CACHE_FILE_TEMPLATE'
 ]

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -1218,7 +1218,6 @@ class AssetConvertible(with_metaclass(ABCMeta)):
 
 AssetConvertible.register(Integral)
 AssetConvertible.register(Asset)
-AssetConvertible.register(ContinuousFuture)
 # Use six.string_types for Python2/3 compatibility
 for _type in string_types:
     AssetConvertible.register(_type)
@@ -1226,6 +1225,19 @@ for _type in string_types:
 
 class NotAssetConvertible(ValueError):
     pass
+
+
+class PricingDataAssociable(with_metaclass(ABCMeta)):
+    """
+    ABC for types that can be associated with pricing data.
+
+    Includes Asset, Future, ContinuousFuture
+    """
+    pass
+
+PricingDataAssociable.register(Asset)
+PricingDataAssociable.register(Future)
+PricingDataAssociable.register(ContinuousFuture)
 
 
 def was_active(reference_date_value, asset):


### PR DESCRIPTION
Register equities, futures, and continuous futures to an `abc` which
signifies that the type is associable with data, and thus can be used in
a history context.

May want to use this in `check_parameters` for `BarData` methods, but
work would need to be done to make sure the error message still displays
the registered types.