### PR TITLE
BUG: Fix bad attribute lookup on session continuous future reader.

### DIFF
--- a/tests/test_continuous_futures.py
+++ b/tests/test_continuous_futures.py
@@ -222,7 +222,7 @@ class ContinuousFuturesTestCase(WithCreateBarData,
                          'Auto close at beginning of session so FOG16 is now '
                          'the current contract.')
 
-    def test_get_spot_value_contract_daily(self):
+    def test_get_value_contract_daily(self):
         cf_primary = self.asset_finder.create_continuous_future(
             'FO', 0, 'calendar')
 
@@ -243,6 +243,30 @@ class ContinuousFuturesTestCase(WithCreateBarData,
         )
 
         self.assertEqual(contract.symbol, 'FOG16',
+                         'Auto close at beginning of session so FOG16 is now '
+                         'the current contract.')
+
+    def test_get_value_close_daily(self):
+        cf_primary = self.asset_finder.create_continuous_future(
+            'FO', 0, 'calendar')
+
+        value = self.data_portal.get_spot_value(
+            cf_primary,
+            'close',
+            pd.Timestamp('2016-01-26', tz='UTC'),
+            'daily',
+        )
+
+        self.assertEqual(value, 105011.44)
+
+        value = self.data_portal.get_spot_value(
+            cf_primary,
+            'close',
+            pd.Timestamp('2016-01-27', tz='UTC'),
+            'daily',
+        )
+
+        self.assertEqual(value, 115021.44,
                          'Auto close at beginning of session so FOG16 is now '
                          'the current contract.')
 

--- a/zipline/data/continuous_future_reader.py
+++ b/zipline/data/continuous_future_reader.py
@@ -135,7 +135,7 @@ class ContinuousFutureSessionBarReader(SessionBarReader):
             If the given dt is not a valid market minute (in minute mode) or
             session (in daily mode) according to this reader's tradingcalendar.
         """
-        rf = self._roll_finders[continuous_future.roll]
+        rf = self._roll_finders[continuous_future.roll_style]
         sid = (rf.get_contract_center(continuous_future.root_symbol,
                                       dt,
                                       continuous_future.offset))

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -541,7 +541,7 @@ class MinuteResampleSessionBarReader(SessionBarReader):
         # This was developed to complete interface, but has not been tuned
         # for real world use.
         start, end = self._calendar.open_and_close_for_session(session)
-        return self._get_resampled([colname], start, end, [sid])[0]
+        return self._get_resampled([colname], start, end, [sid])[0][0][0]
 
     @lazyval
     def sessions(self):


### PR DESCRIPTION
Use `roll_style` not `roll`.

Also, add test case to cover using the session bar reader `get_value`,
by adding a test which uses `close`, since only `contract` was being
exercised, which does not exercise the session daily bar reader.