### PR TITLE
BUG: Fix continuous future end dates.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -922,8 +922,9 @@ class AssetFinder(object):
 
     def create_continuous_future(self, root_symbol, offset, roll_style):
         oc = self.get_ordered_contracts(root_symbol)
-        start_date = self.retrieve_asset(oc.contract_sids[0]).start_date
-        end_date = self.retrieve_asset(oc.contract_sids[-1]).end_date
+        contracts = self.retrieve_all(oc.contract_sids)
+        start_date = min(c.start_date for c in contracts)
+        end_date = max(c.end_date for c in contracts)
         exchange = self._get_root_symbol_exchange(root_symbol)
 
         sid = _encode_continuous_future_sid(root_symbol, offset,


### PR DESCRIPTION
The end date of the last contract with a sufficient start date was being
used for the continuous future overall end date; however the end date of
that contract (which is the last day for which there is data for the
contract) is not necessarily the greatest end date out of all contracts.
It is possible for the furthest out contract to have some, but very
few, trades before it is more actively traded. Which would give it a
start date within in the range of the simulation, but an end date is
earlier than the other contracts which are active during the simulation.

This bug would result in `nan`s when getting the current price because
of the `end_date` check in `get_spot_value`. When the current simulation
time was greater than the `end_date` of the last contract the condition
which guards against attempting to get data for an instrument past its
end date would return a `nan`, even when the current underlying contract
did have data for that date.

Use max end date of all contracts instead of the last one, to ensure
that the continuous future last date is always great enough to allow
access to all contracts with in the chain.

Also, use min start date to accurately mirror the end date behavior.