### PR TITLE
PERF: Speed up retrieval of HistoryLoader calendar.

### DIFF
--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -573,8 +573,9 @@ class MinuteHistoryLoader(HistoryLoader):
     @lazyval
     def _calendar(self):
         mm = self.trading_calendar.all_minutes
-        return mm[mm.slice_indexer(start=self._reader.first_trading_day,
-                                   end=self._reader.last_available_dt)]
+        start = mm.searchsorted(self._reader.first_trading_day)
+        end = mm.searchsorted(self._reader.last_available_dt, side='right')
+        return mm[start:end]
 
     def _array(self, dts, assets, field):
         return self._reader.load_raw_arrays(


### PR DESCRIPTION
The use of `slice_indexer` on all market minutes was taking about 110ms on my
development machine.

This change to getting the start and end indices changes the entire `_calendar`
method to take 10ms on the same machine.

Noticed while creating a `HistoryLoader` in a notebook context.