### PR TITLE
MAINT: Remove duplicate get_rolls in reader.

### DIFF
--- a/zipline/data/continuous_future_reader.py
+++ b/zipline/data/continuous_future_reader.py
@@ -45,8 +45,6 @@ class ContinuousFutureSessionBarReader(SessionBarReader):
         # Get partitions
         partitions_by_asset = {}
         for asset in assets:
-            rolls_by_asset[asset] = rf.get_rolls(
-                asset.root_symbol, start_date, end_date, asset.offset)
             partitions = []
             partitions_by_asset[asset] = partitions
             rolls = rolls_by_asset[asset]


### PR DESCRIPTION
The rolls are already calculated and assigned to `rolls_by_asset` earlier in the
`load_raw_arrays` method, so remove the duplication.

The change should not affect results.