### PR TITLE
ENH: An improved error message when calling zipline api functions

### DIFF
--- a/zipline/utils/api_support.py
+++ b/zipline/utils/api_support.py
@@ -48,7 +48,13 @@ def api_method(f):
     @wraps(f)
     def wrapped(*args, **kwargs):
         # Get the instance and call the method
-        return getattr(get_algo_instance(), f.__name__)(*args, **kwargs)
+        algo_instance = get_algo_instance()
+        if algo_instance is None:
+            raise RuntimeError(
+                'zipline api method %s must be called during a simulation.'
+                % f.__name__
+            )
+        return getattr(algo_instance, f.__name__)(*args, **kwargs)
     # Add functor to zipline.api
     setattr(zipline.api, f.__name__, wrapped)
     zipline.api.__all__.append(f.__name__)


### PR DESCRIPTION
outside of a running simulation. Previously, an AttributeError was
raised.

The goal here is to make the situation clearer for developers, for example: https://github.com/quantopian/zipline/issues/1541 and https://github.com/quantopian/zipline/issues/448#issuecomment-249312347

What do folks think of the message?