### PR TITLE
TMP: Add temporary fix for transactions with nan fill prices.

### DIFF
--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -18,6 +18,8 @@ import abc
 import math
 from six import with_metaclass
 
+from pandas import isnull
+
 from zipline.finance.transaction import create_transaction
 
 SELL = 1 << 0
@@ -75,6 +77,14 @@ class SlippageModel(with_metaclass(abc.ABCMeta)):
         # can use the close price, since we verified there's volume in this
         # bar.
         price = data.current(asset, "close")
+
+        # BEGIN
+        #
+        # Remove this block after fixing data to ensure volume always has
+        # corresponding price.
+        if isnull(price):
+            return
+        # END
         dt = data.current_dt
 
         for order in orders_for_asset:
@@ -158,6 +168,14 @@ class VolumeShareSlippage(SlippageModel):
                            self.volume_limit)
 
         price = data.current(order.asset, "close")
+
+        # BEGIN
+        #
+        # Remove this block after fixing data to ensure volume always has
+        # corresponding price.
+        if isnull(price):
+            return
+        # END
 
         simulated_impact = volume_share ** 2 \
             * math.copysign(self.price_impact, order.direction) \


### PR DESCRIPTION
Protect a case where data is written with a non-zero volume, but a 0/nan for the
OHLC values. The slippage model was relying on a non-zero volume implying that
there was a valid trade price for the corresponding bar. When there was a mismatch,
a transaction with a nan value was created, which would in turn propagate the
nan into portfolio value, which would then cause errors when the portfolio value
was used to size orders during rebalancing.

When data is fixed, can remove.
(Also may want to add behavior to minute bar writer to ensure that 0 volumes
always have corresponding nan ohlc.)