### PR TITLE
Order batch

### DIFF
--- a/tests/pipeline/test_quarters_estimates.py
+++ b/tests/pipeline/test_quarters_estimates.py
@@ -453,10 +453,6 @@ class WithEstimatesTimeZero(WithEstimates):
             SID_FIELD_NAME: sid,
         })
 
-    @classmethod
-    def init_class_fixtures(cls):
-        super(WithEstimatesTimeZero, cls).init_class_fixtures()
-
     def get_expected_estimate(self,
                               q1_knowledge,
                               q2_knowledge,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -123,6 +123,7 @@ from zipline.test_algorithms import (
     TestTargetAlgorithm,
     TestTargetPercentAlgorithm,
     TestTargetValueAlgorithm,
+    TestBatchTargetPercentAlgorithm,
     SetLongOnlyAlgorithm,
     SetAssetDateBoundsAlgorithm,
     SetMaxPositionSizeAlgorithm,
@@ -905,14 +906,15 @@ def before_trading_start(context, data):
         self.assertEqual(algo.sim_params.data_frequency, 'minute')
 
     @parameterized.expand([
-        (TestOrderAlgorithm,),
-        (TestOrderValueAlgorithm,),
-        (TestTargetAlgorithm,),
-        (TestOrderPercentAlgorithm,),
-        (TestTargetPercentAlgorithm,),
-        (TestTargetValueAlgorithm,),
+        ('order', TestOrderAlgorithm,),
+        ('order_value', TestOrderValueAlgorithm,),
+        ('order_target', TestTargetAlgorithm,),
+        ('order_percent', TestOrderPercentAlgorithm,),
+        ('order_target_percent', TestTargetPercentAlgorithm,),
+        ('order_target_value', TestTargetValueAlgorithm,),
+        ('batch_order_target_percent', TestBatchTargetPercentAlgorithm,),
     ])
-    def test_order_methods(self, algo_class):
+    def test_order_methods(self, test_name, algo_class):
         algo = algo_class(
             sim_params=self.sim_params,
             env=self.env,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -939,7 +939,7 @@ def before_trading_start(context, data):
             sim_params=self.sim_params,
             env=self.env,
         )
-        # Ensure that the environment's asset 0 is a Future
+        # Ensure that the environment's asset 3 is a Future
         asset_to_test = algo.sid(3)
         self.assertIsInstance(asset_to_test, Future)
 
@@ -1019,7 +1019,7 @@ def before_trading_start(context, data):
             sim_params = SimulationParameters(
                 start_session=start_session,
                 end_session=period_end,
-                capital_base=float("1.0e5"),
+                capital_base=1.0e5,
                 data_frequency='minute',
                 trading_calendar=self.trading_calendar,
             )
@@ -3701,7 +3701,7 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendars, ZiplineTestCase):
         cls.first_asset_expiration = cls.test_days[2]
 
     def make_data(self, auto_close_delta, frequency,
-                  capital_base=float("1.0e5")):
+                  capital_base=1.0e5):
 
         asset_info = make_jagged_equity_info(
             num_assets=3,

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -340,22 +340,22 @@ class BlotterTestCase(WithCreateBarData,
         blotter2 = Blotter(self.sim_params.data_frequency,
                            self.asset_finder)
         for i in range(1, 4):
-            order_args = [
+            order_arg_lists = [
                 (self.asset_24, i * 100, MarketOrder()),
                 (self.asset_25, i * 100, LimitOrder(i * 100 + 1)),
             ]
 
-            order_batch_ids = blotter1.order_batch(order_args)
+            order_batch_ids = blotter1.order_batch(order_arg_lists)
             order_ids = []
-            for order_arg in order_args:
-                order_ids.append(blotter2.order(*order_arg))
+            for order_args in order_arg_lists:
+                order_ids.append(blotter2.order(*order_args))
             self.assertEqual(len(order_batch_ids), len(order_ids))
 
             self.assertEqual(len(blotter1.open_orders),
                              len(blotter2.open_orders))
 
             for (asset, _, _), order_batch_id, order_id in zip(
-                    order_args, order_batch_ids, order_ids
+                    order_arg_lists, order_batch_ids, order_ids
             ):
                 self.assertEqual(len(blotter1.open_orders[asset]),
                                  len(blotter2.open_orders[asset]))

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -330,7 +330,7 @@ class BlotterTestCase(WithCreateBarData,
 
         blotter.prune_orders([other_order])
 
-    def test_order_batch_matches_multi_order(self):
+    def test_batch_order_matches_multiple_orders(self):
         """
         Ensure the effect of order_batch is the same as multiple calls to
         order.
@@ -345,7 +345,7 @@ class BlotterTestCase(WithCreateBarData,
                 (self.asset_25, i * 100, LimitOrder(i * 100 + 1)),
             ]
 
-            order_batch_ids = blotter1.order_batch(order_arg_lists)
+            order_batch_ids = blotter1.batch_order(order_arg_lists)
             order_ids = []
             for order_args in order_arg_lists:
                 order_ids.append(blotter2.order(*order_args))

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1404,6 +1404,12 @@ class TradingAlgorithm(object):
         if not self._can_order_asset(asset):
             return None
 
+        amount, style = self._calculate_order(asset, amount,
+                                              limit_price, stop_price, style)
+        return self.blotter.order(asset, amount, style)
+
+    def _calculate_order(self, asset, amount,
+                         limit_price=None, stop_price=None, style=None):
         # Truncate to the integer share count that's either within .0001 of
         # amount or closer to zero.
         # E.g. 3.9999 -> 4.0; 5.5 -> 5.0; -5.5 -> -5.0
@@ -1421,7 +1427,7 @@ class TradingAlgorithm(object):
         style = self.__convert_order_params_for_blotter(limit_price,
                                                         stop_price,
                                                         style)
-        return self.blotter.order(asset, amount, style)
+        return amount, style
 
     def validate_order_params(self,
                               asset,
@@ -1744,11 +1750,15 @@ class TradingAlgorithm(object):
         if not self._can_order_asset(asset):
             return None
 
+        amount = self._calculate_order_percent_amount(asset, percent)
+        return self.order(asset, amount,
+                          limit_price=limit_price,
+                          stop_price=stop_price,
+                          style=style)
+
+    def _calculate_order_percent_amount(self, asset, percent):
         value = self.portfolio.portfolio_value * percent
-        return self.order_value(asset, value,
-                                limit_price=limit_price,
-                                stop_price=stop_price,
-                                style=style)
+        return self._calculate_order_value_amount(asset, value)
 
     @api_method
     @disallowed_in_before_trading_start(OrderInBeforeTradingStart())
@@ -1810,18 +1820,18 @@ class TradingAlgorithm(object):
         if not self._can_order_asset(asset):
             return None
 
+        amount = self._calculate_order_target_amount(asset, target)
+        return self.order(asset, amount,
+                          limit_price=limit_price,
+                          stop_price=stop_price,
+                          style=style)
+
+    def _calculate_order_target_amount(self, asset, target):
         if asset in self.portfolio.positions:
             current_position = self.portfolio.positions[asset].amount
-            req_shares = target - current_position
-            return self.order(asset, req_shares,
-                              limit_price=limit_price,
-                              stop_price=stop_price,
-                              style=style)
-        else:
-            return self.order(asset, target,
-                              limit_price=limit_price,
-                              stop_price=stop_price,
-                              style=style)
+            target -= current_position
+
+        return target
 
     @api_method
     @disallowed_in_before_trading_start(OrderInBeforeTradingStart())
@@ -1885,10 +1895,11 @@ class TradingAlgorithm(object):
             return None
 
         target_amount = self._calculate_order_value_amount(asset, target)
-        return self.order_target(asset, target_amount,
-                                 limit_price=limit_price,
-                                 stop_price=stop_price,
-                                 style=style)
+        amount = self._calculate_order_target_amount(asset, target_amount)
+        return self.order(asset, amount,
+                          limit_price=limit_price,
+                          stop_price=stop_price,
+                          style=style)
 
     @api_method
     @disallowed_in_before_trading_start(OrderInBeforeTradingStart())
@@ -1947,11 +1958,15 @@ class TradingAlgorithm(object):
         if not self._can_order_asset(asset):
             return None
 
-        target_value = self.portfolio.portfolio_value * target
-        return self.order_target_value(asset, target_value,
-                                       limit_price=limit_price,
-                                       stop_price=stop_price,
-                                       style=style)
+        amount = self._calculate_order_target_percent_amount(asset, target)
+        return self.order(asset, amount,
+                          limit_price=limit_price,
+                          stop_price=stop_price,
+                          style=style)
+
+    def _calculate_order_target_percent_amount(self, asset, target):
+        target_amount = self._calculate_order_percent_amount(asset, target)
+        return self._calculate_order_target_amount(asset, target_amount)
 
     @error_keywords(sid='Keyword argument `sid` is no longer supported for '
                         'get_open_orders. Use `asset` instead.')

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1382,8 +1382,9 @@ class TradingAlgorithm(object):
 
         Returns
         -------
-        order_id : str
-            The unique identifier for this order.
+        order_id : str or None
+            The unique identifier for this order, or None if no order was
+            placed.
 
         Notes
         -----

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import Iterable
+try:
+    # optional cython based OrderedDict
+    from cyordereddict import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 from copy import copy
 import operator as op
 import warnings
@@ -33,6 +38,7 @@ from six import (
     itervalues,
     string_types,
     viewkeys,
+    viewvalues,
 )
 
 from zipline._protocol import handle_non_market_minutes
@@ -1916,7 +1922,7 @@ class TradingAlgorithm(object):
         ----------
         asset : Asset
             The asset that this order is for.
-        percent : float
+        target : float
             The desired percentage of the porfolio value to allocate to
             ``asset``. This is specified as a decimal, for example:
             0.50 means 50%.
@@ -1968,6 +1974,36 @@ class TradingAlgorithm(object):
     def _calculate_order_target_percent_amount(self, asset, target):
         target_amount = self._calculate_order_percent_amount(asset, target)
         return self._calculate_order_target_amount(asset, target_amount)
+
+    @api_method
+    @disallowed_in_before_trading_start(OrderInBeforeTradingStart())
+    def batch_order_target_percent(self, weights):
+        """Place orders towards a given portfolio of weights.
+
+        Parameters
+        ----------
+        weights : collections.Mapping[Asset -> float]
+
+        Returns
+        -------
+        order_ids : pd.Series[Asset -> str]
+            The unique identifiers for the orders that were placed.
+
+        See Also
+        --------
+        :func:`zipline.api.order_target_percent`
+        """
+        order_args = OrderedDict()
+        for asset, target in iteritems(weights):
+            if self._can_order_asset(asset):
+                amount = self._calculate_order_target_percent_amount(
+                    asset, target,
+                )
+                amount, style = self._calculate_order(asset, amount)
+                order_args[asset] = (asset, amount, style)
+
+        order_ids = self.blotter.batch_order(viewvalues(order_args))
+        return pd.Series(data=order_ids, index=order_args)
 
     @error_keywords(sid='Keyword argument `sid` is no longer supported for '
                         'get_open_orders. Use `asset` instead.')

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -2003,7 +2003,8 @@ class TradingAlgorithm(object):
                 order_args[asset] = (asset, amount, style)
 
         order_ids = self.blotter.batch_order(viewvalues(order_args))
-        return pd.Series(data=order_ids, index=order_args)
+        order_ids = pd.Series(data=order_ids, index=order_args)
+        return order_ids[~order_ids.isnull()]
 
     @error_keywords(sid='Keyword argument `sid` is no longer supported for '
                         'get_open_orders. Use `asset` instead.')

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -75,12 +75,29 @@ class Blotter(object):
         self.current_dt = dt
 
     def order(self, sid, amount, style, order_id=None):
+        """Place an order.
 
-        # something could be done with amount to further divide
-        # between buy by share count OR buy shares up to a dollar amount
-        # numeric == share count  AND  "$dollar.cents" == cost amount
+        Parameters
+        ----------
+        asset : zipline.assets.Asset
+            The asset that this order is for.
+        amount : int
+            The amount of shares to order. If ``amount`` is positive, this is
+            the number of shares to buy or cover. If ``amount`` is negative,
+            this is the number of shares to sell or short.
+        style : zipline.finance.execution.ExecutionStyle
+            The execution style for the order.
+        order_id : str, optional
+            The unique identifier for this order.
 
-        """
+        Returns
+        -------
+        order_id : str or None
+            The unique identifier for this order, or None if no order was
+            placed.
+
+        Notes
+        -----
         amount > 0 :: Buy/Cover
         amount < 0 :: Sell/Short
         Market order:    order(sid, amount)
@@ -89,6 +106,10 @@ class Blotter(object):
         StopLimit order: order(sid, amount, style=StopLimitOrder(limit_price,
                                stop_price))
         """
+        # something could be done with amount to further divide
+        # between buy by share count OR buy shares up to a dollar amount
+        # numeric == share count  AND  "$dollar.cents" == cost amount
+
         if amount == 0:
             # Don't bother placing orders for 0 shares.
             return None
@@ -114,8 +135,26 @@ class Blotter(object):
 
         return order.id
 
-    def order_batch(self, orders):
-        return [self.order(*order) for order in orders]
+    def order_batch(self, order_arg_lists):
+        """Place a batch of orders.
+
+        Parameters
+        ----------
+        order_arg_lists : iterable[tuple]
+            Tuples of args that `order` expects.
+
+        Returns
+        -------
+        order_ids : list[str or None]
+            The unique identifier (or None) for each of the orders placed
+            (or not placed).
+
+        Notes
+        -----
+        This is required for `Blotter` subclasses to be able to place a batch
+        of orders, instead of being passed the order requests one at a time.
+        """
+        return [self.order(*order_args) for order_args in order_arg_lists]
 
     def cancel(self, order_id, relay_status=True):
         if order_id not in self.orders:

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -91,7 +91,7 @@ class Blotter(object):
         """
         if amount == 0:
             # Don't bother placing orders for 0 shares.
-            return
+            return None
         elif amount > self.max_shares:
             # Arbitrary limit of 100 billion (US) shares will never be
             # exceeded except by a buggy algorithm.

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -114,6 +114,9 @@ class Blotter(object):
 
         return order.id
 
+    def order_batch(self, orders):
+        return [self.order(*order) for order in orders]
+
     def cancel(self, order_id, relay_status=True):
         if order_id not in self.orders:
             return

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -135,7 +135,7 @@ class Blotter(object):
 
         return order.id
 
-    def order_batch(self, order_arg_lists):
+    def batch_order(self, order_arg_lists):
         """Place a batch of orders.
 
         Parameters

--- a/zipline/finance/order.py
+++ b/zipline/finance/order.py
@@ -58,7 +58,7 @@ class Order(object):
         assert isinstance(sid, Asset)
 
         # get a string representation of the uuid.
-        self.id = id or self.make_id()
+        self.id = self.make_id() if id is None else id
         self.dt = dt
         self.reason = None
         self.created = dt

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -429,8 +429,16 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
                 "Orders not filled at current price."
 
         self.sale_price = data.current(sid(0), "price")
-        self.order_target_percent(self.sid(0), .002)
+        self._order(self.sid(0), .002)
         self.ordered = True
+
+    def _order(self, asset, target):
+        return self.order_target_percent(asset, target)
+
+
+class TestBatchTargetPercentAlgorithm(TestTargetPercentAlgorithm):
+    def _order(self, asset, target):
+        return self.batch_order_target_percent({asset: target})
 
 
 class TestTargetValueAlgorithm(TradingAlgorithm):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -411,7 +411,7 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
 
     def handle_data(self, data):
         if not self.ordered:
-            assert 0 not in self.portfolio.positions
+            assert not self.portfolio.positions
         else:
             # Since you can't own fractional shares (at least in this
             # example), we want to make sure that our target amount is
@@ -429,7 +429,7 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
                 "Orders not filled at current price."
 
         self.sale_price = data.current(sid(0), "price")
-        self._order(self.sid(0), .002)
+        self._order(sid(0), .002)
         self.ordered = True
 
     def _order(self, asset, target):

--- a/zipline/testing/__init__.py
+++ b/zipline/testing/__init__.py
@@ -7,6 +7,7 @@ from .core import (  # noqa
     FetcherDataPortal,
     MockDailyBarReader,
     OpenPrice,
+    RecordBatchBlotter,
     add_security_data,
     all_pairs_matching_predicate,
     all_subindices,

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -39,6 +39,7 @@ from zipline.data.us_equity_pricing import (
     BcolzDailyBarWriter,
     SQLiteAdjustmentWriter,
 )
+from zipline.finance.blotter import Blotter
 from zipline.finance.trading import TradingEnvironment
 from zipline.finance.order import ORDER_STATUS
 from zipline.lib.labelarray import LabelArray
@@ -1500,6 +1501,20 @@ def ensure_doctest(f, name=None):
         f.__name__ if name is None else name
     ] = f
     return f
+
+
+class RecordBatchBlotter(Blotter):
+    """Blotter that tracks how its batch_order method was called.
+    """
+    def __init__(self, data_frequency, asset_finder):
+        super(RecordBatchBlotter, self).__init__(
+            data_frequency, asset_finder,
+        )
+        self.order_batch_called = []
+
+    def batch_order(self, *args, **kwargs):
+        self.order_batch_called.append((args, kwargs))
+        return super(RecordBatchBlotter, self).batch_order(*args, **kwargs)
 
 
 ####################################

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -366,6 +366,12 @@ class WithAssetFinder(WithDefaultDateBounds):
 
     @classmethod
     def make_asset_finder(cls):
+        """Returns a new AssetFinder
+
+        Returns
+        -------
+        asset_finder : zipline.assets.AssetFinder
+        """
         return cls.enter_class_context(tmp_asset_finder(
             url=cls.make_asset_finder_db_url(),
             equities=cls.make_equity_info(),

--- a/zipline/utils/calendars/calendar_utils.py
+++ b/zipline/utils/calendars/calendar_utils.py
@@ -67,7 +67,7 @@ class TradingCalendarDispatcher(object):
 
         Returns
         -------
-        TradingCalendar
+        calendar : zipline.utils.calendars.TradingCalendar
             The desired calendar.
         """
         canonical_name = self.resolve_alias(name)


### PR DESCRIPTION
Adds `order_batch` to the blotter and factors out ordering helper methods, so one can generate the orders and give them to `order_batch`.