### PR TITLE
BUG: Fix index error when volume roll occurs at end of window.

### DIFF
--- a/tests/test_continuous_futures.py
+++ b/tests/test_continuous_futures.py
@@ -618,6 +618,49 @@ def record_current_contract(algo, data):
                          2,
                          "Should be FOH16 on session after roll.")
 
+        # This query is constructed so that the roll occurs at the end of the
+        # window when there is no prefetch, to protect against a case where the
+        # back contract being active at the end of the window caused an index
+        # error in the roll finder because the front contract's auto close was
+        # beyond the end of the window, which created index errors when
+        # attempting to use that date within the session index.
+        window = self.data_portal.get_history_window(
+            [cf],
+            Timestamp('2016-03-18 18:01', tz='US/Eastern').tz_convert('UTC'),
+            30, '1d', 'sid')
+
+        self.assertEqual(window.loc['2016-02-09', cf],
+                         1,
+                         "Should be FOG16 at beginning of window.")
+
+        self.assertEqual(window.loc['2016-02-10', cf],
+                         1,
+                         "Should have remained FOG16.")
+
+        self.assertEqual(window.loc['2016-02-25', cf],
+                         1,
+                         "Should be FOG16 on session before roll.")
+
+        self.assertEqual(window.loc['2016-02-26', cf],
+                         2,
+                         "Should be FOH16 on session with roll.")
+
+        self.assertEqual(window.loc['2016-02-29', cf],
+                         2,
+                         "Should be FOH16 on session after roll.")
+
+        self.assertEqual(window.loc['2016-03-17', cf],
+                         2,
+                         "Should be FOH16 on session before roll.")
+
+        self.assertEqual(window.loc['2016-03-18', cf],
+                         3,
+                         "Should be FOJ16 on session with roll.")
+
+        self.assertEqual(window.loc['2016-03-21', cf],
+                         3,
+                         "Should be FOJ16 on session after roll.")
+
         # Advance the window a month.
         window = self.data_portal.get_history_window(
             [cf],

--- a/zipline/assets/roll_finder.py
+++ b/zipline/assets/roll_finder.py
@@ -96,9 +96,12 @@ class RollFinder(with_metaclass(ABCMeta, object)):
             i -= 1
         else:
             i -= 2
-        auto_close_date = Timestamp(oc.auto_close_dates[i], tz='UTC')
-        while auto_close_date > start and i > -1:
-            session_loc = sessions.searchsorted(auto_close_date)
+
+        curr = min(
+            Timestamp(oc.auto_close_dates[i], tz='UTC'), sessions[-1])
+
+        while curr >= start and i > -1:
+            session_loc = sessions.get_loc(curr)
             front = oc.contract_sids[i]
             back = oc.contract_sids[i + 1]
             while session_loc > -1:
@@ -111,8 +114,7 @@ class RollFinder(with_metaclass(ABCMeta, object)):
                 rolls.insert(0, (oc.contract_sids[i + offset],
                                  roll_session))
             i -= 1
-            auto_close_date = Timestamp(oc.auto_close_dates[i],
-                                        tz='UTC')
+            curr = Timestamp(oc.auto_close_dates[i], tz='UTC')
         return rolls
 
 


### PR DESCRIPTION
When a volume roll makes the back contract the primary at the end of a window,
the next auto close to use in the roll finder loop (i.e. the auto close of the
front contract on the last session of the window) is greater than the last date
of the window. This caused an index error because the auto close would
searchsorted

Fix by changing the start date when entering the loop to calculate rolls so that
it takes the floor of the auto close and the next date to consider while working
backwards.

Also, use `get_loc` instead of `searchsorted` since exact dates are used.