### PR TITLE
MAINT: Improve minute writer handling of non-trading minutes

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -754,7 +754,7 @@ class BcolzMinuteBarWriter(object):
 
         tds = self._session_labels
         input_first_day = self._calendar.minute_to_session_label(
-            pd.Timestamp(dts[0]))
+            pd.Timestamp(dts[0]), direction='previous')
 
         last_date = self.last_date_in_output_for_sid(sid)
 


### PR DESCRIPTION
Previously, if input to the BcolzMinuteBarWriter had the first bar on a
non-trading minute, the next trading session would be considered the
"first day" in the input. Now, we consider the previous trading session
the "first day".

The intention is to correctly associate minutes after official trading
hours on half days with session that closed early, not the following
session (a future improvement here would be to not accept minutes
outside trading hours).