### PR TITLE
BUG: Support futures which do not roll month to month.

### DIFF
--- a/zipline/assets/continuous_futures.pyx
+++ b/zipline/assets/continuous_futures.pyx
@@ -318,7 +318,12 @@ cdef class OrderedContracts(object):
         while contracts:
             contract = contracts.popleft()
 
-            # Here is where a predicate would go to ensure continuity of the chain.
+            # Prevent contract chains with gaps between auto close and start of
+            # next contract.
+            # This is in lieu of more explicit support for
+            # contracts with quarterly rolls. e.g. Eurodollar
+            if contract.start_date > prev.contract.auto_close_date:
+                continue
 
             self._start_date = min(contract.start_date.value, self._start_date)
             self._end_date = max(contract.end_date.value, self._end_date)


### PR DESCRIPTION
Fix multiple errors when attempting to generate rolls for futures which do not
roll month to month, e.g. the Eurodollar.

These errors were caused by logic that always incremented from contract to
contract by delivery month, with errors when the next contract was not part of
the quarterly roll chain and thus had not yet begun trading even though the
previous contract had autoclosed. Instead, filter out these contracts and only
allow contracts that have begun trading before the previous contract's autoclose.

This is in lieu of a more explicit specification of quarterly rolls.