### PR TITLE
BUG: Fix 1m history for volume rolls with adjustments.

### DIFF
--- a/zipline/assets/roll_finder.py
+++ b/zipline/assets/roll_finder.py
@@ -80,7 +80,8 @@ class RollFinder(with_metaclass(ABCMeta, object)):
         front = self.get_contract_center(root_symbol, end, 0)
         back = oc.contract_at_offset(front, 1, end.value)
         if back is not None:
-            first = self._active_contract(oc, front, back, end)
+            end_session = self.trading_calendar.minute_to_session_label(end)
+            first = self._active_contract(oc, front, back, end_session)
         else:
             first = front
         first_contract = oc.sid_to_contract[first]


### PR DESCRIPTION
Convert the end minute to the its session label before calling `_active_contract`,
otherwise the volume roll finder's attempt to use the session bar reader fails
due to a non-session label Timestamp.