### PR TITLE
ENH: Allow future chains to only use certain delivery months.

### DIFF
--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -49,7 +49,11 @@ from zipline.errors import (
 from . import (
     Asset, Equity, Future,
 )
-from . continuous_futures import OrderedContracts, ContinuousFuture
+from . continuous_futures import (
+    OrderedContracts,
+    ContinuousFuture,
+    CHAIN_PREDICATES
+)
 from .asset_writer import (
     check_version_info,
     split_delimited_symbol,
@@ -183,6 +187,10 @@ class AssetFinder(object):
     engine : str or SQLAlchemy.engine
         An engine with a connection to the asset database to use, or a string
         that can be parsed by SQLAlchemy as a URI.
+    future_chain_predicates : dict
+        A dict mapping future root symbol to a predicate function which accepts
+    a contract as a parameter and returns whether or not the contract should be
+    included in the chain.
 
     See Also
     --------
@@ -193,7 +201,7 @@ class AssetFinder(object):
     PERSISTENT_TOKEN = "<AssetFinder>"
 
     @preprocess(engine=coerce_string_to_eng)
-    def __init__(self, engine):
+    def __init__(self, engine, future_chain_predicates=CHAIN_PREDICATES):
         self.engine = engine
         metadata = sa.MetaData(bind=engine)
         metadata.reflect(only=asset_db_table_names)
@@ -213,6 +221,8 @@ class AssetFinder(object):
         # retrieve_asset will populate the cache on first retrieval.
         self._caches = (self._asset_cache, self._asset_type_cache) = {}, {}
 
+        self._future_chain_predicates = future_chain_predicates \
+            if future_chain_predicates is not None else {}
         self._ordered_contracts = {}
 
         # Populated on first call to `lifetimes`.
@@ -903,7 +913,9 @@ class AssetFinder(object):
         except KeyError:
             contract_sids = self._get_contract_sids(root_symbol)
             contracts = deque(self.retrieve_all(contract_sids))
-            oc = OrderedContracts(root_symbol, contracts)
+            chain_predicate = self._future_chain_predicates.get(root_symbol,
+                                                                None)
+            oc = OrderedContracts(root_symbol, contracts, chain_predicate)
             self._ordered_contracts[root_symbol] = oc
             return oc
 

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -20,6 +20,7 @@ from six import string_types
 from sqlalchemy import create_engine
 
 from zipline.assets import AssetDBWriter, AssetFinder
+from zipline.assets.continuous_futures import CHAIN_PREDICATES
 from zipline.data.loader import load_market_data
 from zipline.utils.calendars import get_calendar
 from zipline.utils.memoize import remember_last
@@ -80,7 +81,8 @@ class TradingEnvironment(object):
         bm_symbol='^GSPC',
         exchange_tz="US/Eastern",
         trading_calendar=None,
-        asset_db_path=':memory:'
+        asset_db_path=':memory:',
+        future_chain_predicates=CHAIN_PREDICATES,
     ):
 
         self.bm_symbol = bm_symbol
@@ -106,7 +108,9 @@ class TradingEnvironment(object):
 
         if engine is not None:
             AssetDBWriter(engine).init_db()
-            self.asset_finder = AssetFinder(engine)
+            self.asset_finder = AssetFinder(
+                engine,
+                future_chain_predicates=future_chain_predicates)
         else:
             self.asset_finder = None
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -451,6 +451,8 @@ class WithTradingEnvironment(WithAssetFinder,
         The max date to forward to the constructed TradingEnvironment.
     TRADING_ENV_TRADING_CALENDAR : pd.DatetimeIndex
         The trading calendar to use for the class's TradingEnvironment.
+    TRADING_ENV_FUTURE_CHAIN_PREDICATES : dict
+        The roll predicates to apply when creating contract chains.
 
     Methods
     -------
@@ -468,6 +470,7 @@ class WithTradingEnvironment(WithAssetFinder,
     --------
     :class:`zipline.finance.trading.TradingEnvironment`
     """
+    TRADING_ENV_FUTURE_CHAIN_PREDICATES = None
 
     @classmethod
     def make_load_function(cls):
@@ -479,6 +482,7 @@ class WithTradingEnvironment(WithAssetFinder,
             load=cls.make_load_function(),
             asset_db_path=cls.asset_finder.engine,
             trading_calendar=cls.trading_calendar,
+            future_chain_predicates=cls.TRADING_ENV_FUTURE_CHAIN_PREDICATES,
         )
 
     @classmethod


### PR DESCRIPTION
To support contracts such as `PL` which should roll from F->J->N->V, add the
ability to pass a predicate function to the ordered contract chain contstrution
which returns `True` if the contract is allowed in the chain.