### PR TITLE
BUG: Allow rolls to skip over contracts.

### DIFF
--- a/zipline/assets/roll_finder.py
+++ b/zipline/assets/roll_finder.py
@@ -98,9 +98,13 @@ class RollFinder(with_metaclass(ABCMeta, object)):
 
         while session > start and curr is not None:
             front = curr.contract.sid
-            back = curr.next.contract.sid
+            back = rolls[0][0]
+            prev_c = curr.prev
             while session > start:
                 prev = session - freq
+                if prev_c is not None:
+                    if prev < prev_c.contract.auto_close_date:
+                        break
                 if back != self._active_contract(oc, front, back, prev):
                     rolls.insert(0, ((curr >> offset).contract.sid, session))
                     break


### PR DESCRIPTION
For futures that behave like GC, use the latest roll as the back contract when
walking backwards over the window, so that when the front contract is skipped
because it never has more volume between its auto close date and the previous
auto close date, the back contract which did have volume is still used when
making comparisons to construct the chain.