### PR TITLE
Handle missing data exceptions

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -1009,7 +1009,7 @@ class SQLiteAdjustmentWriter(object):
                     ratios[i] = ratio
                     # only assign effective_date when data is found
                     effective_dates[i] = ex_date
-            except NoDataOnDate:
+            except (NoDataOnDate, NoDataAfterDate, NoDataBeforeDate):
                 logger.warn("Couldn't compute ratio for dividend %s" % {
                     'sid': sid,
                     'ex_date': ex_date,


### PR DESCRIPTION
This PR attempts to handle exceptions caused by missing data.

Multiple exceptions are raised in https://github.com/quantopian/zipline/blob/master/zipline/data/us_equity_pricing.py#L678-L686 but only one was being caught.

An example of this problem can be found in https://github.com/quantopian/zipline/issues/1566