### PR TITLE
amend blotter.py to prevent splits causing 0 order amt, assert failure if stock halted  (was resubmit: comment out one line in blotter.py)

### DIFF
--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -156,11 +156,11 @@ class Blotter(object):
         """
         return [self.order(*order_args) for order_args in order_arg_lists]
 
-    def cancel_on_split(self, order_id, relaya_status=True):
+    def cancel_on_split(self, order_id, relay_status=True):
         if order_id not in self.orders:
                 return
         cur_order = self.orders[order_id]
-        #no open check
+        # no open check
         order_list = self.open_orders[cur_order.sid]
         if cur_order in order_list:
             order_list.remove(cur_order)
@@ -325,7 +325,7 @@ class Blotter(object):
             orders_to_modify = self.open_orders[sid]
             for order in orders_to_modify:
                 order.handle_split(split[1])
-                if(order.amount==0):
+                if(order.amount == 0):
                     self.cancel_on_split(order.id)
 
     def get_transactions(self, bar_data):

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -162,20 +162,20 @@ class Blotter(object):
 
         cur_order = self.orders[order_id]
 
-        #  if cur_order.open:
-        order_list = self.open_orders[cur_order.sid]
-        if cur_order in order_list:
-            order_list.remove(cur_order)
+        if cur_order.open:
+            order_list = self.open_orders[cur_order.sid]
+            if cur_order in order_list:
+                order_list.remove(cur_order)
 
-        if cur_order in self.new_orders:
-            self.new_orders.remove(cur_order)
-        cur_order.cancel()
-        cur_order.dt = self.current_dt
+            if cur_order in self.new_orders:
+                self.new_orders.remove(cur_order)
+            cur_order.cancel()
+            cur_order.dt = self.current_dt
 
-        if relay_status:
-            # we want this order's new status to be relayed out
-            # along with newly placed orders.
-            self.new_orders.append(cur_order)
+            if relay_status:
+                # we want this order's new status to be relayed out
+                # along with newly placed orders.
+                self.new_orders.append(cur_order)
 
     def cancel_all_orders_for_asset(self, asset, warn=False,
                                     relay_status=True):
@@ -306,6 +306,8 @@ class Blotter(object):
             orders_to_modify = self.open_orders[sid]
             for order in orders_to_modify:
                 order.handle_split(split[1])
+                if(order.amount==0):
+                    self.cancel(order.id)
 
     def get_transactions(self, bar_data):
         """

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -164,7 +164,7 @@ class Blotter(object):
         order_list = self.open_orders[cur_order.sid]
         if cur_order in order_list:
             order_list.remove(cur_order)
-            
+
         if cur_order in self.new_orders:
             self.new_orders.remove(cur_order)
         cur_order.cancel()
@@ -174,7 +174,7 @@ class Blotter(object):
             # we want this order's new status to be relayed out
             # along with newly placed orders.
             self.new_orders.append(cur_order)
-    
+
     def cancel(self, order_id, relay_status=True):
         if order_id not in self.orders:
             return

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -162,20 +162,20 @@ class Blotter(object):
 
         cur_order = self.orders[order_id]
 
-        if cur_order.open:
-            order_list = self.open_orders[cur_order.sid]
-            if cur_order in order_list:
-                order_list.remove(cur_order)
+        #  if cur_order.open:
+        order_list = self.open_orders[cur_order.sid]
+        if cur_order in order_list:
+            order_list.remove(cur_order)
 
-            if cur_order in self.new_orders:
-                self.new_orders.remove(cur_order)
-            cur_order.cancel()
-            cur_order.dt = self.current_dt
+        if cur_order in self.new_orders:
+            self.new_orders.remove(cur_order)
+        cur_order.cancel()
+        cur_order.dt = self.current_dt
 
-            if relay_status:
-                # we want this order's new status to be relayed out
-                # along with newly placed orders.
-                self.new_orders.append(cur_order)
+        if relay_status:
+            # we want this order's new status to be relayed out
+            # along with newly placed orders.
+            self.new_orders.append(cur_order)
 
     def cancel_all_orders_for_asset(self, asset, warn=False,
                                     relay_status=True):

--- a/zipline/finance/blotter.py
+++ b/zipline/finance/blotter.py
@@ -156,6 +156,25 @@ class Blotter(object):
         """
         return [self.order(*order_args) for order_args in order_arg_lists]
 
+    def cancel_on_split(self, order_id, relaya_status=True):
+        if order_id not in self.orders:
+                return
+        cur_order = self.orders[order_id]
+        #no open check
+        order_list = self.open_orders[cur_order.sid]
+        if cur_order in order_list:
+            order_list.remove(cur_order)
+            
+        if cur_order in self.new_orders:
+            self.new_orders.remove(cur_order)
+        cur_order.cancel()
+        cur_order.dt = self.current_dt
+
+        if relay_status:
+            # we want this order's new status to be relayed out
+            # along with newly placed orders.
+            self.new_orders.append(cur_order)
+    
     def cancel(self, order_id, relay_status=True):
         if order_id not in self.orders:
             return
@@ -307,7 +326,7 @@ class Blotter(object):
             for order in orders_to_modify:
                 order.handle_split(split[1])
                 if(order.amount==0):
-                    self.cancel(order.id)
+                    self.cancel_on_split(order.id)
 
     def get_transactions(self, bar_data):
         """


### PR DESCRIPTION
Update:  This would work, if cancel were called only from the cancel_all_orders_asset method in blotter, but, as API calls can be dispatched to this method on any order id, it might be possible to cancel an order twice, updating the timestamp both times.  Thus, the correct approach to solve the reverse split issue is likely to cancel the order, if the split causes the amout to become zero. 
Initial submission modified an old copy of the file
The cancel_all_orders_for_asset call can induce an assertion failure in the case of a reverse split and delisting. See example below.
In fact, in running the test from January 2015 through November 26, 2015, the following scenario played out.

The stock was ordered on 8/25, 2 shares long
The stock experienced a reverse split on 8/25 with a ratio of 7, making the order amount become 2/7 = 0
The stock was halted on 11/25
The past_auto_close_date test for the asset evaluated to true (Quandl set its end date to 11/24)
The cleanup_expired_assets subroutine was invoked, calling cancel_all on the open order for Noranda
Since the order amount was 0, its status was filled, so it was not deleted
The “assert orders” line failed
If the process finds that the current market data set is missing information about a stock, the order for that stock should be invalidated, but this should be done in a fashion which does not break the execution of assert statements. In fact, though, the check on status of open in the open_orders list is redundant, and thus can be removed without loss of generality.
I did not rerun the test with the latest version of all files, but I see no changes to blotter or tradesimulation which would prevent this error from occurring.