### PR TITLE
BUG: Datetimes should be converted in utc.

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -1351,6 +1351,8 @@ class SQLiteAdjustmentReader(object):
 
         def _get_df_from_table(table_name, date_cols):
 
+            # Dates are stored in second resolution as ints in adj.db tables.
+            # Need to specifically convert them as UTC, not local time.
             kwargs = (
                 {'parse_dates': {col: {'unit': 's', 'utc': True}
                                  for col in date_cols}
@@ -1359,7 +1361,6 @@ class SQLiteAdjustmentReader(object):
                 else {}
             )
 
-            # Dates are stored in second resolution as ints in adj.db tables.
             return read_sql(
                 'select * from "{}"'.format(table_name),
                 self.conn,

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -1352,7 +1352,9 @@ class SQLiteAdjustmentReader(object):
         def _get_df_from_table(table_name, date_cols):
 
             kwargs = (
-                {'parse_dates': {col: 's' for col in date_cols}}
+                {'parse_dates': {col: {'unit': 's', 'utc': True}
+                                 for col in date_cols}
+                 }
                 if convert_dates
                 else {}
             )


### PR DESCRIPTION
Fixes a bug where dataframes being returned were creating US/Eastern timestamps out of the ints, potentially changing the date returned to be the date before (at 19 hours).

```python
>>> dt = datetime.datetime(2017, 1, 4, 0, 0)
>>> today_date_epoch = int((dt.date() - datetime.date(1970,1,1)).total_seconds())
>>> today_date_epoch
1483488000
>>> datetime.datetime.fromtimestamp(today_date_epoch)
datetime.datetime(2017, 1, 3, 19, 0)
```

With UTC, the timestamp is now essentially being created like the following:
```python
>>> datetime.datetime.utcfromtimestamp(today_date_epoch)
datetime.datetime(2017, 1, 4, 0, 0)
```