### PR TITLE
BUG: IchimokuKinkoHyo techinical factor has wrong default inputs

### DIFF
--- a/zipline/pipeline/factors/technical.py
+++ b/zipline/pipeline/factors/technical.py
@@ -598,7 +598,7 @@ class IchimokuKinkoHyo(CustomFactor):
         'kijun_sen_length': 26,
         'chikou_span_length': 26,
     }
-    inputs = USEquityPricing.high, USEquityPricing.close
+    inputs = (USEquityPricing.high, USEquityPricing.low, USEquityPricing.close)
     outputs = (
         'tenkan_sen',
         'kijun_sen',


### PR DESCRIPTION
Very small bug fix: creating a IchimokuKinkoHyo factor raises an exception because the default inputs  are not in line with the factor's documentation