### PR TITLE
STY: Use def statements instead of lambda assignment.

### DIFF
--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -53,7 +53,9 @@ field_info = {
     "close": 0
 }
 
-str_to_ts = lambda dt_str: pd.Timestamp(dt_str, tz='UTC')
+
+def str_to_ts(dt_str):
+    return pd.Timestamp(dt_str, tz='UTC')
 
 
 class WithBarDataChecks(object):

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -21,7 +21,10 @@ from zipline.testing.fixtures import (
     ZiplineTestCase,
 )
 
-str_to_ts = lambda dt_str: pd.Timestamp(dt_str, tz='UTC')
+
+def str_to_ts(dt_str):
+    return pd.Timestamp(dt_str, tz='UTC')
+
 FROZEN = RESTRICTION_STATES.FROZEN
 ALLOWED = RESTRICTION_STATES.ALLOWED
 MINUTE = pd.Timedelta(minutes=1)

--- a/tests/utils/test_pandas_utils.py
+++ b/tests/utils/test_pandas_utils.py
@@ -16,7 +16,8 @@ class TestNearestUnequalElements(ZiplineTestCase):
             ['2014-01-01', '2014-01-05', '2014-01-06', '2014-01-09'],
         ).tz_localize(tz)
 
-        t = lambda s: None if s is None else pd.Timestamp(s, tz=tz)
+        def t(s):
+            return None if s is None else pd.Timestamp(s, tz=tz)
 
         for dt, before, after in (('2013-12-30', None, '2014-01-01'),
                                   ('2013-12-31', None, '2014-01-01'),
@@ -40,7 +41,9 @@ class TestNearestUnequalElements(ZiplineTestCase):
 
         # Length 1.
         dts = pd.to_datetime(['2014-01-01']).tz_localize(tz)
-        t = lambda s: None if s is None else pd.Timestamp(s, tz=tz)
+
+        def t(s):
+            return None if s is None else pd.Timestamp(s, tz=tz)
 
         for dt, before, after in (('2013-12-31', None, '2014-01-01'),
                                   ('2014-01-01', None, None),

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -508,7 +508,9 @@ class DataPortal(object):
             assets = [assets]
 
         adjustment_ratios_per_asset = []
-        split_adj_factor = lambda x: x if field != 'volume' else 1.0 / x
+
+        def split_adj_factor(x):
+            return x if field != 'volume' else 1.0 / x
 
         for asset in assets:
             adjustments_for_asset = []

--- a/zipline/lib/labelarray.py
+++ b/zipline/lib/labelarray.py
@@ -536,7 +536,8 @@ class LabelArray(ndarray):
         # them on None, which is the only non-str value we ever store in
         # categories.
         if self.missing_value is None:
-            f_to_use = lambda x: False if x is None else f(x)
+            def f_to_use(x):
+                return False if x is None else f(x)
         else:
             f_to_use = f
 

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -1084,7 +1084,9 @@ def temp_pipeline_engine(calendar, sids, random_seed, symbols=None):
     )
 
     loader = make_seeded_random_loader(random_seed, calendar, sids)
-    get_loader = lambda column: loader
+
+    def get_loader(column):
+        return loader
 
     with tmp_asset_finder(equities=equity_info) as finder:
         yield SimplePipelineEngine(get_loader, calendar, finder)

--- a/zipline/utils/input_validation.py
+++ b/zipline/utils/input_validation.py
@@ -246,7 +246,8 @@ def expect_dtypes(__funcname=_qualified_name, **named):
             )
 
     if isinstance(__funcname, str):
-        get_funcname = lambda _: __funcname
+        def get_funcname(_):
+            return __funcname
     else:
         get_funcname = __funcname
 
@@ -430,7 +431,8 @@ def make_check(exc_type, template, pred, actual, funcname):
         to refer to the class name instead of the method name.
     """
     if isinstance(funcname, str):
-        get_funcname = lambda _: funcname
+        def get_funcname(_):
+            return funcname
     else:
         get_funcname = funcname
 
@@ -593,13 +595,16 @@ def expect_bounded(__funcname=_qualified_name, **named):
     def _expect_bounded(bounds):
         (lower, upper) = bounds
         if lower is None:
-            should_fail = lambda value: value > upper
+            def should_fail(value):
+                return value > upper
             predicate_descr = "less than or equal to " + str(upper)
         elif upper is None:
-            should_fail = lambda value: value < lower
+            def should_fail(value):
+                return value < lower
             predicate_descr = "greater than or equal to " + str(lower)
         else:
-            should_fail = lambda value: not (lower <= value <= upper)
+            def should_fail(value):
+                return not (lower <= value <= upper)
             predicate_descr = "between %s and %s" % bounds
 
         template = (
@@ -639,7 +644,8 @@ def expect_dimensions(__funcname=_qualified_name, **dimensions):
     but got a 1-D array instead.
     """
     if isinstance(__funcname, str):
-        get_funcname = lambda _: __funcname
+        def get_funcname(_):
+            return __funcname
     else:
         get_funcname = __funcname
 


### PR DESCRIPTION
This is a step towards upgrading from flake8 `2.4.1` -> `3.2.1`.
Beyond general keeping up-to-date clean living, I am interested in upgrading to `3.2.1` because the current version of the Emacs `flycheck-mode` integration with `flake8` requires >= 3.0 because it uses on the `--stdin-display-name` option.


From pep-0008:

```
Always use a def statement instead of an assignment statement that binds a
lambda expression directly to an identifier.

Yes:

def f(x): return 2*x
No:

f = lambda x: 2*x

The first form means that the name of the resulting function object is
specifically 'f' instead of the generic '<lambda>'. This is more useful for
tracebacks and string representations in general. The use of the assignment
statement eliminates the sole benefit a lambda expression can offer over an
explicit def statement (i.e. that it can be embedded inside a larger expression)
```