### PR TITLE
Don't allow ordering assets after their auto close date

### DIFF
--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -508,6 +508,9 @@ cdef class BarData:
             # asset isn't alive
             return False
 
+        if asset.auto_close_date and session_label >= asset.auto_close_date:
+            return False
+
         if not self._daily_mode:
             # Find the next market minute for this calendar, and check if this
             # asset's exchange is open at that minute.

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1348,10 +1348,10 @@ class TradingAlgorithm(object):
         if asset.auto_close_date:
             day = normalize_date(self.get_datetime())
 
-            if asset.end_date < day < asset.auto_close_date:
-                # we are between the asset's end date and auto close date,
-                # so warn the user that they can't place an order for this
-                # asset, and return None.
+            if day > min(asset.end_date, asset.auto_close_date):
+                # If we are after the asset's end date or auto close date, warn
+                # the user that they can't place an order for this asset, and
+                # return None.
                 log.warn("Cannot place order for {0}, as it has de-listed. "
                          "Any existing positions for this asset will be "
                          "liquidated on "


### PR DESCRIPTION
Futures contracts can currently be entered into after their `auto_close_date`. This change prevents that as well as makes `can_trade` return `False` after the `auto_close_date`.