### PR TITLE
Events loader handle empty raw data pr review

### DIFF
--- a/zipline/pipeline/loaders/events.py
+++ b/zipline/pipeline/loaders/events.py
@@ -192,17 +192,30 @@ class EventsLoader(PipelineLoader):
         def to_frame(array):
             return pd.DataFrame(array, index=dates, columns=sids)
 
+        assert indexer.shape == (len(dates), len(sids))
+
         out = {}
         for c in columns:
+            # Array holding the value for column `c` for every event we have.
             col_array = self.events[name_map[c]]
+
             if not len(col_array):
+                # We don't have **any** events, so return col.missing_value
+                # every day for every sid. We have to special case empty events
+                # because in normal branch we depend on being able to index
+                # with -1 for missing values, which fails if there are no
+                # events at all.
                 raw = np.full(
                     (len(dates), len(sids)), c.missing_value, dtype=c.dtype
                 )
             else:
+                # Slot event values into sid/date locations using `indexer`.
+                # This produces a 2D array of the same shape as `indexer`,
+                # which must be (len(dates), len(sids))`.
                 raw = col_array[indexer]
+
                 # indexer will be -1 for locations where we don't have a known
-                # value.
+                # value. Overwrite those locations with c.missing_value.
                 raw[indexer < 0] = c.missing_value
 
             # Delegate the actual array formatting logic to a DataFrameLoader.


### PR DESCRIPTION
@mtydykov your change looks good.  I had two suggestions which I figured were easier to just implement in the form of a PR.

1. We can simplify the assertion for the empty data frame to not have do a bunch of fancy unstacking.
2. Added a few comments in the logic for unpacking events to explain why we're special-casing empty input.