### PR TITLE
BUG: Fix end session metadata for minute bar writer.

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -497,7 +497,7 @@ class BcolzMinuteBarWriter(object):
             metadata.minutes_per_day,
             metadata.default_ohlc_ratio,
             metadata.ohlc_ratios_per_sid,
-            write_metadata=False
+            write_metadata=end_session is not None
         )
 
     @property


### PR DESCRIPTION
When opening with a new `end_session`, i.e. opening for append, write the new
end session to the metadata.

Fixes an issue where the calendar on minute bar readers did not include the
recently appended day, causing reads on the last values to fail.

According, update append test to read a value, instead of checking table length.