### PR TITLE
Multipliers were not removed when closing a position

### DIFF
--- a/zipline/finance/performance/position_tracker.py
+++ b/zipline/finance/performance/position_tracker.py
@@ -192,6 +192,8 @@ class PositionTracker(object):
             # if this position now has 0 shares, remove it from our internal
             # bookkeeping.
             del self.positions[sid]
+            del self._position_value_multipliers[sid]
+            del self._position_exposure_multipliers[sid]
 
             try:
                 # if this position exists in our user-facing dictionary,
@@ -199,8 +201,8 @@ class PositionTracker(object):
                 del self._positions_store[sid]
             except KeyError:
                 pass
-
-        self._update_asset(sid)
+        else:
+            self._update_asset(sid)
 
     def handle_commission(self, sid, cost):
         # Adjust the cost basis of the stock if we own it


### PR DESCRIPTION
Due to relying on the order of the multipliers dicts, algorithms which mixed futures and equities were hitting the wrong multipliers after closing a position because the closing asset was not being removed from the multipliers dicts.