### PR TITLE
Change to a 10.5 hour futures calendar

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -531,6 +531,17 @@ class TradingAlgorithm(object):
             # as the last minute of the session.
             market_opens = market_closes
 
+        # The calendar's execution times are the minutes over which we actually
+        # want to run the clock. Typically the execution times simply adhere to
+        # the market open and close times. In the case of the futures calendar,
+        # for example, we only want to simulate over a subset of the full 24
+        # hour calendar, so the execution times dictate a market open time of
+        # 6:31am US/Eastern and a close of 5:00pm US/Eastern.
+        execution_opens = \
+            self.trading_calendar.execution_time_from_open(market_opens)
+        execution_closes = \
+            self.trading_calendar.execution_time_from_close(market_closes)
+
         # FIXME generalize these values
         before_trading_start_minutes = days_at_time(
             self.sim_params.sessions,
@@ -540,8 +551,8 @@ class TradingAlgorithm(object):
 
         return MinuteSimulationClock(
             self.sim_params.sessions,
-            market_opens,
-            market_closes,
+            execution_opens,
+            execution_closes,
             before_trading_start_minutes,
             minute_emission=minutely_emission,
         )

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -667,6 +667,12 @@ class TradingCalendar(with_metaclass(ABCMeta)):
     def last_session(self):
         return self.all_sessions[-1]
 
+    def execution_time_from_open(self, open_dates):
+        return open_dates
+
+    def execution_time_from_close(self, close_dates):
+        return close_dates
+
     @lazyval
     def all_minutes(self):
         """

--- a/zipline/utils/calendars/us_futures_calendar.py
+++ b/zipline/utils/calendars/us_futures_calendar.py
@@ -1,6 +1,6 @@
 from datetime import time
 
-from pandas import Timestamp
+from pandas import Timedelta, Timestamp
 from pandas.tseries.holiday import GoodFriday
 from pytz import timezone
 
@@ -12,6 +12,12 @@ from zipline.utils.calendars.us_holidays import (
     USNewYearsDay,
     Christmas
 )
+
+# Number of hours of offset between the open and close times dictated by this
+# calendar versus the 6:31am to 5:00pm times over which we want to simulate
+# futures algos.
+FUTURES_OPEN_TIME_OFFSET = 12.5
+FUTURES_CLOSE_TIME_OFFSET = -1
 
 
 class QuantopianUSFuturesCalendar(TradingCalendar):
@@ -62,6 +68,12 @@ class QuantopianUSFuturesCalendar(TradingCalendar):
     @property
     def open_offset(self):
         return -1
+
+    def execution_time_from_open(self, open_dates):
+        return open_dates + Timedelta(hours=FUTURES_OPEN_TIME_OFFSET)
+
+    def execution_time_from_close(self, close_dates):
+        return close_dates + Timedelta(hours=FUTURES_CLOSE_TIME_OFFSET)
 
     @property
     def regular_holidays(self):


### PR DESCRIPTION
Change algorithms that use the futures calendar to run from 6:30am to 5:00pm instead of 24 hours. Minutely history calls will still return 24-hour data however.