### PR TITLE
TEST: Allow parameter_space to work on repeated calls of test

### DIFF
--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -1142,16 +1142,20 @@ def parameter_space(__fail_fast=False, **params):
                 "supplied to parameter_space()." % extra
             )
 
-        param_sets = product(*(params[name] for name in argnames))
+        make_param_sets = lambda: product(*(params[name] for name in argnames))
 
         if __fail_fast:
             @wraps(f)
             def wrapped(self):
-                for args in param_sets:
+                for args in make_param_sets():
                     f(self, *args)
             return wrapped
         else:
-            return subtest(param_sets, *argnames)(f)
+            @wraps(f)
+            def wrapped(*args, **kwargs):
+                subtest(make_param_sets(), *argnames)(f)(*args, **kwargs)
+
+        return wrapped
 
     return decorator
 


### PR DESCRIPTION
If we have a test that's being called more than once (i.e. two
test cases, both subclasses of the same base test case, with
different setup but calling the same test), allow the subsequent
calls to re-consume the same params