### PR TITLE
MAINT: Removes unnecessary capital_base arg to TradingAlgorithm

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -4278,7 +4278,6 @@ class TestEquityAutoClose(WithTmpDir, WithTradingCalendars, ZiplineTestCase):
             env=env,
             sim_params=resources.sim_params,
             data_frequency='minute',
-            capital_base=capital_base,
         )
 
         output = algo.run(resources.data_portal)

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -144,8 +144,6 @@ from zipline.gens.sim_engine import MinuteSimulationClock
 from zipline.sources.benchmark_source import BenchmarkSource
 from zipline.zipline_warnings import ZiplineDeprecationWarning
 
-DEFAULT_CAPITAL_BASE = 1e5
-
 
 log = logbook.Logger("ZiplineLog")
 
@@ -181,8 +179,6 @@ class TradingAlgorithm(object):
         tracebacks. default: '<string>'.
     data_frequency : {'daily', 'minute'}, optional
         The duration of the bars.
-    capital_base : float, optional
-        How much capital to start with. default: 1.0e5
     instant_fill : bool, optional
         Whether to fill orders immediately or on next bar. default: False
     equities_metadata : dict or DataFrame or file-like object, optional
@@ -303,16 +299,14 @@ class TradingAlgorithm(object):
             get_calendar("NYSE")
         )
 
-        # set the capital base
-        self.capital_base = kwargs.pop('capital_base', DEFAULT_CAPITAL_BASE)
         self.sim_params = kwargs.pop('sim_params', None)
         if self.sim_params is None:
             self.sim_params = create_simulation_parameters(
-                capital_base=self.capital_base,
                 start=kwargs.pop('start', None),
                 end=kwargs.pop('end', None),
                 trading_calendar=self.trading_calendar,
             )
+        self.capital_base = self.sim_params.capital_base
 
         self.perf_tracker = None
         # Pull in the environment's new AssetFinder for quick reference

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -306,7 +306,6 @@ class TradingAlgorithm(object):
                 end=kwargs.pop('end', None),
                 trading_calendar=self.trading_calendar,
             )
-        self.capital_base = self.sim_params.capital_base
 
         self.perf_tracker = None
         # Pull in the environment's new AssetFinder for quick reference
@@ -499,7 +498,7 @@ class TradingAlgorithm(object):
     blotter={blotter},
     recorded_vars={recorded_vars})
 """.strip().format(class_name=self.__class__.__name__,
-                   capital_base=self.capital_base,
+                   capital_base=self.sim_params.capital_base,
                    sim_params=repr(self.sim_params),
                    initialized=self.initialized,
                    slippage=repr(self.blotter.slippage_func),

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -28,6 +28,9 @@ from zipline.utils.memoize import remember_last
 log = logbook.Logger('Trading')
 
 
+DEFAULT_CAPITAL_BASE = 1e5
+
+
 class TradingEnvironment(object):
     """
     The financial simulations in zipline depend on information
@@ -128,7 +131,7 @@ class TradingEnvironment(object):
 class SimulationParameters(object):
     def __init__(self, start_session, end_session,
                  trading_calendar,
-                 capital_base=10e3,
+                 capital_base=DEFAULT_CAPITAL_BASE,
                  emission_rate='daily',
                  data_frequency='daily',
                  arena='backtest'):

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -157,7 +157,6 @@ def _run(handle_data,
 
     perf = TradingAlgorithm(
         namespace=namespace,
-        capital_base=capital_base,
         env=env,
         get_pipeline_loader=choose_loader,
         sim_params=create_simulation_parameters(


### PR DESCRIPTION
Capital base is included in the sim params, so we should define the
value there, or use the default.

This change also unifies the default capital base as 1e5, as was
previously defined in algorithm.py.