### PR TITLE
BLD: Pin python version of conda root env to python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     #   is sufficient: ["read:org", "user:email", "repo_deployment", "repo:status", "write:repo_hook"]
     #   See https://docs.travis-ci.com/api#external-apis.
     - secure: "iVr5iE75CPUZLX3ucgth0QA8y0JQJm+p3YrHwnCYZ5d+qTJA1eWGeA7k5+6Fhx1opCXkG+MkU8fNrSkqIA55mcAHoCINquQeQ4lfpDBgwjbjs+/2gB08Jm6ZQ78QG8cy6hEoSMDXAs27PMKyBuMkZKrIJWB8v5dWIDBz8cntBHs="
+    - CONDA_ROOT_PYTHON_VERSION: "2.7"
   matrix:
     - NUMPY_VERSION=1.11.1 SCIPY_VERSION=0.17.1
 cache:
@@ -23,11 +24,12 @@ cache:
     - $HOME/.cache/.pip/
 
 before_install:
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget https://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [ ${CONDA_ROOT_PYTHON_VERSION:0:1} == "2" ]; then wget https://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
 install:
+  - conda info -a
   - conda install conda=4.1.11 conda-build=1.21.11 anaconda-client=1.5.1 --yes
 
   - TALIB_VERSION=$(cat ./etc/requirements_talib.txt | sed "s/TA-Lib==\(.*\)/\1/")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@ environment:
     ANACONDA_TOKEN:
       secure: "u3oPlANiKY5g1yMtcK+2MQfb4ViKGEap3TcBtvS7Y1InyeWs80Ko3/PsP7Lp6qwq"
 
+    CONDA_ROOT_PYTHON_VERSION: "2.7"
+
   matrix:
     - PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"

--- a/ci/appveyor/install.ps1
+++ b/ci/appveyor/install.ps1
@@ -89,7 +89,7 @@ function UpdateConda ($python_home) {
 
 
 function main () {
-    InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallMiniconda $env:CONDA_ROOT_PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
     UpdateConda $env:PYTHON
     InstallCondaPackages $env:PYTHON "conda-build jinja2 anaconda-client"
 }


### PR DESCRIPTION
(And print conda info on travis.)

Miniconda latest for python 3 now installs python 3.6 in the root environment, but win-64 anaconda-client 1.5.1 doesn't exist for python 3.6. So using python 2 in the conda root environment, even when building/running python3 in the test environment.

Fixes the appveyor py3 build error:
```
UnsatisfiableError: The following specifications were found to be in conflict:
  - anaconda-client 1.5.1* -> python 2.7*
  - python 3.6*
```