### PR TITLE
DOC: Fix typo in -k/--keep-last option description

### DIFF
--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -342,7 +342,7 @@ def ingest(bundle, assets_version, show_progress):
     type=int,
     metavar='N',
     help='Clear all but the last N downloads.'
-    ' This may not be passed with -b / --before or -a / --after',
+    ' This may not be passed with -e / --before or -a / --after',
 )
 def clean(bundle, before, after, keep_last):
     """Clean up data downloaded with the ingest command.


### PR DESCRIPTION
-b is shortopt for --bundle, not --before:

```
$ zipline clean --help
Usage: zipline clean [OPTIONS]
...

  -b, --bundle BUNDLE-NAME  The data bundle to clean.  [default: quantopian-
                            quandl]
  -e, --before TIMESTAMP    Clear all data before TIMESTAMP. This may not be
                            passed with -k / --keep-last
...
  -k, --keep-last N         Clear all but the last N downloads. This may not
                            be passed with -b / --before or -a / --after
```