### PR TITLE
Sort pipeline data on asofdate

### DIFF
--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -1104,6 +1104,11 @@ class BlazeLoader(dict):
             materialized_deltas,
             dates,
         )
+        # If we ever have cases where we find out about multiple asof_dates'
+        # data on the same TS, we want to make sure that last_in_date_group
+        # selects the correct last asof_date's value.
+        sparse_output.sort_values(AD_FIELD_NAME, inplace=True)
+        non_novel_deltas.sort_values(AD_FIELD_NAME, inplace=True)
         if AD_FIELD_NAME not in requested_columns:
             sparse_output.drop(AD_FIELD_NAME, axis=1, inplace=True)
 

--- a/zipline/pipeline/loaders/utils.py
+++ b/zipline/pipeline/loaders/utils.py
@@ -281,15 +281,17 @@ def last_in_date_group(df,
                        assets,
                        reindex=True,
                        have_sids=True,
-                       extra_groupers=[]):
+                       extra_groupers=None):
     """
     Determine the last piece of information known on each date in the date
-    index for each group.
+    index for each group. Input df MUST be sorted such that the correct last
+    item is chosen from each group.
 
     Parameters
     ----------
     df : pd.DataFrame
-        The DataFrame containing the data to be grouped.
+        The DataFrame containing the data to be grouped. Must be sorted so that
+        the correct last item is chosen from each group.
     dates : pd.DatetimeIndex
         The dates to use for grouping and reindexing.
     assets : pd.Int64Index
@@ -316,6 +318,8 @@ def last_in_date_group(df,
     )]]
     if have_sids:
         idx += [SID_FIELD_NAME]
+    if extra_groupers is None:
+        extra_groupers = []
     idx += extra_groupers
 
     last_in_group = df.drop(TS_FIELD_NAME, axis=1).groupby(


### PR DESCRIPTION
Addresses an issue where values for 2 subsequent dates, d1 and d2, came in for the first time on d3 and had the same timestamp; because d1 happened to be in a later row than d2, `last_in_date_group` selected d1 to be the "latest" value for the next date in the index, which was d5. The fix for this issue is to sort the data on asof_date before we drop the asof_date column.