### PR TITLE
ENH: Adds StaticSids pipeline filter

### DIFF
--- a/zipline/pipeline/filters/__init__.py
+++ b/zipline/pipeline/filters/__init__.py
@@ -9,6 +9,7 @@ from .filter import (
     PercentileFilter,
     SingleAsset,
     StaticAssets,
+    StaticSids,
 )
 from .smoothing import All, Any, AtLeastN
 
@@ -26,4 +27,5 @@ __all__ = [
     'PercentileFilter',
     'SingleAsset',
     'StaticAssets',
+    'StaticSids',
 ]


### PR DESCRIPTION
Useful for avoiding the need to create `Asset` objects when sids are easier to use.

This is based off the existing implementation of `StaticAssets`, and `StaticAssets` is now implemented as a wrapper around `StaticSids`.