### PR TITLE
POC/BUG: Round target toward zero on order_target_*.

### DIFF
--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -96,7 +96,7 @@ from zipline.finance.execution import (
     StopOrder,
 )
 from zipline.finance.controls import AssetDateBounds
-from zipline.utils.math_utils import round_if_near_integer
+from zipline.utils.math_utils import round_if_near_integer_else_truncate
 
 
 class TestAlgorithm(TradingAlgorithm):
@@ -396,7 +396,7 @@ class TestOrderPercentAlgorithm(TradingAlgorithm):
                 (data.current(sid(0), "price") *
                     self.sid(0).contract_multiplier)
 
-        new_shares = int(round_if_near_integer(new_shares))
+        new_shares = round_if_near_integer_else_truncate(new_shares)
         self.target_shares += new_shares
 
 

--- a/zipline/utils/math_utils.py
+++ b/zipline/utils/math_utils.py
@@ -68,12 +68,12 @@ except ImportError:
     nanargmin = np.nanargmin
 
 
-def round_if_near_integer(a, epsilon=1e-4):
+def round_if_near_integer_else_truncate(a, epsilon=1e-4):
     """
     Round a to the nearest integer if that integer is within an epsilon
-    of a.
+    of a, otherwise truncate toward zero.
     """
     if abs(a - round(a)) <= epsilon:
-        return round(a)
+        return int(round(a))
     else:
-        return a
+        return int(a)


### PR DESCRIPTION
Rather than rounding the order size.

Fixes a bug where order_target_percent(asset, very_small_number) would
often result in a vestigial single-share position if an algorithm
currently held a position.