### PR TITLE
ENH: Remove path.py as its not a dependency

### DIFF
--- a/docs/deploy.py
+++ b/docs/deploy.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 from contextlib import contextmanager
 from glob import glob
-from path import path
 import os
 from os.path import abspath, basename, dirname, exists, isfile
 from shutil import move, rmtree
@@ -32,8 +31,11 @@ def ensure_not_exists(path):
 
 
 def main():
+    old_dir = os.getcwd()
     print("Moving to %s." % HERE)
-    with path(HERE):
+    os.chdir(HERE)
+
+    try:
         print("Building docs with 'make html'")
         check_call(['make', 'html'])
 
@@ -64,6 +66,8 @@ def main():
                 print("%s -> %s" % (file_, base))
                 ensure_not_exists(base)
                 move(file_, '.')
+    finally:
+        os.chdir(old_dir)
 
     print()
     print("Updated documentation branch in directory %s" % ZIPLINE_ROOT)


### PR DESCRIPTION
Should fix #1237.

I traced the call to `path()` down to this section of [path.py](https://github.com/jaraco/path.py/blob/master/path.py)

```
def __enter__(self):
    self._old_dir = self.getcwd()
    os.chdir(self)
    return self
```

And changed our `deploy.py` to just do the same thing