### PR TITLE
MAINT: Clear up naming and logic in resample close.

### DIFF
--- a/zipline/data/_resample.pyx
+++ b/zipline/data/_resample.pyx
@@ -73,22 +73,20 @@ cpdef void _minute_to_session_low(intp_t[:] close_locs,
 cpdef void _minute_to_session_close(intp_t[:] close_locs,
                                     float64_t[:] data,
                                     float64_t[:] out):
-    cdef intp_t i, close_loc, loc = 0
+    cdef intp_t i, prev_close_loc, loc = 0
     cdef float64_t val
-    loc = len(data) - 1
     num_out = len(close_locs)
-    for j in range(num_out, 0, -1):
-        i = j - 1
+    for i in range(num_out - 1, -1, -1):
         if i > 0:
-            close_loc = close_locs[i - 1]
+            prev_close_loc = close_locs[i - 1]
         else:
-            close_loc = -1
+            prev_close_loc = -1
+        loc = close_locs[i]
         val = data[loc]
-        while isnan(val) and loc > close_loc:
+        while isnan(val) and loc > prev_close_loc:
             loc -= 1
             val = data[loc]
         out[i] = val
-        loc = close_loc
 
 
 @boundscheck(False)


### PR DESCRIPTION
- Instead of maintaining a separate `j` value, set the bounds of the range so
that `i` is the values emitted by the range.
- Change `close_loc` to `prev_close_loc` since the market close location is used
to ensure that the data index stops at the market open if the entire day is nans.
- Change the setting of `loc` to be done before the loop which check for nans,
   instead of setting to the previous close loc at the end of the loop.

This prepares for a separate fix to prevent out of bounds access when the first
session has nans for all minutes.

### Notes

This does not fix https://github.com/quantopian/zipline/pull/1721

The following is a potential fix:
```
--- a/zipline/data/_resample.pyx
+++ b/zipline/data/_resample.pyx
@@ -82,11 +82,13 @@ cpdef void _minute_to_session_close(intp_t[:] close_locs,
         else:
             prev_close_loc = -1
         loc = close_locs[i]
-        val = data[loc]
-        while isnan(val) and loc > prev_close_loc:
-            loc -= 1
+        while loc > prev_close_loc:
             val = data[loc]
-        out[i] = val
+            if not isnan(val):
+                out[i] = val
+                break
+            else:
+                loc -= 1

```

@dmichalowicz is working on a failing test (e.g. where the first session has all nans) and applying the fix.