### PR TITLE
MAINT: Prepare parameter check for adding an additional check.

### DIFF
--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -82,48 +82,40 @@ cdef class check_parameters(object):
             for i, arg in enumerate(args[1:]):
                 expected_type = self.types[i]
 
-                if isinstance(arg, expected_type):
-                    continue
-
-                elif (i == 0 or i == 1) and _is_iterable(arg):
+                if (i == 0 or i == 1) and _is_iterable(arg):
                     if len(arg) == 0:
                         continue
+                    arg = arg[0]
 
-                    if isinstance(arg[0], expected_type):
-                        continue
+                if not isinstance(arg, expected_type):
+                    expected_type_name = expected_type.__name__ \
+                        if not _is_iterable(expected_type) \
+                        else ', '.join([type_.__name__ for type_ in expected_type])
 
-                expected_type_name = expected_type.__name__ \
-                    if not _is_iterable(expected_type) \
-                    else ', '.join([type_.__name__ for type_ in expected_type])
-
-                raise TypeError("Expected %s argument to be of type %s%s" %
-                                (self.keyword_names[i],
-                                 'or iterable of type ' if i in (0, 1) else '',
-                                 expected_type_name)
-                )
+                    raise TypeError("Expected %s argument to be of type %s%s" %
+                        (self.keyword_names[i],
+                         'or iterable of type ' if i in (0, 1) else '',
+                         expected_type_name)
+                    )
 
             # verify type of each kwarg
             for keyword, arg in iteritems(kwargs):
-                if isinstance(arg, self.keys_to_types[keyword]):
-                    continue
-                elif keyword in ('assets', 'fields') and _is_iterable(arg):
+                if keyword in ('assets', 'fields') and _is_iterable(arg):
                     if len(arg) == 0:
                         continue
+                    arg = arg[0]
+                if not isinstance(arg, self.keys_to_types[keyword]):
+                    expected_type = self.keys_to_types[keyword].__name__ \
+                        if not _is_iterable(self.keys_to_types[keyword]) \
+                        else ', '.join([type_.__name__ for type_ in
+                            self.keys_to_types[keyword]])
 
-                    if isinstance(arg[0], self.keys_to_types[keyword]):
-                        continue
-
-                expected_type = self.keys_to_types[keyword].__name__ \
-                    if not _is_iterable(self.keys_to_types[keyword]) \
-                    else ', '.join([type_.__name__ for type_ in
-                                    self.keys_to_types[keyword]])
-
-                raise TypeError("Expected %s argument to be of type %s%s" %
-                                (keyword,
-                                 'or iterable of type ' if keyword in
-                                 ('assets', 'fields') else '',
-                                 expected_type)
-                )
+                    raise TypeError("Expected %s argument to be of type %s%s" %
+                                    (keyword,
+                                     'or iterable of type ' if keyword in
+                                     ('assets', 'fields') else '',
+                                     expected_type)
+                    )
 
             return func(*args, **kwargs)
 


### PR DESCRIPTION
Should be no functional change.

By making the raise on `if not isinstance` instead of doing a continue on `if
isinstance` (with a raise at the end of the loop if no 'good' conditions were
met'), the function should be more amenable to adding an additional validity
check, after the type check passes.

This is on the path to adding an additional validity checks parameter to
`check_parameters`, e.g. adding an 'is positive' check.