### PR TITLE
OrderedContracts chain could sometimes terminate on first contract

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -139,6 +139,7 @@ def build_lookup_generic_cases(asset_finder_type):
                 'root_symbol': 'FO',
                 'start_date': unique_start.value,
                 'end_date': unique_end.value,
+                'auto_close_date': unique_end.value,
                 'exchange': 'FUT',
             },
         ],


### PR DESCRIPTION
It is possible for the first contract of a `ContinuousFuture` to have a start date which is after its auto close date. In that case the continuous future terminates immediately, giving it a premature end date. To handle this, throw out the first contract if it hits this case because it is not tradable anyway.