### PR TITLE
MAINT: Add better repr for transactions

### DIFF
--- a/tests/finance/test_transaction.py
+++ b/tests/finance/test_transaction.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2017 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pandas as pd
+from unittest import TestCase
+
+from zipline.assets import Equity
+from zipline.finance.transaction import Transaction
+
+
+class TransactionTestCase(TestCase):
+
+    def test_transaction_repr(self):
+        dt = pd.Timestamp('2017-01-01')
+
+        asset = Equity(1, exchange='test')
+        txn = Transaction(asset, amount=100, dt=dt, price=10, order_id=0)
+
+        expected = (
+            "Transaction(asset=Equity(1), dt=2017-01-01 00:00:00,"
+            " amount=100, price=10)"
+        )
+
+        self.assertEqual(repr(txn), expected)

--- a/zipline/finance/transaction.py
+++ b/zipline/finance/transaction.py
@@ -35,6 +35,20 @@ class Transaction(object):
     def __getitem__(self, name):
         return self.__dict__[name]
 
+    def __repr__(self):
+        template = (
+            "{cls}(asset={asset}, dt={dt},"
+            " amount={amount}, price={price})"
+        )
+
+        return template.format(
+            cls=type(self).__name__,
+            asset=self.asset,
+            dt=self.dt,
+            amount=self.amount,
+            price=self.price
+        )
+
     def to_dict(self):
         py = copy(self.__dict__)
         del py['type']


### PR DESCRIPTION
The `repr` for a Transaction object now looks like:

`Transaction(order_id=20, sid=Asset(0), dt=2015-01-01 00:00:00, amount=10, price=50)`