### PR TITLE
Improve TradingCalendar perf with scalar-optimized accesses

### DIFF
--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -452,8 +452,10 @@ class ExchangeCalendarTestBase(object):
         (2, 1),
     ])
     def test_minute_index_to_session_labels(self, interval, offset):
-        minutes = self.calendar.minutes_for_sessions_in_range('2011-01-04',
-                                                              '2011-04-04')
+        minutes = self.calendar.minutes_for_sessions_in_range(
+            pd.Timestamp('2011-01-04', tz='UTC'),
+            pd.Timestamp('2011-04-04', tz='UTC'),
+        )
         minutes = minutes[range(offset, len(minutes), interval)]
 
         np.testing.assert_array_equal(

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -521,7 +521,7 @@ class MinuteResampleSessionBarReader(SessionBarReader):
         sessions = self._calendar.sessions_in_range(start_dt, end_dt)
         m_closes = np.zeros(len(sessions), dtype=np.dtype('datetime64[ns]'))
         for i, s in enumerate(sessions):
-            close = self._calendar.open_and_close_for_session(s)[1]
+            close = self._calendar.session_close(s)
             m_closes[i] = close.value
         m_locs = np.searchsorted(dts, m_closes)
         results = []

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -460,7 +460,10 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         pd.DateTimeIndex
             All the minutes for the given session.
         """
-        return self.minutes_in_range(*self.schedule.loc[session_label])
+        return self.minutes_in_range(
+            start_minute=self.schedule.at[session_label, 'market_open'],
+            end_minute=self.schedule.at[session_label, 'market_close'],
+        )
 
     def minutes_window(self, start_dt, count):
         start_dt_nanos = start_dt.value
@@ -635,22 +638,24 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         (Timestamp, Timestamp)
             The open and close for the given session.
         """
-        o_and_c = self.schedule.loc[session_label]
+        sched = self.schedule
 
         # `market_open` and `market_close` should be timezone aware, but pandas
         # 0.16.1 does not appear to support this:
         # http://pandas.pydata.org/pandas-docs/stable/whatsnew.html#datetime-with-tz  # noqa
-        return (o_and_c['market_open'].tz_localize('UTC'),
-                o_and_c['market_close'].tz_localize('UTC'))
+        return (
+            sched.at[session_label, 'market_open'].tz_localize('UTC'),
+            sched.at[session_label, 'market_close'].tz_localize('UTC'),
+        )
 
     def session_open(self, session_label):
-        return self.schedule.loc[
+        return self.schedule.at[
             session_label,
             'market_open'
         ].tz_localize('UTC')
 
     def session_close(self, session_label):
-        return self.schedule.loc[
+        return self.schedule.at[
             session_label,
             'market_close'
         ].tz_localize('UTC')


### PR DESCRIPTION
When retrieving the open and close for a given session, we only care about the scalar values, so using `DataFrame.at` instead of `DataFrame.loc` is significantly faster.

Also improves `MinuteResampleSessionBarReader` by only retrieving session close when we need just the close, instead of the open and close.