### PR TITLE
MAINT: batch_order_target_percent -> batch_market_order.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 zipline/_version.py export-subst
+*.ipynb binary

--- a/zipline/api.pyi
+++ b/zipline/api.pyi
@@ -34,21 +34,18 @@ def attach_pipeline(pipeline, name, chunks=None):
     :func:`zipline.api.pipeline_output`
     """
 
-def batch_order_target_percent(weights):
-    """Place orders towards a given portfolio of weights.
+def batch_market_order(share_counts):
+    """Place a batch market order for multiple assets.
 
     Parameters
     ----------
-    weights : collections.Mapping[Asset -> float]
+    share_counts : pd.Series[Asset -> int]
+        Map from asset to number of shares to order for that asset.
 
     Returns
     -------
-    order_ids : pd.Series[Asset -> str]
-        The unique identifiers for the orders that were placed.
-
-    See Also
-    --------
-    :func:`zipline.api.order_target_percent`
+    order_ids : pd.Index[str]
+        Index of ids for newly-created orders.
     """
 
 def cancel_order(order_param):

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -436,11 +436,6 @@ class TestTargetPercentAlgorithm(TradingAlgorithm):
         return self.order_target_percent(asset, target)
 
 
-class TestBatchTargetPercentAlgorithm(TestTargetPercentAlgorithm):
-    def _order(self, asset, target):
-        return self.batch_order_target_percent({asset: target})
-
-
 class TestTargetValueAlgorithm(TradingAlgorithm):
     def initialize(self):
         self.set_slippage(FixedSlippage())


### PR DESCRIPTION
Replace `batch_order_target_percent` with `batch_market_order`.

The only downstream context that was using batch_order_target_percent
already had all necessary prices, so calling batch_order_target_percent
was wasteful.