### PR TITLE
Allow gaps between auto close and start date

### DIFF
--- a/zipline/assets/continuous_futures.pyx
+++ b/zipline/assets/continuous_futures.pyx
@@ -339,13 +339,6 @@ cdef class OrderedContracts(object):
             if prev is None and contract.start_date >= contract.auto_close_date:
                 continue
 
-            # Prevent contract chains with gaps between auto close and start of
-            # next contract.
-            # This is in lieu of more explicit support for
-            # contracts with quarterly rolls. e.g. Eurodollar
-            if prev is not None and contract.start_date > prev.contract.auto_close_date:
-                continue
-
             if not chain_predicate(contract):
                 continue
 


### PR DESCRIPTION
If ever in the middle of a futures chain a contract auto closes before the start date of the next contract, the chain would end prematurely. Instead, set the current contract during that gap to be the next upcoming contract, essentially as a placeholder.