### PR TITLE
MAINT: Modify ReindexBarReader.get_value to return nan on missing data

### DIFF
--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -16,7 +16,7 @@ from numbers import Real
 
 from nose_parameterized import parameterized
 from numpy.testing import assert_almost_equal
-from numpy import nan, array, full
+from numpy import nan, array, full, isnan
 import pandas as pd
 from pandas import DataFrame
 from six import iteritems
@@ -863,11 +863,9 @@ class TestReindexSessionBars(WithBcolzEquityDailyBarReader,
                             "first session should be 10.")
         tday = pd.Timestamp('2015-11-26', tz='UTC')
 
-        with self.assertRaises(NoDataOnDate):
-            self.reader.get_value(1, tday, 'close')
+        self.assertTrue(isnan(self.reader.get_value(1, tday, 'close')))
 
-        with self.assertRaises(NoDataOnDate):
-            self.reader.get_value(1, tday, 'volume')
+        self.assertTrue(isnan(self.reader.get_value(1, tday, 'volume')))
 
     def test_last_availabe_dt(self):
         self.assertEqual(self.reader.last_available_dt, self.END_DATE)

--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pandas import DataFrame
 from six import iteritems
 
-from zipline.data.bar_reader import NoDataOnDate
 from zipline.data.resample import (
     minute_frame_to_session_frame,
     DailyHistoryAggregator,

--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -864,7 +864,7 @@ class TestReindexSessionBars(WithBcolzEquityDailyBarReader,
 
         self.assertTrue(isnan(self.reader.get_value(1, tday, 'close')))
 
-        self.assertTrue(isnan(self.reader.get_value(1, tday, 'volume')))
+        self.assertEqual(self.reader.get_value(1, tday, 'volume'), 0)
 
     def test_last_availabe_dt(self):
         self.assertEqual(self.reader.last_available_dt, self.END_DATE)

--- a/tests/test_api_shim.py
+++ b/tests/test_api_shim.py
@@ -265,6 +265,7 @@ class TestAPIShim(WithCreateBarData,
                         5,
                         "1m",
                         "volume",
+                        "minute",
                         True
                     )
                 else:
@@ -274,6 +275,7 @@ class TestAPIShim(WithCreateBarData,
                         5,
                         "1m",
                         "volume",
+                        "minute",
                     )
 
         test_sim_params = SimulationParameters(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -101,7 +101,12 @@ class TestBenchmark(WithDataPortal, WithSimParams, WithTradingCalendars,
         # should be the equivalent of getting the price history, then doing
         # a pct_change on it
         manually_calculated = self.data_portal.get_history_window(
-            [1], days_to_use[-1], len(days_to_use), "1d", "close"
+            [1],
+            days_to_use[-1],
+            len(days_to_use),
+            "1d",
+            "close",
+            "daily",
         )[1].pct_change()
 
         # compare all the fields except the first one, for which we don't have
@@ -187,6 +192,7 @@ class TestBenchmark(WithDataPortal, WithSimParams, WithTradingCalendars,
                 len(days_to_use),
                 "1d",
                 "close",
+                "daily",
             )[2].pct_change()
 
             for idx, day in enumerate(days_to_use[1:]):

--- a/tests/test_continuous_futures.py
+++ b/tests/test_continuous_futures.py
@@ -670,7 +670,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-03-04 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1d', 'sid')
+            30, '1d', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-01-26', cf],
                          0,
@@ -696,7 +696,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-04-06 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1d', 'sid')
+            30, '1d', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-02-25', cf],
                          1,
@@ -724,7 +724,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-01-11 18:01', tz='US/Eastern').tz_convert('UTC'),
-            3, '1d', 'sid')
+            3, '1d', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-01-08', cf],
                          10,
@@ -745,7 +745,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-03-04 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1d', 'sid')
+            30, '1d', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-01-26', cf],
                          1,
@@ -771,7 +771,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-04-06 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1d', 'sid')
+            30, '1d', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-02-25', cf],
                          2,
@@ -799,7 +799,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-03-04 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1d', 'sid')
+            30, '1d', 'sid', 'minute')
 
         # Volume cuts out for FOF16 on 2016-01-25
         self.assertEqual(window.loc['2016-01-26', cf],
@@ -826,7 +826,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-04-06 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1d', 'sid')
+            30, '1d', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-02-25', cf],
                          1,
@@ -863,7 +863,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf.sid],
             Timestamp('2016-01-26 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'sid')
+            30, '1m', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-01-26 22:32', cf],
                          0,
@@ -882,7 +882,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-01-27 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'sid')
+            30, '1m', 'sid', 'minute')
 
         self.assertEqual(window.loc['2016-01-27 22:32', cf],
                          1,
@@ -896,7 +896,9 @@ def record_current_contract(algo, data):
         cf = self.data_portal.asset_finder.create_continuous_future(
             'FO', 0, 'calendar', None)
         window = self.data_portal.get_history_window(
-            [cf.sid], Timestamp('2016-03-06', tz='UTC'), 30, '1d', 'close')
+            [cf.sid],
+            Timestamp('2016-03-06', tz='UTC'),
+            30, '1d', 'close', 'daily')
 
         assert_almost_equal(
             window.loc['2016-01-26', cf],
@@ -915,7 +917,9 @@ def record_current_contract(algo, data):
 
         # Advance the window a month.
         window = self.data_portal.get_history_window(
-            [cf.sid], Timestamp('2016-04-06', tz='UTC'), 30, '1d', 'close')
+            [cf.sid],
+            Timestamp('2016-04-06', tz='UTC'),
+            30, '1d', 'close', 'daily')
 
         assert_almost_equal(
             window.loc['2016-02-24', cf],
@@ -946,7 +950,9 @@ def record_current_contract(algo, data):
         cf = self.data_portal.asset_finder.create_continuous_future(
             'MA', 0, 'volume', None)
         window = self.data_portal.get_history_window(
-            [cf.sid], Timestamp('2016-03-06', tz='UTC'), 30, '1d', 'close')
+            [cf.sid],
+            Timestamp('2016-03-06', tz='UTC'),
+            30, '1d', 'close', 'daily')
 
         assert_almost_equal(
             window.loc['2016-01-26', cf],
@@ -965,7 +971,9 @@ def record_current_contract(algo, data):
 
         # Advance the window a month.
         window = self.data_portal.get_history_window(
-            [cf.sid], Timestamp('2016-04-06', tz='UTC'), 30, '1d', 'close')
+            [cf.sid],
+            Timestamp('2016-04-06', tz='UTC'),
+            30, '1d', 'close', 'daily')
 
         assert_almost_equal(
             window.loc['2016-02-24', cf],
@@ -991,7 +999,8 @@ def record_current_contract(algo, data):
             'FO', 0, 'calendar', 'add')
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
-            Timestamp('2016-03-06', tz='UTC'), 30, '1d', 'close')
+            Timestamp('2016-03-06', tz='UTC'),
+            30, '1d', 'close', 'daily')
 
         # Unadjusted value is: 115011.44
         # Adjustment is based on hop from 115231.44 to 125231.44
@@ -1034,7 +1043,8 @@ def record_current_contract(algo, data):
         # Advance the window a month.
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
-            Timestamp('2016-04-06', tz='UTC'), 30, '1d', 'close')
+            Timestamp('2016-04-06', tz='UTC'),
+            30, '1d', 'close', 'daily')
 
         # Unadjusted value: 115221.44
         # Adjustments based on hops:
@@ -1116,7 +1126,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf.sid],
             Timestamp('2016-02-25 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'close')
+            30, '1m', 'close', 'minute')
 
         self.assertEqual(window.loc['2016-02-25 22:32', cf],
                          115231.412,
@@ -1135,7 +1145,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf],
             Timestamp('2016-02-28 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'close')
+            30, '1m', 'close', 'minute')
 
         self.assertEqual(window.loc['2016-02-26 22:32', cf],
                          125241.412,
@@ -1155,7 +1165,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
             Timestamp('2016-02-25 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'close')
+            30, '1m', 'close', 'minute')
 
         # Unadjusted: 115231.412
         # Adjustment based on roll:
@@ -1198,7 +1208,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
             Timestamp('2016-02-28 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'close')
+            30, '1m', 'close', 'minute')
 
         # No adjustments in this window.
         self.assertEqual(window.loc['2016-02-26 22:32', cf_mul],
@@ -1219,7 +1229,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
             Timestamp('2016-02-25 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'close')
+            30, '1m', 'close', 'minute')
 
         # Unadjusted: 115231.412
         # Adjustment based on roll:
@@ -1262,7 +1272,7 @@ def record_current_contract(algo, data):
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
             Timestamp('2016-02-28 18:01', tz='US/Eastern').tz_convert('UTC'),
-            30, '1m', 'close')
+            30, '1m', 'close', 'minute')
 
         # No adjustments in this window.
         self.assertEqual(window.loc['2016-02-26 22:32', cf_mul],

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -235,8 +235,7 @@ class WithHistory(WithCreateBarData, WithDataPortal):
                 'declared_date',
                 'pay_date',
                 'amount',
-                'sid',
-            ],
+                'sid'],
         )
 
     @classmethod
@@ -248,6 +247,38 @@ class WithHistory(WithCreateBarData, WithDataPortal):
             freq = '1d'
         else:
             freq = '1m'
+
+        def reindex_to_primary_calendar(a, field):
+            """
+            Reindex an array of prices from a window on the NYSE
+            calendar by the window on the primary calendar with the same
+            dt and window size.
+            """
+
+            if mode == 'daily':
+                dts = self.trading_calendar.sessions_window(dt, -9)
+
+                # `dt` may not be a session on the NYSE calendar, so
+                # `find the next valid session.
+                nyse_sess = self.nyse_calendar.minute_to_session_label(dt)
+                nyse_dts = self.nyse_calendar.sessions_window(nyse_sess, -9)
+            elif mode == 'minute':
+                dts = self.trading_calendar.minutes_window(dt, -10)
+                nyse_dts = self.nyse_calendar.minutes_window(dt, -10)
+
+            output = pd.Series(
+                index=nyse_dts,
+                data=a,
+            ).reindex(dts)
+
+            # Fill after reindexing, to ensure we don't forward fill
+            # with values that are being dropped.
+            if field == 'volume':
+                return output.fillna(0)
+            elif field == 'price':
+                return output.fillna(method='ffill')
+            else:
+                return output
 
         fields = fields if fields is not None else ALL_FIELDS
         assets = assets if assets is not None else [self.ASSET2, self.ASSET3]
@@ -330,11 +361,19 @@ class WithHistory(WithCreateBarData, WithDataPortal):
                         asset3_answer_key = np.full(10, np.nan)
                         asset3_answer_key[-position_from_end] = \
                             value_for_asset3
+                        asset3_answer_key = reindex_to_primary_calendar(
+                            asset3_answer_key,
+                            field,
+                        )
 
                         if asset == self.ASSET2:
                             np.testing.assert_array_equal(
-                                np.array(
-                                    range(base + idx - 9, base + idx + 1)),
+                                reindex_to_primary_calendar(
+                                    np.array(
+                                        range(base + idx - 9, base + idx + 1)
+                                    ),
+                                    field,
+                                ),
                                 asset_series
                             )
 
@@ -347,12 +386,19 @@ class WithHistory(WithCreateBarData, WithDataPortal):
                         asset3_answer_key = np.zeros(10)
                         asset3_answer_key[-position_from_end] = \
                             value_for_asset3 * 100
+                        asset3_answer_key = reindex_to_primary_calendar(
+                            asset3_answer_key,
+                            field,
+                        )
 
                         if asset == self.ASSET2:
                             np.testing.assert_array_equal(
-                                np.array(
-                                    range(base + idx - 9, base + idx + 1)
-                                ) * 100,
+                                reindex_to_primary_calendar(
+                                    np.array(
+                                        range(base + idx - 9, base + idx + 1)
+                                    ) * 100,
+                                    field,
+                                ),
                                 asset_series
                             )
 
@@ -369,20 +415,38 @@ class WithHistory(WithCreateBarData, WithDataPortal):
                         if asset == self.ASSET2:
                             # at idx 9, the data is 2 to 11
                             np.testing.assert_array_equal(
-                                range(idx - 7, idx + 3),
+                                reindex_to_primary_calendar(
+                                    range(idx - 7, idx + 3),
+                                    field=field,
+                                ),
                                 asset_series
                             )
 
                         if asset == self.ASSET3:
-                            first_part = asset_series[0:-position_from_end]
-                            second_part = asset_series[-position_from_end:]
+                            first_end = (
+                                dt -
+                                (self.nyse_calendar.day * position_from_end)
+                            )
+                            second_begin = (
+                                dt -
+                                (self.trading_calendar.day * position_from_end)
+                            )
+                            first_part = asset_series[:first_end]
+                            second_part = asset_series[
+                                (second_begin + self.trading_calendar.day):
+                            ]
 
                             decile_count = ((idx + 1) // 10)
 
                             # in our test data, asset3 prices will be nine
                             # NaNs, then ten 11s, ten 21s, ten 31s...
 
-                            if decile_count == 1:
+                            if len(second_part) >= 10:
+                                np.testing.assert_array_equal(
+                                    np.full(len(first_part), np.nan),
+                                    first_part
+                                )
+                            elif decile_count == 1:
                                 np.testing.assert_array_equal(
                                     np.full(len(first_part), np.nan),
                                     first_part
@@ -1386,7 +1450,7 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
     @classmethod
     def create_df_for_asset(cls, start_day, end_day, interval=1,
                             force_zeroes=False):
-        sessions = cls.trading_calendar.sessions_in_range(start_day, end_day)
+        sessions = cls.nyse_calendar.sessions_in_range(start_day, end_day)
         sessions_count = len(sessions)
 
         # default to 2 because the low array subtracts 1, and we don't
@@ -1455,7 +1519,9 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
         # get the first 30 days of 2015
         jan5 = pd.Timestamp('2015-01-05')
 
-        days = self.trading_calendar.sessions_window(jan5, 30)
+        # Regardless of the calendar used for this test, equities will
+        # only have data on NYSE sessions.
+        days = self.nyse_calendar.sessions_window(jan5, 30)
 
         for idx, day in enumerate(days):
             self.verify_regular_dt(idx, day, 'daily')
@@ -1806,20 +1872,31 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
 
         offsets = np.arange(4)
 
-        def assert_window_prices(window, starting_price):
-            np.testing.assert_almost_equal(window.loc[:, self.ASSET1],
-                                           starting_price + offsets)
+        def assert_window_prices(window, prices):
+            np.testing.assert_almost_equal(window.loc[:, self.ASSET1], prices)
 
         # Window 1 starts on the 23rd day of data for ASSET 1.
-        assert_window_prices(window_1, 23)
+        assert_window_prices(window_1, 23 + offsets)
         # Window 2 starts on the 21st day of data for ASSET 1.
-        assert_window_prices(window_2, 21)
+        assert_window_prices(window_2, 21 + offsets)
         # Window 3 starts on the 23rd day of data for ASSET 1.
-        assert_window_prices(window_3, 23)
+        assert_window_prices(window_3, 23 + offsets)
+
         # Window 4 starts on the 11th day of data for ASSET 1.
-        assert_window_prices(window_4, 11)
+        if not self.trading_calendar.is_session('2014-01-20'):
+            assert_window_prices(window_4, 11 + offsets)
+        else:
+            # If not on the NYSE calendar, it is possible that MLK day
+            # (2014-01-20) is an active trading session. In that case,
+            # we expect a nan value for this asset.
+            assert_window_prices(window_4, [12, nan, 13, 14])
 
 
 class NoPrefetchDailyEquityHistoryTestCase(DailyEquityHistoryTestCase):
     DATA_PORTAL_MINUTE_HISTORY_PREFETCH = 0
     DATA_PORTAL_DAILY_HISTORY_PREFETCH = 0
+
+
+class DailyEquityHistoryOnFuturesCalendarTestCase(DailyEquityHistoryTestCase):
+    TRADING_CALENDAR_STRS = ('NYSE', 'us_futures')
+    TRADING_CALENDAR_PRIMARY_CAL = 'us_futures'

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -423,18 +423,21 @@ class WithHistory(WithCreateBarData, WithDataPortal):
                             )
 
                         if asset == self.ASSET3:
-                            first_end = (
-                                dt -
-                                (self.nyse_calendar.day * position_from_end)
-                            )
+                            cal = self.trading_calendar
+                            nyse_cal = self.nyse_calendar
+
+                            # Second part begins on the session after
+                            # `position_from_end` on the NYSE calendar.
                             second_begin = (
-                                dt -
-                                (self.trading_calendar.day * position_from_end)
+                                dt - nyse_cal.day * (position_from_end - 1)
                             )
+
+                            # First part goes up until the start of the
+                            # second part, because we forward-fill.
+                            first_end = second_begin - cal.day
+
                             first_part = asset_series[:first_end]
-                            second_part = asset_series[
-                                (second_begin + self.trading_calendar.day):
-                            ]
+                            second_part = asset_series[second_begin:]
 
                             decile_count = ((idx + 1) // 10)
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -655,7 +655,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 self.trading_calendar.open_and_close_for_session(jan5)[1],
                 2,
                 '1d',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             np.testing.assert_array_equal(np.array([np.nan, 8389]), window1)
@@ -666,7 +667,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-06 14:35', tz='UTC'),
                 2,
                 '1d',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             # Value from 1/5 should be quartered
@@ -684,7 +686,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-07 14:35', tz='UTC'),
                 3,
                 '1d',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             np.testing.assert_array_equal(
@@ -698,7 +701,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-08 14:40', tz='UTC'),
                 2,
                 '1d',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             # should not be adjusted
@@ -716,7 +720,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             self.trading_calendar.open_and_close_for_session(jan5)[1],
             2,
             '1d',
-            'close'
+            'close',
+            'minute',
         )[asset]
 
         np.testing.assert_array_equal(np.array([nan, 391]), window1)
@@ -727,7 +732,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-06 14:35', tz='UTC'),
             2,
             '1d',
-            'close'
+            'close',
+            'minute',
         )[asset]
 
         np.testing.assert_array_equal(
@@ -743,7 +749,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-07 14:35', tz='UTC'),
             3,
             '1d',
-            'close'
+            'close',
+            'minute',
         )[asset]
 
         np.testing.assert_array_equal(
@@ -759,7 +766,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-08 14:40', tz='UTC'),
             2,
             '1d',
-            'close'
+            'close',
+            'minute',
         )[asset]
 
         # should not be adjusted, should be 787 to 791
@@ -978,7 +986,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 equity_cal.open_and_close_for_session(jan5)[1],
                 10,
                 '1m',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             np.testing.assert_array_equal(
@@ -998,7 +1007,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-06 14:35', tz='UTC'),
                 window2_count,
                 '1m',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             # five minutes from 1/5 should be halved
@@ -1035,7 +1045,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-07 14:35', tz='UTC'),
                 window3_count,
                 '1m',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             # first five minutes should be 4385-4390, but eigthed
@@ -1066,7 +1077,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-07 14:40', tz='UTC'),
                 5,
                 '1m',
-                'close'
+                'close',
+                'minute',
             )[asset]
 
             # should not be adjusted, should be 1005 to 1009
@@ -1081,7 +1093,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-05 21:00', tz='UTC'),
             10,
             '1m',
-            'close'
+            'close',
+            'minute',
         )[self.DIVIDEND_ASSET]
 
         np.testing.assert_array_equal(np.array(range(382, 392)), window1)
@@ -1097,7 +1110,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             window2_end,
             window2_count,
             '1m',
-            'close'
+            'close',
+            'minute',
         )[self.DIVIDEND_ASSET]
 
         # first dividend is 2%, so the first five values should be 2% lower
@@ -1124,7 +1138,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             window3_end,
             window3_count,
             '1m',
-            'close'
+            'close',
+            'minute',
         )[self.DIVIDEND_ASSET]
 
         # first five minute from 1/7 should be hit by 0.9408 (= 0.98 * 0.96)
@@ -1279,7 +1294,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             window_end,
             bar_count,
             '1m',
-            'close'
+            'close',
+            'minute',
         )[self.HALF_DAY_TEST_ASSET]
 
         # 390 minutes for 7/2, 210 minutes for 7/3, 7/4-7/6 closed
@@ -1335,7 +1351,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             first_equity_open,
             bar_count,
             '1m',
-            'close'
+            'close',
+            'minute',
         )
 
         expected = range(asset1_idx - 97, asset1_idx + 3)
@@ -1377,7 +1394,12 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             with self.assertRaisesRegexp(
                     HistoryWindowStartsBeforeData, exp_msg):
                 self.data_portal.get_history_window(
-                    [self.ASSET1], first_day_minutes[5], 15, '1m', 'price'
+                    [self.ASSET1],
+                    first_day_minutes[5],
+                    15,
+                    '1m',
+                    'price',
+                    'minute',
                 )[self.ASSET1]
 
     def test_daily_history_blended(self):
@@ -1406,7 +1428,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                     minute,
                     3,
                     '1d',
-                    field
+                    field,
+                    'minute',
                 )[self.ASSET2]
 
                 self.assertEqual(len(window), 3)
@@ -1428,10 +1451,6 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                     self.assertEqual(window[1], 22873500)
 
                 last_val = -1
-
-                # XXX
-                if minute == day:
-                    continue
 
                 if minute < equity_open:
                     # If before the equity calendar open, we don't yet
@@ -1487,7 +1506,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 minute,
                 3,
                 '1d',
-                field
+                field,
+                'minute',
             )[self.ASSET2]
 
             self.assertEqual(len(window), 3)
@@ -1510,10 +1530,6 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             elif field == 'volume':
                 self.assertEqual(window[0], 22873500)
                 self.assertEqual(window[1], 38083500)
-
-            # XXX
-            if minute == day:
-                continue
 
             last_val = -1
 
@@ -1777,7 +1793,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-05', tz='UTC'),
                 1,
                 '1d',
-                'close'
+                'close',
+                'daily',
             )[asset]
 
             np.testing.assert_array_equal(window1, [2])
@@ -1787,7 +1804,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-05', tz='UTC'),
                 1,
                 '1d',
-                'volume'
+                'volume',
+                'daily',
             )[asset]
 
             np.testing.assert_array_equal(window1_volume, [200])
@@ -1798,7 +1816,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-06', tz='UTC'),
                 2,
                 '1d',
-                'close'
+                'close',
+                'daily',
             )[asset]
 
             # first value should be halved, second value unadjusted
@@ -1809,7 +1828,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-06', tz='UTC'),
                 2,
                 '1d',
-                'volume'
+                'volume',
+                'daily',
             )[asset]
 
             if asset == self.SPLIT_ASSET:
@@ -1824,7 +1844,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-07', tz='UTC'),
                 3,
                 '1d',
-                'close'
+                'close',
+                'daily',
             )[asset]
 
             np.testing.assert_array_equal([0.25, 1.5, 4], window3)
@@ -1834,7 +1855,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 pd.Timestamp('2015-01-07', tz='UTC'),
                 3,
                 '1d',
-                'volume'
+                'volume',
+                'daily',
             )[asset]
 
             if asset == self.SPLIT_ASSET:
@@ -1851,7 +1873,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-05', tz='UTC'),
             1,
             '1d',
-            'close'
+            'close',
+            'daily',
         )[self.DIVIDEND_ASSET]
 
         np.testing.assert_array_equal(window1, [2])
@@ -1862,7 +1885,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-06', tz='UTC'),
             2,
             '1d',
-            'close'
+            'close',
+            'daily',
         )[self.DIVIDEND_ASSET]
 
         # first dividend is 2%, so the first value should be 2% lower than
@@ -1875,7 +1899,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2015-01-07', tz='UTC'),
             3,
             '1d',
-            'close'
+            'close',
+            'daily',
         )[self.DIVIDEND_ASSET]
 
         # second dividend is 0.96
@@ -1935,7 +1960,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 second_day,
                 4,
                 '1d',
-                'price'
+                'price',
+                'daily',
             )[self.ASSET1]
 
         with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
@@ -1944,7 +1970,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 second_day,
                 4,
                 '1d',
-                'volume'
+                'volume',
+                'daily',
             )[self.ASSET1]
 
         # Use a minute to force minute mode.
@@ -1957,7 +1984,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                 first_minute,
                 4,
                 '1d',
-                'close'
+                'close',
+                'daily',
             )[self.ASSET2]
 
     def test_history_window_different_order(self):
@@ -1974,7 +2002,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             day,
             4,
             "1d",
-            "close"
+            "close",
+            'daily',
         )
 
         window_2 = self.data_portal.get_history_window(
@@ -1982,7 +2011,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             day,
             4,
             "1d",
-            "close"
+            "close",
+            'daily',
         )
 
         np.testing.assert_almost_equal(window_1[self.ASSET1].values,
@@ -2002,7 +2032,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2014-02-07', tz='UTC'),
             4,
             "1d",
-            "close"
+            "close",
+            'daily',
         )
 
         window_2 = self.data_portal.get_history_window(
@@ -2010,7 +2041,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2014-02-05', tz='UTC'),
             4,
             "1d",
-            "close"
+            "close",
+            'daily',
         )
 
         window_3 = self.data_portal.get_history_window(
@@ -2018,7 +2050,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2014-02-07', tz='UTC'),
             4,
             "1d",
-            "close"
+            "close",
+            'daily',
         )
 
         window_4 = self.data_portal.get_history_window(
@@ -2026,7 +2059,8 @@ class DailyEquityHistoryTestCase(WithHistory, ZiplineTestCase):
             pd.Timestamp('2014-01-22', tz='UTC'),
             4,
             "1d",
-            "close"
+            "close",
+            'daily',
         )
 
         # Calling 02-07 after resetting the window should not affect the

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -820,7 +820,8 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
         # 10 minutes
         asset = self.env.asset_finder.retrieve_asset(sid)
 
-        minutes = self.trading_calendar.minutes_for_session(
+        # Check the first hour of equities trading.
+        minutes = self.trading_calendars[Equity].minutes_for_session(
             pd.Timestamp('2015-01-05', tz='UTC')
         )[0:60]
 

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -648,7 +648,8 @@ cdef class BarData:
                 self._get_current_minute(),
                 bar_count,
                 frequency,
-                fields
+                fields,
+                self.data_frequency,
             )
 
             if self._adjust_minutes:
@@ -680,7 +681,8 @@ cdef class BarData:
                         self._get_current_minute(),
                         bar_count,
                         frequency,
-                        field
+                        field,
+                        self.data_frequency,
                     )[assets] for field in fields
                 }
 
@@ -708,7 +710,8 @@ cdef class BarData:
                         self._get_current_minute(),
                         bar_count,
                         frequency,
-                        field
+                        field,
+                        self.data_frequency,
                     ) for field in fields
                 }
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -2160,6 +2160,7 @@ class TradingAlgorithm(object):
                 bar_count,
                 frequency,
                 field,
+                self.data_frequency,
                 ffill,
             )
         else:
@@ -2176,6 +2177,7 @@ class TradingAlgorithm(object):
                 bar_count,
                 frequency,
                 field,
+                self.data_frequency,
                 ffill,
             )
 

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -735,8 +735,12 @@ class DataPortal(object):
             )
         return tds[start_loc:end_loc + 1]
 
-    def _get_history_daily_window(self, assets, end_dt, bar_count,
-                                  field_to_use):
+    def _get_history_daily_window(self,
+                                  assets,
+                                  end_dt,
+                                  bar_count,
+                                  field_to_use,
+                                  data_frequency):
         """
         Internal method that returns a dataframe containing history bars
         of daily frequency for the given sids.
@@ -750,7 +754,7 @@ class DataPortal(object):
                                 columns=None)
 
         data = self._get_history_daily_window_data(
-            assets, days_for_window, end_dt, field_to_use
+            assets, days_for_window, end_dt, field_to_use, data_frequency
         )
         return pd.DataFrame(
             data,
@@ -762,10 +766,9 @@ class DataPortal(object):
                                        assets,
                                        days_for_window,
                                        end_dt,
-                                       field_to_use):
-        ends_at_midnight = (end_dt.hour == end_dt.minute == 0)
-
-        if ends_at_midnight:
+                                       field_to_use,
+                                       data_frequency):
+        if data_frequency == 'daily':
             # two cases where we use daily data for the whole range:
             # 1) the history window ends at midnight utc.
             # 2) the last desired day of the window is after the
@@ -860,7 +863,13 @@ class DataPortal(object):
             columns=assets
         )
 
-    def get_history_window(self, assets, end_dt, bar_count, frequency, field,
+    def get_history_window(self,
+                           assets,
+                           end_dt,
+                           bar_count,
+                           frequency,
+                           field,
+                           data_frequency,
                            ffill=True):
         """
         Public API method that returns a dataframe containing the requested
@@ -880,6 +889,10 @@ class DataPortal(object):
         field: string
             The desired field of the asset.
 
+        data_frequency: string
+            The frequency of the data to query; i.e. whether the data is
+            'daily' or 'minute' bars.
+
         ffill: boolean
             Forward-fill missing values. Only has effect if field
             is 'price'.
@@ -894,10 +907,10 @@ class DataPortal(object):
         if frequency == "1d":
             if field == "price":
                 df = self._get_history_daily_window(assets, end_dt, bar_count,
-                                                    "close")
+                                                    "close", data_frequency)
             else:
                 df = self._get_history_daily_window(assets, end_dt, bar_count,
-                                                    field)
+                                                    field, data_frequency)
         elif frequency == "1m":
             if field == "price":
                 df = self._get_history_minute_window(assets, end_dt, bar_count,
@@ -1299,7 +1312,13 @@ class DataPortal(object):
             # returns is always calculated over the last 2 days, regardless
             # of the simulation's data frequency.
             hst = self.get_history_window(
-                [asset], dt, 2, "1d", "price", ffill=True
+                [asset],
+                dt,
+                2,
+                "1d",
+                "price",
+                data_frequency,
+                ffill=True,
             )[asset]
 
             return (hst.iloc[-1] - hst.iloc[0]) / hst.iloc[0]
@@ -1317,7 +1336,13 @@ class DataPortal(object):
             calculated_bar_count = bars
 
         price_arr = self.get_history_window(
-            [asset], dt, calculated_bar_count, freq_str, "price", ffill=True
+            [asset],
+            dt,
+            calculated_bar_count,
+            freq_str,
+            "price",
+            data_frequency,
+            ffill=True,
         )[asset]
 
         if transform_name == "mavg":
@@ -1326,8 +1351,13 @@ class DataPortal(object):
             return nanstd(price_arr, ddof=1)
         elif transform_name == "vwap":
             volume_arr = self.get_history_window(
-                [asset], dt, calculated_bar_count, freq_str, "volume",
-                ffill=True
+                [asset],
+                dt,
+                calculated_bar_count,
+                freq_str,
+                "volume",
+                data_frequency,
+                ffill=True,
             )[asset]
 
             vol_sum = nansum(volume_arr)

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -810,23 +810,25 @@ class DataPortal(object):
             return daily_data
 
     def _handle_minute_history_out_of_bounds(self, bar_count):
+        cal = self.trading_calendar
+
         first_trading_minute_loc = (
-            self.trading_calendar.all_minutes.get_loc(
+            cal.all_minutes.get_loc(
                 self._first_trading_minute
             )
             if self._first_trading_minute is not None else None
         )
 
-        suggested_start_day = (
-            self.trading_calendar.all_minutes[
+        suggested_start_day = cal.minute_to_session_label(
+            cal.all_minutes[
                 first_trading_minute_loc + bar_count
-            ] + self.trading_calendar.day
-        ).date()
+            ] + cal.day
+        )
 
         raise HistoryWindowStartsBeforeData(
             first_trading_day=self._first_trading_day.date(),
             bar_count=bar_count,
-            suggested_start_day=suggested_start_day,
+            suggested_start_day=suggested_start_day.date(),
         )
 
     def _get_history_minute_window(self, assets, end_dt, bar_count,

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -25,6 +25,7 @@ from zipline.data._resample import (
     _minute_to_session_close,
     _minute_to_session_volume,
 )
+from zipline.data.bar_reader import NoDataOnDate
 from zipline.data.minute_bars import MinuteBarReader
 from zipline.data.session_bars import SessionBarReader
 from zipline.utils.memoize import lazyval
@@ -606,10 +607,6 @@ class ReindexBarReader(with_metaclass(ABCMeta)):
     Currently only supports a ``trading_calendar`` which is a superset of the
     ``reader``'s calendar.
 
-    Also, the currenty implementation only reindexes the results from
-    ``load_raw_arrays``, but in the future, `get_value` may also be made to
-    provide an empty result instead of raising on error.
-
     Parameters
     ----------
 
@@ -652,7 +649,11 @@ class ReindexBarReader(with_metaclass(ABCMeta)):
         return self._reader.first_trading_day
 
     def get_value(self, sid, dt, field):
-        return self._reader.get_value(sid, dt, field)
+        # Give an empty result if no data is present.
+        try:
+            return self._reader.get_value(sid, dt, field)
+        except NoDataOnDate:
+            return np.nan
 
     @abstractmethod
     def _outer_dts(self, start_dt, end_dt):

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -653,7 +653,10 @@ class ReindexBarReader(with_metaclass(ABCMeta)):
         try:
             return self._reader.get_value(sid, dt, field)
         except NoDataOnDate:
-            return np.nan
+            if field == 'volume':
+                return 0.0
+            else:
+                return np.nan
 
     @abstractmethod
     def _outer_dts(self, start_dt, end_dt):

--- a/zipline/sources/benchmark_source.py
+++ b/zipline/sources/benchmark_source.py
@@ -146,6 +146,7 @@ class BenchmarkSource(object):
                 bar_count=len(minutes) + 1,
                 frequency="1m",
                 field="price",
+                data_frequency=self.emission_rate,
                 ffill=True
             )[asset]
 
@@ -163,6 +164,7 @@ class BenchmarkSource(object):
                     bar_count=len(trading_days) + 1,
                     frequency="1d",
                     field="price",
+                    data_frequency=self.emission_rate,
                     ffill=True
                 )[asset]
                 return benchmark_series.pct_change()[1:]
@@ -175,6 +177,7 @@ class BenchmarkSource(object):
                     bar_count=len(trading_days),
                     frequency="1d",
                     field="price",
+                    data_frequency=self.emission_rate,
                     ffill=True
                 )[asset]
 

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -714,7 +714,7 @@ class FakeDataPortal(DataPortal):
             return 1.0
 
     def get_history_window(self, assets, end_dt, bar_count, frequency, field,
-                           ffill=True):
+                           data_frequency, ffill=True):
         if frequency == "1d":
             end_idx = \
                 self.trading_calendar.all_sessions.searchsorted(end_dt)

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -433,7 +433,10 @@ class WithTradingCalendars(object):
 
         cls.trading_calendars = {}
 
-        for cal_str in cls.TRADING_CALENDAR_STRS:
+        for cal_str in (
+            set(cls.TRADING_CALENDAR_STRS) |
+            {cls.TRADING_CALENDAR_PRIMARY_CAL}
+        ):
             # Set name to allow aliasing.
             calendar = get_calendar(cal_str)
             setattr(cls,


### PR DESCRIPTION
This was causing issues with '1d' history calls with equities made on the futures calendar on minutes outside the NYSE calendar. This is because we need to make a `get_value` call to get the most recent value for the current day.