### PR TITLE
MAINT: Create a __eq__ for commission objects

### DIFF
--- a/tests/finance/test_commissions.py
+++ b/tests/finance/test_commissions.py
@@ -79,6 +79,16 @@ class CommissionUnitTests(WithAssetFinder, ZiplineTestCase):
         self.assertEqual(0, model.calculate(order, txns[1]))
         self.assertEqual(0, model.calculate(order, txns[2]))
 
+    def test_equality_and_comparison(self):
+        perdollar1 = PerDollar(cost=0.2)
+        perdollar2 = PerDollar(cost=0.2)
+
+        self.assertEqual(perdollar1, perdollar2)
+        self.assertEqual(hash(perdollar1), hash(perdollar2))
+
+        self.assertEqual(perdollar1.__dict__, perdollar1.asdict())
+        self.assertEqual(perdollar2.__dict__, perdollar2.asdict())
+
     def test_per_trade(self):
         # Test per trade model for equities.
         model = PerTrade(cost=10)

--- a/zipline/finance/commission.py
+++ b/zipline/finance/commission.py
@@ -16,7 +16,7 @@ import abc
 from abc import abstractmethod
 from collections import defaultdict
 
-from six import with_metaclass
+from six import with_metaclass, iteritems
 from toolz import merge
 
 from zipline.assets import Equity, Future
@@ -68,6 +68,18 @@ class CommissionModel(with_metaclass(abc.ABCMeta)):
             this order.
         """
         raise NotImplementedError('calculate')
+
+    def __eq__(self, other):
+        return self.asdict() == other.asdict()
+
+    def __hash__(self):
+        return hash((
+            type(self),
+            tuple(sorted(iteritems(self.asdict())))
+        ))
+
+    def asdict(self):
+        return self.__dict__
 
 
 class EquityCommissionModel(CommissionModel):


### PR DESCRIPTION
Just like for the slippage objects, allows commission object
instances to equate if they're called with the same params