### PR TITLE
Gold/Silver futures contracts only trade certain months

### DIFF
--- a/zipline/assets/continuous_futures.pyx
+++ b/zipline/assets/continuous_futures.pyx
@@ -64,6 +64,12 @@ CHAIN_PREDICATES = {
     'CD': march_cycle_delivery_predicate,
     'AD': march_cycle_delivery_predicate,
     'BP': march_cycle_delivery_predicate,
+
+    # Gold and silver contracts trade on an unusual specific set of months.
+    'GC': partial(delivery_predicate, set(['G', 'J', 'M', 'Q', 'V', 'Z'])),
+    'XG': partial(delivery_predicate, set(['G', 'J', 'M', 'Q', 'V', 'Z'])),
+    'SV': partial(delivery_predicate, set(['H', 'K', 'N', 'U', 'Z'])),
+    'YS': partial(delivery_predicate, set(['H', 'K', 'N', 'U', 'Z'])),
 }
 
 ADJUSTMENT_STYLES = {'add', 'mul', None}


### PR DESCRIPTION
Sources: These are the month codes for silver, http://www.mrci.com/web/online-explanation-pages/symbols-a-codes.html and https://www.theice.com/products/31500923/Mini-Silver-Future

Fix silver continuous futures (calendar roll) from looking like this:

![screen shot 2017-05-03 at 3 12 19 pm](https://cloud.githubusercontent.com/assets/13137798/25677604/a3512f36-3014-11e7-8dc8-ae1c8e0ef24e.png)

to this:

![screen shot 2017-05-03 at 3 12 42 pm](https://cloud.githubusercontent.com/assets/13137798/25677610/a6b51840-3014-11e7-92ad-82826ab60b91.png)
