### PR TITLE
MAINT: Remove __eq__ implementation from slippage

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -97,16 +97,6 @@ class SlippageTestCase(WithCreateBarData,
         super(SlippageTestCase, cls).init_class_fixtures()
         cls.ASSET133 = cls.env.asset_finder.retrieve_asset(133)
 
-    def test_equality_and_comparison(self):
-        vol1 = VolumeShareSlippage(volume_limit=0.2)
-        vol2 = VolumeShareSlippage(volume_limit=0.2)
-
-        self.assertEqual(vol1, vol2)
-        self.assertEqual(hash(vol1), hash(vol2))
-
-        self.assertEqual(vol1.__dict__, vol1.asdict())
-        self.assertEqual(vol2.__dict__, vol2.asdict())
-
     def test_allowed_asset_types(self):
         # Custom equities model.
         class MyEquitiesModel(EquitySlippageModel):

--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -19,7 +19,7 @@ import math
 
 import numpy as np
 from pandas import isnull
-from six import with_metaclass, iteritems
+from six import with_metaclass
 from toolz import merge
 
 from zipline.assets import Equity, Future
@@ -162,15 +162,6 @@ class SlippageModel(with_metaclass(FinancialModelMeta)):
             if txn:
                 self._volume_for_bar += abs(txn.amount)
                 yield order, txn
-
-    def __eq__(self, other):
-        return self.asdict() == other.asdict()
-
-    def __hash__(self):
-        return hash((
-            type(self),
-            tuple(sorted(iteritems(self.asdict())))
-        ))
 
     def asdict(self):
         return self.__dict__


### PR DESCRIPTION
There is no way to safely evaluate equality between slippage objects as per https://github.com/quantopian/zipline/pull/1777#discussion_r114665366