### PR TITLE
Slippage cleanup

### DIFF
--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -32,7 +32,6 @@ from zipline.finance.asset_restrictions import NoRestrictions
 from zipline.finance.order import Order
 from zipline.finance.slippage import (
     fill_price_worse_than_limit_price,
-    MarketImpactBase,
     NO_DATA_VOLATILITY_SLIPPAGE_IMPACT,
     VolatilityVolumeShare,
     VolumeShareSlippage,
@@ -875,7 +874,7 @@ class MarketImpactTestCase(WithCreateBarData, ZiplineTestCase):
         data = self.create_bardata(simulation_dt_func=lambda: minute)
         asset = self.asset_finder.retrieve_asset(1)
 
-        mean_volume, volatility = MarketImpactBase()._get_window_data(
+        mean_volume, volatility = VolatilityVolumeShare(0.0)._get_window_data(
             data, asset, window_length=20,
         )
 

--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -193,8 +193,6 @@ class VolumeShareSlippage(SlippageModel):
     """
     Model slippage as a function of the volume of contracts traded.
     """
-    allowed_asset_types = (Equity, Future)
-
     def __init__(self, volume_limit=DEFAULT_EQUITY_VOLUME_SLIPPAGE_BAR_LIMIT,
                  price_impact=0.1):
 
@@ -271,8 +269,6 @@ class FixedSlippage(SlippageModel):
     spread : float, optional
         spread / 2 will be added to buys and subtracted from sells.
     """
-    allowed_asset_types = (Equity, Future)
-
     def __init__(self, spread=0.0):
         super(FixedSlippage, self).__init__()
         self.spread = spread

--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -291,7 +291,7 @@ class FixedSlippage(SlippageModel):
         )
 
 
-class MarketImpactBase(object):
+class MarketImpactBase(SlippageModel):
     """
     Base class for slippage models which compute a simulated price impact
     according to a history lookback.
@@ -318,13 +318,13 @@ class MarketImpactBase(object):
         raise NotImplementedError('get_txn_volume')
 
     @abstractmethod
-    def simulated_impact(self,
-                         order,
-                         current_price,
-                         current_volume,
-                         txn_volume,
-                         mean_volume,
-                         volatility):
+    def get_simulated_impact(self,
+                             order,
+                             current_price,
+                             current_volume,
+                             txn_volume,
+                             mean_volume,
+                             volatility):
         """
         Calculate simulated price impact.
 
@@ -341,7 +341,7 @@ class MarketImpactBase(object):
         ------
         int : impact on the current price.
         """
-        raise NotImplementedError('simulated_impact')
+        raise NotImplementedError('get_simulated_impact')
 
     def process_order(self, data, order):
         if order.open_amount == 0:
@@ -430,7 +430,7 @@ class MarketImpactBase(object):
         return values['volume'], values['close']
 
 
-class VolatilityVolumeShare(MarketImpactBase, FutureSlippageModel):
+class VolatilityVolumeShare(MarketImpactBase):
     """
     Model slippage for futures contracts according to the following formula:
 

--- a/zipline/finance/slippage.py
+++ b/zipline/finance/slippage.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from __future__ import division
 
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 import math
 from six import with_metaclass, iteritems
 from toolz import merge
@@ -91,7 +91,7 @@ class SlippageModel(with_metaclass(ABCMeta)):
     def volume_for_bar(self):
         return self._volume_for_bar
 
-    @abstractproperty
+    @abstractmethod
     def process_order(self, data, order):
         """Process how orders get filled.
 
@@ -198,10 +198,10 @@ class VolumeShareSlippage(SlippageModel):
     def __init__(self, volume_limit=DEFAULT_EQUITY_VOLUME_SLIPPAGE_BAR_LIMIT,
                  price_impact=0.1):
 
+        super(VolumeShareSlippage, self).__init__()
+
         self.volume_limit = volume_limit
         self.price_impact = price_impact
-
-        super(VolumeShareSlippage, self).__init__()
 
     def __repr__(self):
         return """
@@ -274,6 +274,7 @@ class FixedSlippage(SlippageModel):
     allowed_asset_types = (Equity, Future)
 
     def __init__(self, spread=0.0):
+        super(FixedSlippage, self).__init__()
         self.spread = spread
 
     def __repr__(self):

--- a/zipline/testing/slippage.py
+++ b/zipline/testing/slippage.py
@@ -23,6 +23,7 @@ class TestingSlippage(SlippageModel):
     allowed_asset_types = (Equity,)
 
     def __init__(self, filled_per_tick):
+        super(TestingSlippage, self).__init__()
         self.filled_per_tick = filled_per_tick
 
     def process_order(self, data, order):


### PR DESCRIPTION
- `process_order` is a method. Call super's `__init__` to set up base state
- Fixed abstractness of `MarketImpactBase`