### PR TITLE
Some futures prices need more precision when rounding

### DIFF
--- a/tests/test_data_portal.py
+++ b/tests/test_data_portal.py
@@ -20,40 +20,48 @@ import pandas as pd
 from pandas.tslib import Timedelta
 
 from zipline.assets import Equity
+from zipline.data.data_portal import OHLCV_FIELDS
 from zipline.testing.fixtures import (
     ZiplineTestCase,
     WithTradingSessions,
     WithDataPortal,
     alias,
 )
+from zipline.testing.predicates import assert_equal
+from zipline.utils.numpy_utils import float64_dtype
 
 
 class DataPortalTestBase(WithDataPortal,
                          WithTradingSessions,
                          ZiplineTestCase):
 
-    ASSET_FINDER_EQUITY_SIDS = (1,)
+    ASSET_FINDER_EQUITY_SIDS = (1, 2)
     START_DATE = pd.Timestamp('2016-08-01')
     END_DATE = pd.Timestamp('2016-08-08')
 
-    TRADING_CALENDAR_STRS = ('NYSE', 'CME')
+    TRADING_CALENDAR_STRS = ('NYSE', 'us_futures')
 
     EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE = True
 
+    # Since these assets have a tick size of 0.0001, they need a multiplier of
+    # 10,000 for their prices to be stored as integers.
+    OHLC_RATIOS_PER_SID = {2: 10000, 10001: 10000}
+
     @classmethod
     def make_futures_info(cls):
-        trading_sessions = cls.trading_sessions['CME']
+        trading_sessions = cls.trading_sessions['us_futures']
         return pd.DataFrame({
-            'sid': [10000],
-            'root_symbol': ['BAR'],
-            'symbol': ['BARA'],
-            'start_date': [trading_sessions[1]],
-            'end_date': [cls.END_DATE],
+            'sid': [10000, 10001],
+            'root_symbol': ['BAR', 'BUZ'],
+            'symbol': ['BARA', 'BUZZ'],
+            'start_date': [trading_sessions[1], trading_sessions[1]],
+            'end_date': [cls.END_DATE, cls.END_DATE],
             # TODO: Make separate from 'end_date'
-            'notice_date': [cls.END_DATE],
-            'expiration_date': [cls.END_DATE],
-            'multiplier': [500],
-            'exchange': ['CME'],
+            'notice_date': [cls.END_DATE, cls.END_DATE],
+            'expiration_date': [cls.END_DATE, cls.END_DATE],
+            'tick_size': [0.01, 0.0001],
+            'multiplier': [500, 50000],
+            'exchange': ['CME', 'CME'],
         })
 
     @classmethod
@@ -102,13 +110,25 @@ class DataPortalTestBase(WithDataPortal,
                 'volume': full(len(dts), 0),
             },
             index=dts))
-        yield 1, pd.concat(dfs)
+        asset1_df = pd.concat(dfs)
+        yield 1, asset1_df
+
+        asset2_df = pd.DataFrame(
+            {
+                'open': 1.0055,
+                'high': 1.0059,
+                'low': 1.0051,
+                'close': 1.0055,
+                'volume': 100,
+            },
+            index=asset1_df.index,
+        )
+        yield 2, asset2_df
 
     @classmethod
     def make_future_minute_bar_data(cls):
-        asset = cls.asset_finder.retrieve_asset(10000)
-        trading_calendar = cls.trading_calendars[asset.exchange]
-        trading_sessions = cls.trading_sessions[asset.exchange]
+        trading_calendar = cls.trading_calendars['us_futures']
+        trading_sessions = cls.trading_sessions['us_futures']
         # No data on first day, future asset intentionally not on the same
         # dates as equities, so that cross-wiring of results do not create a
         # false positive.
@@ -154,7 +174,20 @@ class DataPortalTestBase(WithDataPortal,
                 'volume': full(len(dts), 0),
             },
             index=dts))
-        yield asset.sid, pd.concat(dfs)
+        asset10000_df = pd.concat(dfs)
+        yield 10000, asset10000_df
+
+        asset10001_df = pd.DataFrame(
+            {
+                'open': 1.0055,
+                'high': 1.0059,
+                'low': 1.0051,
+                'close': 1.0055,
+                'volume': 100,
+            },
+            index=asset10000_df.index,
+        )
+        yield 10001, asset10001_df
 
     def test_get_last_traded_equity_minute(self):
         trading_calendar = self.trading_calendars[Equity]
@@ -180,7 +213,7 @@ class DataPortalTestBase(WithDataPortal,
 
     def test_get_last_traded_future_minute(self):
         asset = self.asset_finder.retrieve_asset(10000)
-        trading_calendar = self.trading_calendars[asset.exchange]
+        trading_calendar = self.trading_calendars['us_futures']
         # Case: Missing data at front of data set, and request dt is before
         # first value.
         dts = trading_calendar.minutes_for_session(self.trading_days[0])
@@ -258,7 +291,7 @@ class DataPortalTestBase(WithDataPortal,
         assert_almost_equal(array(list(expected.values())), result)
 
     def test_get_spot_value_future_minute(self):
-        trading_calendar = self.trading_calendars['CME']
+        trading_calendar = self.trading_calendars['us_futures']
         asset = self.asset_finder.retrieve_asset(10000)
         dts = trading_calendar.minutes_for_session(self.trading_days[3])
 
@@ -299,7 +332,7 @@ class DataPortalTestBase(WithDataPortal,
     def test_get_spot_value_multiple_assets(self):
         equity = self.asset_finder.retrieve_asset(1)
         future = self.asset_finder.retrieve_asset(10000)
-        trading_calendar = self.trading_calendars['CME']
+        trading_calendar = self.trading_calendars['us_futures']
         dts = trading_calendar.minutes_for_session(self.trading_days[3])
 
         # We expect the outputs to be lists of spot values.
@@ -384,7 +417,7 @@ class DataPortalTestBase(WithDataPortal,
                          "return that as the last trade on the fifth.")
 
         future = self.asset_finder.retrieve_asset(10000)
-        calendar = self.trading_calendars[future.exchange]
+        calendar = self.trading_calendars['us_futures']
         minutes = calendar.minutes_for_session(self.trading_days[3])
         result = self.data_portal.get_last_traded_dt(future,
                                                      minutes[3],
@@ -404,6 +437,46 @@ class DataPortalTestBase(WithDataPortal,
     def test_get_empty_splits(self):
         splits = self.data_portal.get_splits([], self.trading_days[2])
         self.assertEqual([], splits)
+
+    def test_price_rounding(self):
+        equity = self.asset_finder.retrieve_asset(2)
+        future = self.asset_finder.retrieve_asset(10001)
+        minutes = self.nyse_calendar.minutes_for_session(self.trading_days[1])
+        minute = minutes[0]
+
+        expected_equity_values = {
+            'open': 1.006,
+            'high': 1.006,
+            'low': 1.005,
+            'close': 1.006,
+            'volume': 100,
+        }
+        expected_future_values = {
+            'open': 1.0055,
+            'high': 1.0059,
+            'low': 1.0051,
+            'close': 1.0055,
+            'volume': 100,
+        }
+
+        for field in OHLCV_FIELDS:
+            result = self.data_portal.get_history_window(
+                assets=[equity, future],
+                end_dt=minute,
+                bar_count=1,
+                frequency='1m',
+                field=field,
+            )
+            expected_result = pd.DataFrame(
+                {
+                    equity: expected_equity_values[field],
+                    future: expected_future_values[field],
+                },
+                index=[minute],
+                dtype=float64_dtype,
+            )
+
+            assert_equal(result, expected_result)
 
 
 class TestDataPortal(DataPortalTestBase):

--- a/tests/test_data_portal.py
+++ b/tests/test_data_portal.py
@@ -444,6 +444,7 @@ class DataPortalTestBase(WithDataPortal,
         minutes = self.nyse_calendar.minutes_for_session(self.trading_days[1])
         minute = minutes[0]
 
+        # Equity prices should be rounded to three decimal places.
         expected_equity_values = {
             'open': 1.006,
             'high': 1.006,

--- a/tests/utils/test_math_utils.py
+++ b/tests/utils/test_math_utils.py
@@ -1,0 +1,13 @@
+
+from unittest import TestCase
+
+from zipline.utils.math_utils import number_of_decimal_places
+
+
+class MathUtilsTestCase(TestCase):
+
+    def test_number_of_decimal_places(self):
+        self.assertEqual(number_of_decimal_places(1), 0)
+        self.assertEqual(number_of_decimal_places(3.14), 2)
+        self.assertEqual(number_of_decimal_places('3.14'), 2)
+        self.assertEqual(number_of_decimal_places(-3.14), 2)

--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -533,7 +533,7 @@ class HistoryLoader(with_metaclass(ABCMeta)):
         return concatenate(
             [window.get(end_ix) for window in block],
             axis=1,
-        ).round(3)
+        )
 
 
 class DailyHistoryLoader(HistoryLoader):

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -915,6 +915,7 @@ class _WithMinuteBarDataBase(WithTradingEnvironment):
     MINUTE_BAR_LOOKBACK_DAYS = 0
     MINUTE_BAR_START_DATE = alias('START_DATE')
     MINUTE_BAR_END_DATE = alias('END_DATE')
+    OHLC_RATIOS_PER_SID = None
 
 
 class WithEquityMinuteBarData(_WithMinuteBarDataBase):
@@ -1087,7 +1088,8 @@ class WithBcolzEquityMinuteBarReader(WithEquityMinuteBarData, WithTmpDir):
             cls.trading_calendars[Equity],
             days[0],
             days[-1],
-            US_EQUITIES_MINUTES_PER_DAY
+            US_EQUITIES_MINUTES_PER_DAY,
+            ohlc_ratios_per_sid=cls.OHLC_RATIOS_PER_SID,
         )
         writer.write(cls.make_equity_minute_bar_data())
 
@@ -1148,6 +1150,7 @@ class WithBcolzFutureMinuteBarReader(WithFutureMinuteBarData, WithTmpDir):
             days[0],
             days[-1],
             FUTURES_MINUTES_PER_DAY,
+            ohlc_ratios_per_sid=cls.OHLC_RATIOS_PER_SID,
         )
         writer.write(cls.make_future_minute_bar_data())
 

--- a/zipline/utils/math_utils.py
+++ b/zipline/utils/math_utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from decimal import Decimal
 import math
 
 from numpy import isnan
@@ -77,3 +78,20 @@ def round_if_near_integer(a, epsilon=1e-4):
         return round(a)
     else:
         return a
+
+
+def number_of_decimal_places(n):
+    """
+    Compute the number of decimal places in a number.
+
+    Examples
+    --------
+    >>> number_of_decimal_places(1)
+    0
+    >>> number_of_decimal_places(3.14)
+    2
+    >>> number_of_decimal_places('3.14')
+    2
+    """
+    decimal = Decimal(str(n))
+    return -decimal.as_tuple().exponent


### PR DESCRIPTION
Previously, _all_ asset prices were being rounded to 3 decimal places because this is the most precision we ever needed for equities. Some futures however have tick sizes with precision less than 0.001, so we need to dynamically account for that when rounding.