### PR TITLE
MAINT: Shorten __repr__ for different assets

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -30,7 +30,7 @@ from nose_parameterized import parameterized
 from numpy import full, int32, int64
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
-from six import PY2, viewkeys
+from six import viewkeys
 import sqlalchemy as sa
 
 from zipline.assets import (
@@ -379,30 +379,9 @@ class TestFuture(WithAssetFinder, ZiplineTestCase):
         cls.future = cls.asset_finder.lookup_future_symbol('OMH15')
         cls.future2 = cls.asset_finder.lookup_future_symbol('CLG06')
 
-    def test_str(self):
-        strd = str(self.future)
-        self.assertEqual("Future(2468 [OMH15])", strd)
-
     def test_repr(self):
         reprd = repr(self.future)
-        self.assertIn("Future", reprd)
-        self.assertIn("2468", reprd)
-        self.assertIn("OMH15", reprd)
-        self.assertIn("root_symbol=%s'OM'" % ('u' if PY2 else ''), reprd)
-        self.assertIn(
-            "notice_date=Timestamp('2014-01-20 00:00:00+0000', tz='UTC')",
-            reprd,
-        )
-        self.assertIn(
-            "expiration_date=Timestamp('2014-02-20 00:00:00+0000'",
-            reprd,
-        )
-        self.assertIn(
-            "auto_close_date=Timestamp('2014-01-18 00:00:00+0000'",
-            reprd,
-        )
-        self.assertIn("tick_size=0.01", reprd)
-        self.assertIn("multiplier=500", reprd)
+        self.assertEqual("Future(2468 [OMH15])", reprd)
 
     def test_reduce(self):
         assert_equal(

--- a/zipline/assets/_assets.pyx
+++ b/zipline/assets/_assets.pyx
@@ -140,20 +140,11 @@ cdef class Asset:
         else:
             raise AssertionError('%d is not an operator' % op)
 
-    def __str__(self):
+    def __repr__(self):
         if self.symbol:
             return '%s(%d [%s])' % (type(self).__name__, self.sid, self.symbol)
         else:
             return '%s(%d)' % (type(self).__name__, self.sid)
-
-    def __repr__(self):
-        attrs = ('symbol', 'asset_name', 'exchange',
-                 'start_date', 'end_date', 'first_traded', 'auto_close_date')
-        tuples = ((attr, repr(getattr(self, attr, None)))
-                  for attr in attrs)
-        strings = ('%s=%s' % (t[0], t[1]) for t in tuples)
-        params = ', '.join(strings)
-        return 'Asset(%d, %s)' % (self.sid, params)
 
     cpdef __reduce__(self):
         """
@@ -232,16 +223,6 @@ cdef class Asset:
 
 
 cdef class Equity(Asset):
-
-    def __repr__(self):
-        attrs = ('symbol', 'asset_name', 'exchange',
-                 'start_date', 'end_date', 'first_traded', 'auto_close_date',
-                 'exchange_full')
-        tuples = ((attr, repr(getattr(self, attr, None)))
-                  for attr in attrs)
-        strings = ('%s=%s' % (t[0], t[1]) for t in tuples)
-        params = ', '.join(strings)
-        return 'Equity(%d, %s)' % (self.sid, params)
 
     property security_start_date:
         """
@@ -342,17 +323,6 @@ cdef class Future(Asset):
                 self.auto_close_date = notice_date
             else:
                 self.auto_close_date = min(notice_date, expiration_date)
-
-    def __repr__(self):
-        attrs = ('symbol', 'root_symbol', 'asset_name', 'exchange',
-                 'start_date', 'end_date', 'first_traded', 'notice_date',
-                 'expiration_date', 'auto_close_date', 'tick_size',
-                 'multiplier', 'exchange_full')
-        tuples = ((attr, repr(getattr(self, attr, None)))
-                  for attr in attrs)
-        strings = ('%s=%s' % (t[0], t[1]) for t in tuples)
-        params = ', '.join(strings)
-        return 'Future(%d, %s)' % (self.sid, params)
 
     cpdef __reduce__(self):
         """


### PR DESCRIPTION
x-ref https://github.com/quantopian/zipline/issues/1675

This change shortens the `__repr__` method for `Asset`, and uses the same repr for different Asset classes (e.g. Futures and Equities). 

Only concern I have here is the comment from Eddie and others on the Futures repr:

![image](https://cloud.githubusercontent.com/assets/8339018/25827937/8ede1536-341b-11e7-8232-ef37a998bf65.png)
