### PR TITLE
Allow to define start/end in `get_calendar()`

### DIFF
--- a/tests/calendars/test_calendar_dispatcher.py
+++ b/tests/calendars/test_calendar_dispatcher.py
@@ -1,6 +1,11 @@
 """
 Tests for TradingCalendarDispatcher.
 """
+from datetime import datetime
+
+import pandas as pd
+from nose_parameterized import parameterized
+
 from zipline.errors import (
     CalendarNameCollision,
     CyclicCalendarAlias,
@@ -93,3 +98,18 @@ class CalendarAliasTestCase(ZiplineTestCase):
 
         expected = "Cycle in calendar aliases: ['C' -> 'A' -> 'B' -> 'C']"
         self.assertEqual(str(e.exception), expected)
+
+    @parameterized.expand([
+        (pd.Timestamp('2010-1-4'), pd.Timestamp('2010-1-8')),
+        (datetime(2010, 1, 4), datetime(2010, 1, 8)),
+        ('2010-1-4', '2010-1-8'),
+    ])
+    def test_start_end(self, start, end):
+        """
+        Check TradingCalendar with defined start/end dates.
+        """
+        calendar = self.dispatcher.get_calendar('NYSE', start=start, end=end)
+        expected_first = pd.Timestamp(start, tz='UTC')
+        expected_last = pd.Timestamp(end, tz='UTC')
+        self.assertTrue(calendar.first_trading_session == expected_first)
+        self.assertTrue(calendar.last_trading_session == expected_last)

--- a/tests/calendars/test_nyse_calendar.py
+++ b/tests/calendars/test_nyse_calendar.py
@@ -226,3 +226,17 @@ class NYSECalendarTestCase(ExchangeCalendarTestBase, TestCase):
         self.assertFalse(self.calendar.is_open_on_minute(wednesday_before))
         self.assertTrue(self.calendar.is_open_on_minute(friday_after_open))
         self.assertTrue(self.calendar.is_open_on_minute(friday_after))
+
+
+class CalendarStartEndTestCase(TestCase):
+    def test_start_end(self):
+        """
+        Check TradingCalendar with defined start/end dates.
+        """
+        start = pd.Timestamp('2010-1-3')
+        end = pd.Timestamp('2010-1-10')
+        calendar = NYSEExchangeCalendar(start=start, end=end)
+        expected_first = pd.Timestamp('2010-1-4', tz='UTC')
+        expected_last = pd.Timestamp('2010-1-8', tz='UTC')
+        self.assertTrue(calendar.first_trading_session == expected_first)
+        self.assertTrue(calendar.last_trading_session == expected_last)

--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import time
+from datetime import datetime
 from os.path import (
     abspath,
     dirname,
@@ -66,6 +67,23 @@ class FakeCalendar(TradingCalendar):
     @property
     def close_time(self):
         return time(11, 49)
+
+
+class CalendarStartEndTestCase(TestCase):
+    @parameterized.expand([
+        (pd.Timestamp('2010-1-4'), pd.Timestamp('2010-1-8')),
+        (datetime(2010, 1, 4), datetime(2010, 1, 8)),
+        ('2010-1-4', '2010-1-8'),
+    ])
+    def test_start_end(self, start, end):
+        """
+        Check TradingCalendar with defined start/end dates.
+        """
+        calendar = FakeCalendar(start=start, end=end)
+        expected_first = pd.Timestamp(start, tz='UTC')
+        expected_last = pd.Timestamp(end, tz='UTC')
+        self.assertTrue(calendar.first_trading_session == expected_first)
+        self.assertTrue(calendar.last_trading_session == expected_last)
 
 
 class CalendarRegistrationTestCase(TestCase):

--- a/zipline/utils/calendars/calendar_utils.py
+++ b/zipline/utils/calendars/calendar_utils.py
@@ -56,7 +56,7 @@ class TradingCalendarDispatcher(object):
         self._calendar_factories = calendar_factories
         self._aliases = aliases
 
-    def get_calendar(self, name):
+    def get_calendar(self, name, start=None, end=None):
         """
         Retrieves an instance of an TradingCalendar whose name is given.
 
@@ -64,6 +64,10 @@ class TradingCalendarDispatcher(object):
         ----------
         name : str
             The name of the TradingCalendar to be retrieved.
+        start : str or datetime/timestamp, default is None
+            The calendar start datetime/timestamp.
+        end : str or datetime/timestamp, default is None
+            The calendar end datetime/timestamp.
 
         Returns
         -------
@@ -72,8 +76,9 @@ class TradingCalendarDispatcher(object):
         """
         canonical_name = self.resolve_alias(name)
 
+        configuration = (canonical_name, start, end)
         try:
-            return self._calendars[canonical_name]
+            return self._calendars[configuration]
         except KeyError:
             # We haven't loaded this calendar yet, so make a new one.
             pass
@@ -85,7 +90,7 @@ class TradingCalendarDispatcher(object):
             raise InvalidCalendarName(calendar_name=name)
 
         # Cache the calendar for future use.
-        calendar = self._calendars[canonical_name] = factory()
+        calendar = self._calendars[configuration] = factory(start, end)
         return calendar
 
     def has_calendar(self, name):

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -889,11 +889,7 @@ def days_at_time(days, t, tz, day_offset=0):
 
 def holidays_at_time(calendar, start, end, time, tz):
     return days_at_time(
-        calendar.holidays(
-            # Workaround for https://github.com/pydata/pandas/issues/9825.
-            start.tz_localize(None),
-            end.tz_localize(None),
-        ),
+        calendar.holidays(start, end),
         time,
         tz=tz,
     )

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -63,8 +63,24 @@ class TradingCalendar(with_metaclass(ABCMeta)):
     used for convenience.
 
     For each session, we store the open and close time in UTC time.
+
+    Parameters
+    ----------
+    start : str or datetime/timestamp, default is None
+        The calendar start datetime/timestamp.
+    end : str or datetime/timestamp, default is None
+        The calendar end datetime/timestamp.
     """
-    def __init__(self, start=start_default, end=end_default):
+    def __init__(self, start=None, end=None):
+        # Set default start/end dates if not defined
+        if not start:
+            start = start_default
+        if not end:
+            end = end_default
+        # Convert start/end to pandas.Timestamp
+        start = pd.Timestamp(start, tz='UTC')
+        end = pd.Timestamp(end, tz='UTC')
+
         # Midnight in UTC for each trading day.
 
         # In pandas 0.18.1, pandas calls into its own code here in a way that


### PR DESCRIPTION
Currently `get_calendar()` does not propagate start/end parameters to TradingCalendar initialization. Also, try to be more flexible in the start/end types allowed for TradingCalendar initialization.

This pull-request also includes #1795 as first commit.