### PR TITLE
Improve start/end utilization in TradingCalendar

### DIFF
--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -75,15 +75,40 @@ class CalendarStartEndTestCase(TestCase):
         (datetime(2010, 1, 4), datetime(2010, 1, 8)),
         ('2010-1-4', '2010-1-8'),
     ])
-    def test_start_end(self, start, end):
+    def test_start_end_types(self, start, end):
         """
-        Check TradingCalendar with defined start/end dates.
+        Check TradingCalendar with start/end dates using different types.
         """
         calendar = FakeCalendar(start=start, end=end)
-        expected_first = pd.Timestamp(start, tz='UTC')
-        expected_last = pd.Timestamp(end, tz='UTC')
-        self.assertTrue(calendar.first_trading_session == expected_first)
-        self.assertTrue(calendar.last_trading_session == expected_last)
+
+        # Check calendar first/last trading session
+        first_session = pd.Timestamp(start, tz='UTC')
+        last_session = pd.Timestamp(end, tz='UTC')
+        self.assertTrue(calendar.first_trading_session == first_session)
+        self.assertTrue(calendar.last_trading_session == last_session)
+
+    @parameterized.expand([
+        ('2010-1-4', '2010-1-8', '2010-1-4', '2010-1-8'),
+        ('2010-1-2', '2010-1-10', '2010-1-4', '2010-1-8'),
+    ])
+    def test_start_end_attributes(self, start, end, first, last):
+        """
+        Start/end attributes do not need to match the first/last trading
+        session in the calendar.
+        """
+        calendar = FakeCalendar(start=start, end=end)
+
+        # Check calendar start/end attributes
+        start = pd.Timestamp(start, tz='UTC')
+        end = pd.Timestamp(end, tz='UTC')
+        self.assertTrue(calendar.start == start)
+        self.assertTrue(calendar.end == end)
+
+        # Check calendar first/last trading session
+        first = pd.Timestamp(first, tz='UTC')
+        last = pd.Timestamp(last, tz='UTC')
+        self.assertTrue(calendar.first_trading_session == first)
+        self.assertTrue(calendar.last_trading_session == last)
 
 
 class CalendarRegistrationTestCase(TestCase):

--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import time
+from datetime import datetime
 from os.path import (
     abspath,
     dirname,
@@ -66,6 +67,23 @@ class FakeCalendar(TradingCalendar):
     @property
     def close_time(self):
         return time(11, 49)
+
+
+class CalendarStartEndTestCase(TestCase):
+    @parameterized.expand([
+        (pd.Timestamp('2010-1-4'), pd.Timestamp('2010-1-8')),
+        (datetime(2010, 1, 4), datetime(2010, 1, 8)),
+        ('2010-1-4', '2010-1-8'),
+    ])
+    def test_start_end(self, start, end):
+        """
+        Check TradingCalendar with defined start/end dates.
+        """
+        calendar = FakeCalendar(start=start, end=end)
+        expected_first = pd.Timestamp(start, tz='UTC')
+        expected_last = pd.Timestamp(end, tz='UTC')
+        self.assertTrue(calendar.first_trading_session == expected_first)
+        self.assertTrue(calendar.last_trading_session == expected_last)
 
 
 class CalendarRegistrationTestCase(TestCase):

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -80,6 +80,8 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         # Convert start/end to pandas.Timestamp
         start = pd.Timestamp(start, tz='UTC')
         end = pd.Timestamp(end, tz='UTC')
+        self.start = start
+        self.end = end
 
         # Midnight in UTC for each trading day.
 

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -63,8 +63,24 @@ class TradingCalendar(with_metaclass(ABCMeta)):
     used for convenience.
 
     For each session, we store the open and close time in UTC time.
+
+    Parameters
+    ----------
+    start : str or datetime/timestamp, default is None
+        The calendar start datetime/timestamp.
+    end : str or datetime/timestamp, default is None
+        The calendar end datetime/timestamp.
     """
-    def __init__(self, start=start_default, end=end_default):
+    def __init__(self, start=None, end=None):
+        # Set default start/end dates if not defined
+        if not start:
+            start = start_default
+        if not end:
+            end = end_default
+        # Convert start/end to pandas.Timestamp
+        start = pd.Timestamp(start, tz='UTC')
+        end = pd.Timestamp(end, tz='UTC')
+
         # Midnight in UTC for each trading day.
 
         # In pandas 0.18.1, pandas calls into its own code here in a way that


### PR DESCRIPTION
Changes:

- Allow to pass string and datetime types to `TradingCalendar`'s `start` and `end` parameters.
- Set default parameters to `None`. This way it is easier to propagate undefined `start`/`end` parameters when the `TradingCalendar` initialization is encapsulated in another function/method (no need to import `start_default`/`end_default` to have consistent behavior).
- Store `start`/`end` attributes as they are useful to know the first/last day of the calendar (they do not need to match the first/last trading session in the calendar).