### PR TITLE
Upgrade SciPy to version 0.18.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - secure: "W2tTHoZYLuEjoIMI/K3adv7QW7yx4iVOIkVOn73jUkv3IlyZZ+BraL0hBw5Dh/iBA9PnO1qOKeRFLDDfDza/1S+2QxZMBmJ8HAkcZehbtTPdCgn/+CYSlauUlJ2izxgnXFw49qJDllQWtwsK2PEuvHrir6wbdElkXKvIJoD7jQ4="
     - CONDA_ROOT_PYTHON_VERSION: "2.7"
   matrix:
-    - NUMPY_VERSION=1.11.1 SCIPY_VERSION=0.17.1
+    - NUMPY_VERSION=1.11.1 SCIPY_VERSION=0.18.1
 cache:
   directories:
     - $HOME/.cache/.pip/

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN mkdir ${PROJECT_DIR} \
 WORKDIR /ta-lib
 
 RUN pip install 'numpy>=1.11.1,<2.0.0' \
-  && pip install 'scipy>=0.17.1,<1.0.0' \
+  && pip install 'scipy>=0.18.1,<1.0.0' \
   && pip install 'pandas>=0.18.1,<1.0.0' \
   && ./configure --prefix=/usr \
   && make \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,19 +23,19 @@ environment:
       PYTHON_ARCH: "64"
       PANDAS_VERSION: "0.18.1"
       NUMPY_VERSION: "1.11.1"
-      SCIPY_VERSION: "0.17.1"
+      SCIPY_VERSION: "0.18.1"
 
     - PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
       PANDAS_VERSION: "0.18.1"
       NUMPY_VERSION: "1.11.1"
-      SCIPY_VERSION: "0.17.1"
+      SCIPY_VERSION: "0.18.1"
 
     - PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
       PANDAS_VERSION: "0.18.1"
       NUMPY_VERSION: "1.11.1"
-      SCIPY_VERSION: "0.17.1"
+      SCIPY_VERSION: "0.18.1"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -16,7 +16,7 @@ requests-file==1.4.1
 
 # scipy and pandas are required for statsmodels,
 # statsmodels in turn is required for some pandas packages
-scipy==0.17.1
+scipy==0.18.1
 pandas==0.18.1
 pandas-datareader==0.2.1
 # Needed for parts of pandas.stats


### PR DESCRIPTION
Increase strict requirement version number to a more recent version. The change seems trivial, as changes from 0.17.1 to 0.18.1 do not break any tests nor require other changes in the dependencies.