### PR TITLE
BLD: Swap conda build args to check CI label/channel first

### DIFF
--- a/ci/make_conda_packages.py
+++ b/ci/make_conda_packages.py
@@ -31,8 +31,8 @@ def main(env, do_upload):
                "--python", env['CONDA_PY'],
                "--numpy", env['CONDA_NPY'],
                "--skip-existing",
-               "-c", "quantopian",
-               "-c", "https://conda.anaconda.org/quantopian/label/ci"]
+               "-c", "quantopian/label/ci",
+               "-c", "quantopian"]
 
         output = None
 


### PR DESCRIPTION
Making this change because the build failed when we started building Python 3.5 packages for the first time; we were checking the Quantopian channel `main` label first to see if there is an existing built package for packages like `sortedcontainers` or `setuptools_scm`.

Order matters when passing `-c` flags to `conda build`. 

We've also been unnecessarily building packages in our CI builds because the URL we specified in `make_conda_packages.py` needed to be updated to just be the name of the channel and label.