### PR TITLE
MAINT: Modify broken treasury data link

### DIFF
--- a/zipline/data/treasuries.py
+++ b/zipline/data/treasuries.py
@@ -60,14 +60,13 @@ def earliest_possible_date():
 
 def get_treasury_data(start_date, end_date):
     return pd.read_csv(
-        "http://www.federalreserve.gov/datadownload/Output.aspx"
+        "https://www.federalreserve.gov/datadownload/Output.aspx"
         "?rel=H15"
         "&series=bf17364827e38702b42a58cf8eaa3f78"
         "&lastObs="
         "&from="  # An unbounded query is ~2x faster than specifying dates.
         "&to="
         "&filetype=csv"
-        "&label=omit"
         "&layout=seriescolumn"
         "&type=package",
         skiprows=1,  # First row is a useless header.
@@ -93,7 +92,7 @@ def dataconverter(s):
 def get_daily_10yr_treasury_data():
     """Download daily 10 year treasury rates from the Federal Reserve and
     return a pandas.Series."""
-    url = "http://www.federalreserve.gov/datadownload/Output.aspx?rel=H15" \
+    url = "https://www.federalreserve.gov/datadownload/Output.aspx?rel=H15" \
           "&series=bcb44e57fb57efbe90002369321bfb3f&lastObs=&from=&to=" \
           "&filetype=csv&label=include&layout=seriescolumn"
     return pd.read_csv(url, header=5, index_col=0, names=['DATE', 'BC_10YEAR'],


### PR DESCRIPTION
After moving around on the Federal Reserve site, the link that we're using for `get_treasury_data()` isn't valid (x-ref https://github.com/quantopian/zipline/issues/1817), and so I removed `label=omit` from the URL params to make a working link.

You can see that the same URL is generated when going to `https://www.federalreserve.gov/datadownload/`, clicking on "Selected Interest Rates (H.15)", clicking "Treasury Constant Maturities" and then clicking "Go to Download", lastly click "Download file".

Full URL `https://www.federalreserve.gov/datadownload/Download.aspx?rel=H15&series=bf17364827e38702b42a58cf8eaa3f78&lastobs=&from=&to=&filetype=csv&label=include&layout=seriescolumn&type=package`