### PR TITLE
BUG: Fix Docker startup errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ENTRYPOINT ["/tini", "--"]
 
 ENV PROJECT_DIR=/projects \
     NOTEBOOK_PORT=8888 \
+    JUPYTER_HOME=/root/.jupyter \
     SSL_CERT_PEM=/root/.jupyter/jupyter.pem \
     SSL_CERT_KEY=/root/.jupyter/jupyter.key \
     PW_HASH="u'sha1:31cb67870a35:1a2321318481f00b0efdf3d1f71af523d3ffc505'" \
@@ -42,7 +43,8 @@ ENV PROJECT_DIR=/projects \
 # install TA-Lib and other prerequisites
 #
 
-RUN mkdir ${PROJECT_DIR} \
+RUN mkdir -p ${PROJECT_DIR} \
+    && mkdir -p ${JUPYTER_HOME} \
     && apt-get -y update \
     && apt-get -y install libfreetype6-dev libpng-dev libopenblas-dev liblapack-dev gfortran \
     && curl -L https://downloads.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz | tar xvz

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -5,7 +5,7 @@
 #
 # Note: the dev build requires a quantopian/zipline image, which you can build as follows:
 #
-#    docker build -t quantopian/zipline -f Dockerfile
+#    docker build -t quantopian/zipline -f Dockerfile .
 #
 # To run the container:
 #


### PR DESCRIPTION
The .jupyter directory does not exist in the Docker image.  This was the error output:

```
Generating a 2048 bit RSA private key
......................................................+++
.+++
writing new private key to '/root/.jupyter/jupyter.key'
/root/.jupyter/jupyter.key: No such file or directory
[...]
self.ssl_options['certfile'])
ValueError: certfile "/root/.jupyter/jupyter.pem" does not exist
```

Conflicts with https://github.com/quantopian/zipline/pull/1823