### PR TITLE
Add engine docs

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -187,10 +187,6 @@ Pipeline API
    :members: __and__, __or__
    :exclude-members: dtype
 
-.. autoclass:: zipline.pipeline.data.EarningsCalendar
-   :members: next_announcement, previous_announcement
-   :undoc-members:
-
 .. autoclass:: zipline.pipeline.data.USEquityPricing
    :members: open, high, low, close, volume
    :undoc-members:
@@ -309,9 +305,6 @@ Readers
    :members:
 
 .. autoclass:: zipline.assets.AssetFinder
-   :members:
-
-.. autoclass:: zipline.assets.AssetFinderCachedEquities
    :members:
 
 .. autoclass:: zipline.data.data_portal.DataPortal

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -176,6 +176,10 @@ Pipeline API
    :members:
    :member-order: groupwise
 
+.. autoclass:: zipline.pipeline.filters.Filter
+   :members: __and__, __or__
+   :exclude-members: dtype
+
 .. autoclass:: zipline.pipeline.factors.Factor
    :members: bottom, deciles, demean, linear_regression, pearsonr,
              percentile_between, quantiles, quartiles, quintiles, rank,
@@ -185,9 +189,9 @@ Pipeline API
    :exclude-members: dtype
    :member-order: bysource
 
-.. autoclass:: zipline.pipeline.filters.Filter
-   :members: __and__, __or__
-   :exclude-members: dtype
+.. autoclass:: zipline.pipeline.term.Term
+   :members:
+   :exclude-members: compute_extra_rows, dependencies, inputs, mask, windowed
 
 .. autoclass:: zipline.pipeline.data.USEquityPricing
    :members: open, high, low, close, volume

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -177,8 +177,10 @@ Pipeline API
    :member-order: groupwise
 
 .. autoclass:: zipline.pipeline.factors.Factor
-   :members: top, bottom, rank, percentile_between, isnan, notnan, isfinite,
-             eq, __add__, __sub__, __mul__, __div__, __mod__, __pow__, __lt__,
+   :members: bottom, deciles, demean, linear_regression, pearsonr,
+             percentile_between, quantiles, quartiles, quintiles, rank,
+             spearmanr, top, winsorize, zscore, isnan, notnan, isfinite, eq,
+             __add__, __sub__, __mul__, __div__, __mod__, __pow__, __lt__,
              __le__, __ne__, __ge__, __gt__
    :exclude-members: dtype
    :member-order: bysource

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -242,6 +242,25 @@ Built-in Factors
 .. autoclass:: zipline.pipeline.factors.WeightedAverageValue
    :members:
 
+Pipeline Engine
+```````````````
+
+.. autoclass:: zipline.pipeline.engine.PipelineEngine
+   :members: run_pipeline, run_chunked_pipeline
+   :member-order: bysource
+
+.. autoclass:: zipline.pipeline.engine.SimplePipelineEngine
+   :members: __init__, run_pipeline, run_chunked_pipeline
+   :member-order: bysource
+
+.. autofunction:: zipline.pipeline.engine.default_populate_initial_workspace
+
+Data Loaders
+````````````
+
+.. autoclass:: zipline.pipeline.loaders.equity_pricing_loader.USEquityPricingLoader
+   :members: __init__, from_files, load_adjusted_array
+   :member-order: bysource
 
 Asset Metadata
 ~~~~~~~~~~~~~~

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -183,54 +183,6 @@ Pipeline API
    :exclude-members: dtype
    :member-order: bysource
 
-.. autoclass:: zipline.pipeline.factors.Latest
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.MaxDrawdown
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.Returns
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.RSI
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.BusinessDaysUntilNextEarnings
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.BusinessDaysSincePreviousEarnings
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.SimpleMovingAverage
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.VWAP
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.WeightedAverageValue
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.ExponentialWeightedMovingAverage
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.ExponentialWeightedMovingStdDev
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.AverageDollarVolume
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.BollingerBands
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.RollingPearsonOfReturns
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.RollingSpearmanOfReturns
-   :members:
-
-.. autoclass:: zipline.pipeline.factors.RollingLinearRegressionOfReturns
-   :members:
-
 .. autoclass:: zipline.pipeline.filters.Filter
    :members: __and__, __or__
    :exclude-members: dtype
@@ -242,6 +194,57 @@ Pipeline API
 .. autoclass:: zipline.pipeline.data.USEquityPricing
    :members: open, high, low, close, volume
    :undoc-members:
+
+Built-in Factors
+````````````````
+
+.. autoclass:: zipline.pipeline.factors.AverageDollarVolume
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.BollingerBands
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.BusinessDaysSincePreviousEvent
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.BusinessDaysUntilNextEvent
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.ExponentialWeightedMovingAverage
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.ExponentialWeightedMovingStdDev
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.Latest
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.MaxDrawdown
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.Returns
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.RollingLinearRegressionOfReturns
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.RollingPearsonOfReturns
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.RollingSpearmanOfReturns
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.RSI
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.SimpleMovingAverage
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.VWAP
+   :members:
+
+.. autoclass:: zipline.pipeline.factors.WeightedAverageValue
+   :members:
 
 
 Asset Metadata

--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -307,13 +307,13 @@ have.
 help some bundles generate queries for the days needed.
 
 ``start_session``
-````````````
+`````````````````
 
 ``start_session`` is a :class:`pandas.Timestamp` object indicating the first
 day that the bundle should load data for.
 
 ``end_session``
-````````````
+```````````````
 
 ``end_session`` is a :class:`pandas.Timestamp` object indicating the last day
 that the bundle should load data for.

--- a/docs/source/whatsnew/1.0.2.txt
+++ b/docs/source/whatsnew/1.0.2.txt
@@ -81,7 +81,7 @@ Enhancements
 - Disallow regressions of length 1. (:issue:`1466`)
 
 Experimental
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 - Add support for comingled Future and Equity history windows, and enable other
   Future data access via data portal. (:issue:`1435`) (:issue:`1432`)
@@ -111,7 +111,7 @@ Bug Fixes
 
 - Alpha and sharpe ratio are now annualized. (:issue:`1322`)
 
-- Fix units during reading and writing of daily bar ``first_trading_day ``
+- Fix units during reading and writing of daily bar ``first_trading_day``
   attribute. (:issue:`1245`)
 
 - Optional dispatch modules, when missing, no longer cause a `NameError`.
@@ -131,7 +131,7 @@ Bug Fixes
 
 - Fix ``AverageDollarVolume`` NaN handling. (:issue:`1309`)
 
-  Performance
+Performance
 ~~~~~~~~~~~
 
 - Performance improvements to blaze core loader. (:issue:`1227`)
@@ -157,7 +157,7 @@ Testing
   fixtures. (:issue:`1243`)
 
 Data Format Changes
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 - ``BcolzDailyBarReader`` and ``BcolzDailyBarWriter`` use trading calendar instance,
   instead of trading days serialized to ``JSON``. (:issue:`1330`)

--- a/tests/pipeline/test_filter.py
+++ b/tests/pipeline/test_filter.py
@@ -49,8 +49,8 @@ def rowwise_rank(array, mask=None):
     Take a 2D array and return the 0-indexed sorted position of each element in
     the array for each row.
 
-    Example
-    -------
+    Examples
+    --------
     In [5]: data
     Out[5]:
     array([[-0.141, -1.103, -1.0171,  0.7812,  0.07  ],

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -147,8 +147,8 @@ def to_dict(l):
     """
     Convert a list to a dict with keys drawn from '0', '1', '2', ...
 
-    Example
-    -------
+    Examples
+    --------
     >>> to_dict([2, 3, 4])  # doctest: +SKIP
     {'0': 2, '1': 3, '2': 4}
     """

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -1374,7 +1374,9 @@ class DataPortal(object):
         Retrieves the future chain for the contract at the given `dt` according
         the `continuous_future` specification.
 
-        Returns:
+        Returns
+        -------
+
         future_chain : list[Future]
             A list of active futures, where the first index is the current
             contract specified by the continuous future definition, the second

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -90,13 +90,13 @@ def _sid_subdir_path(sid):
     The number in each directory is designed to support at least 100000
     equities.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     sid : int
         Asset identifier.
 
-    Returns:
-    --------
+    Returns
+    -------
     out : string
         A path for the bcolz rootdir, including subdirectory prefixes based on
         the padded string representation of the given sid.
@@ -517,13 +517,13 @@ class BcolzMinuteBarWriter(object):
 
     def sidpath(self, sid):
         """
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             Asset identifier.
 
-        Returns:
-        --------
+        Returns
+        -------
         out : string
             Full path to the bcolz rootdir for the given sid.
         """
@@ -532,13 +532,13 @@ class BcolzMinuteBarWriter(object):
 
     def last_date_in_output_for_sid(self, sid):
         """
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             Asset identifier.
 
-        Returns:
-        --------
+        Returns
+        -------
         out : pd.Timestamp
             The midnight of the last date written in to the output for the
             given sid.
@@ -561,8 +561,8 @@ class BcolzMinuteBarWriter(object):
         """
         Create empty ctable for given path.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         path : string
             The path to rootdir of the new ctable.
         """
@@ -624,8 +624,8 @@ class BcolzMinuteBarWriter(object):
         including the specified date) will be padded with `minute_per_day`
         worth of zeros
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             The asset identifier for the data being written.
         date : datetime-like
@@ -703,8 +703,8 @@ class BcolzMinuteBarWriter(object):
         If the length of the bcolz ctable is not exactly to the date before
         the first day provided, fill the ctable with 0s up to that date.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             The asset identifer for the data being written.
         df : pd.DataFrame
@@ -736,8 +736,8 @@ class BcolzMinuteBarWriter(object):
         If the length of the bcolz ctable is not exactly to the date before
         the first day provided, fill the ctable with 0s up to that date.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             The asset identifier for the data being written.
         dts : datetime64 array
@@ -763,8 +763,8 @@ class BcolzMinuteBarWriter(object):
         """
         Internal method for `write_cols` and `write`.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             The asset identifier for the data being written.
         dts : datetime64 array
@@ -887,8 +887,8 @@ class BcolzMinuteBarReader(MinuteBarReader):
     """
     Reader for data written by BcolzMinuteBarWriter
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     rootdir : string
         The root directory containing the metadata and asset bcolz
         directories.
@@ -980,8 +980,8 @@ class BcolzMinuteBarReader(MinuteBarReader):
         based on the regular period of minutes per day and the market close
         do not match.
 
-        Returns:
-        --------
+        Returns
+        -------
         List of DatetimeIndex representing the minutes to exclude because
         of early closes.
         """
@@ -1080,8 +1080,8 @@ class BcolzMinuteBarReader(MinuteBarReader):
         """
         Retrieve the pricing info for the given sid, dt, and field.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         sid : int
             Asset identifier.
         dt : datetime-like
@@ -1090,8 +1090,8 @@ class BcolzMinuteBarReader(MinuteBarReader):
             The type of pricing data to retrieve.
             ('open', 'high', 'low', 'close', 'volume')
 
-        Returns:
-        --------
+        Returns
+        -------
         out : float|int
 
         The market data for the given sid, dt, and field coordinates.

--- a/zipline/lib/normalize.py
+++ b/zipline/lib/normalize.py
@@ -24,8 +24,8 @@ def naive_grouped_rowwise_apply(data,
         Array into which to write output.  If not supplied, a new array of the
         same shape as ``data`` is allocated and returned.
 
-    Example
-    -------
+    Examples
+    --------
     >>> data = np.array([[1., 2., 3.],
     ...                  [2., 3., 4.],
     ...                  [5., 6., 7.]])

--- a/zipline/pipeline/api_utils.py
+++ b/zipline/pipeline/api_utils.py
@@ -22,8 +22,8 @@ def restrict_to_dtype(dtype, message_template):
         `message_template.format` will be called with keyword arguments
         `method_name`, `expected_dtype`, and `received_dtype`.
 
-    Usage
-    -----
+    Examples
+    --------
     @restrict_to_dtype(
         dtype=float64_dtype,
         message_template=(

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -37,7 +37,8 @@ class PipelineEngine(with_metaclass(ABCMeta)):
     @abstractmethod
     def run_pipeline(self, pipeline, start_date, end_date):
         """
-        Compute values for `pipeline` between `start_date` and `end_date`.
+        Compute values for ``pipeline`` between ``start_date`` and
+        ``end_date``.
 
         Returns a DataFrame with a MultiIndex of (date, asset) pairs.
 
@@ -55,14 +56,14 @@ class PipelineEngine(with_metaclass(ABCMeta)):
         result : pd.DataFrame
             A frame of computed results.
 
-            The columns `result` correspond to the entries of
+            The ``result`` columns correspond to the entries of
             `pipeline.columns`, which should be a dictionary mapping strings to
-            instances of `zipline.pipeline.term.Term`.
+            instances of :class:`zipline.pipeline.term.Term`.
 
-            For each date between `start_date` and `end_date`, `result` will
-            contain a row for each asset that passed `pipeline.screen`.  A
-            screen of None indicates that a row should be returned for each
-            asset that existed each day.
+            For each date between ``start_date`` and ``end_date``, ``result``
+            will contain a row for each asset that passed `pipeline.screen`.
+            A screen of ``None`` indicates that a row should be returned for
+            each asset that existed each day.
         """
         raise NotImplementedError("run_pipeline")
 
@@ -90,18 +91,18 @@ class PipelineEngine(with_metaclass(ABCMeta)):
         result : pd.DataFrame
             A frame of computed results.
 
-            The columns `result` correspond to the entries of
+            The ``result`` columns correspond to the entries of
             `pipeline.columns`, which should be a dictionary mapping strings to
-            instances of `zipline.pipeline.term.Term`.
+            instances of :class:`zipline.pipeline.term.Term`.
 
-            For each date between `start_date` and `end_date`, `result` will
-            contain a row for each asset that passed `pipeline.screen`.  A
-            screen of None indicates that a row should be returned for each
-            asset that existed each day.
+            For each date between ``start_date`` and ``end_date``, ``result``
+            will contain a row for each asset that passed `pipeline.screen`.
+            A screen of ``None`` indicates that a row should be returned for
+            each asset that existed each day.
 
         See Also
         --------
-        :meth:`PipelineEngine.run_pipeline`
+        :meth:`zipline.pipeline.engine.PipelineEngine.run_pipeline`
         """
         raise NotImplementedError("run_chunked_pipeline")
 
@@ -217,15 +218,6 @@ class SimplePipelineEngine(PipelineEngine):
         """
         Compute a pipeline.
 
-        Parameters
-        ----------
-        pipeline : zipline.pipeline.Pipeline
-            The pipeline to run.
-        start_date : pd.Timestamp
-            Start date of the computed matrix.
-        end_date : pd.Timestamp
-            End date of the computed matrix.
-
         The algorithm implemented here can be broken down into the following
         stages:
 
@@ -256,10 +248,33 @@ class SimplePipelineEngine(PipelineEngine):
         Step 2 is performed in ``SimplePipelineEngine.compute_chunk``.
         Steps 3, 4, and 5 are performed in ``SimplePiplineEngine._to_narrow``.
 
+        Parameters
+        ----------
+        pipeline : zipline.pipeline.Pipeline
+            The pipeline to run.
+        start_date : pd.Timestamp
+            Start date of the computed matrix.
+        end_date : pd.Timestamp
+            End date of the computed matrix.
+
+        Returns
+        -------
+        result : pd.DataFrame
+            A frame of computed results.
+
+            The ``result`` columns correspond to the entries of
+            `pipeline.columns`, which should be a dictionary mapping strings to
+            instances of :class:`zipline.pipeline.term.Term`.
+
+            For each date between ``start_date`` and ``end_date``, ``result``
+            will contain a row for each asset that passed `pipeline.screen`.
+            A screen of ``None`` indicates that a row should be returned for
+            each asset that existed each day.
+
         See Also
         --------
-        :meth:`PipelineEngine.run_pipeline`
-        :meth:`PipelineEngine.run_chunked_pipeline`
+        :meth:`zipline.pipeline.engine.PipelineEngine.run_pipeline`
+        :meth:`zipline.pipeline.engine.PipelineEngine.run_chunked_pipeline`
         """
         if end_date < start_date:
             raise ValueError(

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -410,8 +410,8 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
         groupby : zipline.pipeline.Classifier, optional
             A classifier defining partitions over which to compute means.
 
-        Example
-        -------
+        Examples
+        --------
         Let ``f`` be a Factor which would produce the following output::
 
                          AAPL   MSFT    MCD     BK
@@ -562,8 +562,8 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
 
         ``zscore()`` is only supported on Factors of dtype float64.
 
-        Example
-        -------
+        Examples
+        --------
         See :meth:`~zipline.pipeline.factors.Factor.demean` for an in-depth
         example of the semantics for ``mask`` and ``groupby``.
 
@@ -674,8 +674,8 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
             A new Factor that will compute correlations between `target` and
             the columns of `self`.
 
-        Example
-        -------
+        Examples
+        --------
         Suppose we want to create a factor that computes the correlation
         between AAPL's 10-day returns and the 10-day returns of all other
         assets, computing each correlation over 30 days. This can be achieved
@@ -739,8 +739,8 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
             A new Factor that will compute correlations between `target` and
             the columns of `self`.
 
-        Example
-        -------
+        Examples
+        --------
         Suppose we want to create a factor that computes the correlation
         between AAPL's 10-day returns and the 10-day returns of all other
         assets, computing each correlation over 30 days. This can be achieved
@@ -803,8 +803,8 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
             A new Factor that will compute linear regressions of `target`
             against the columns of `self`.
 
-        Example
-        -------
+        Examples
+        --------
         Suppose we want to create a factor that regresses AAPL's 10-day returns
         against the 10-day returns of all other assets, computing each
         regression over 30 days. This can be achieved by doing the following::

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -881,34 +881,37 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
         winsorized : zipline.pipeline.Factor
             A Factor producing a winsorized version of self.
 
-        Example
-        -------
+        Examples
+        --------
+        .. code-block:: python
 
-        price = USEquityPricing.close.latest
-        columns={
-            'PRICE': price,
-            'WINSOR_1: price.winsorize(
-                min_percentile=0.25, max_percentile=0.75
-            ),
-            'WINSOR_2': price.winsorize(
-                min_percentile=0.50, max_percentile=1.0
-            ),
-            'WINSOR_3': price.winsorize(
-                min_percentile=0.0, max_percentile=0.5
-            ),
+            price = USEquityPricing.close.latest
+            columns={
+                'PRICE': price,
+                'WINSOR_1: price.winsorize(
+                    min_percentile=0.25, max_percentile=0.75
+                ),
+                'WINSOR_2': price.winsorize(
+                    min_percentile=0.50, max_percentile=1.0
+                ),
+                'WINSOR_3': price.winsorize(
+                    min_percentile=0.0, max_percentile=0.5
+                ),
 
-        }
+            }
 
         Given a pipeline with columns, defined above, the result for a
         given day could look like:
 
-                'PRICE' 'WINSOR_1' 'WINSOR_2' 'WINSOR_3'
-        Asset_1    1        2          4          3
-        Asset_2    2        2          4          3
-        Asset_3    3        3          4          3
-        Asset_4    4        4          4          4
-        Asset_5    5        5          5          4
-        Asset_6    6        5          5          4
+        ::
+
+                    'PRICE' 'WINSOR_1' 'WINSOR_2' 'WINSOR_3'
+            Asset_1    1        2          4          3
+            Asset_2    2        2          4          3
+            Asset_3    3        3          4          3
+            Asset_4    4        4          4          4
+            Asset_5    5        5          5          4
+            Asset_6    6        5          5          4
 
         See Also
         --------

--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -237,14 +237,14 @@ class RollingPearsonOfReturns(RollingPearson):
         A Filter describing which assets should have their correlation with the
         target asset computed each day.
 
-    Note
-    ----
+    Notes
+    -----
     Computing this factor over many assets can be time consuming. It is
     recommended that a mask be used in order to limit the number of assets over
     which correlations are computed.
 
-    Example
-    -------
+    Examples
+    --------
     Let the following be example 10-day returns for three different assets::
 
                        SPY    MSFT     FB
@@ -327,8 +327,8 @@ class RollingSpearmanOfReturns(RollingSpearman):
         A Filter describing which assets should have their correlation with the
         target asset computed each day.
 
-    Note
-    ----
+    Notes
+    -----
     Computing this factor over many assets can be time consuming. It is
     recommended that a mask be used in order to limit the number of assets over
     which correlations are computed.
@@ -397,8 +397,8 @@ class RollingLinearRegressionOfReturns(RollingLinearRegression):
     For more help on factors with multiple outputs, see
     :class:`zipline.pipeline.factors.CustomFactor`.
 
-    Example
-    -------
+    Examples
+    --------
     Let the following be example 10-day returns for three different assets::
 
                        SPY    MSFT     FB

--- a/zipline/pipeline/factors/technical.py
+++ b/zipline/pipeline/factors/technical.py
@@ -226,8 +226,8 @@ class _ExponentialWeightedFactor(SingleInputMixin, CustomFactor):
         Forwards `decay_rate` as `1 - (2.0 / (1 + span))`.  This provides the
         behavior equivalent to passing `span` to pandas.ewma.
 
-        Example
-        -------
+        Examples
+        --------
         .. code-block:: python
 
             # Equivalent to:
@@ -242,8 +242,8 @@ class _ExponentialWeightedFactor(SingleInputMixin, CustomFactor):
                 span=15,
             )
 
-        Note
-        ----
+        Notes
+        -----
         This classmethod is provided by both
         :class:`ExponentialWeightedMovingAverage` and
         :class:`ExponentialWeightedMovingStdDev`.
@@ -273,8 +273,8 @@ class _ExponentialWeightedFactor(SingleInputMixin, CustomFactor):
         Forwards ``decay_rate`` as ``exp(log(.5) / halflife)``.  This provides
         the behavior equivalent to passing `halflife` to pandas.ewma.
 
-        Example
-        -------
+        Examples
+        --------
         .. code-block:: python
 
             # Equivalent to:
@@ -289,8 +289,8 @@ class _ExponentialWeightedFactor(SingleInputMixin, CustomFactor):
                 halflife=15,
             )
 
-        Note
-        ----
+        Notes
+        -----
         This classmethod is provided by both
         :class:`ExponentialWeightedMovingAverage` and
         :class:`ExponentialWeightedMovingStdDev`.
@@ -322,8 +322,8 @@ class _ExponentialWeightedFactor(SingleInputMixin, CustomFactor):
         Forwards `decay_rate` as `1 - (1 / 1 + center_of_mass)`.  This provides
         behavior equivalent to passing `center_of_mass` to pandas.ewma.
 
-        Example
-        -------
+        Examples
+        --------
         .. code-block:: python
 
             # Equivalent to:
@@ -338,8 +338,8 @@ class _ExponentialWeightedFactor(SingleInputMixin, CustomFactor):
                 center_of_mass=15,
             )
 
-        Note
-        ----
+        Notes
+        -----
         This classmethod is provided by both
         :class:`ExponentialWeightedMovingAverage` and
         :class:`ExponentialWeightedMovingStdDev`.

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -370,8 +370,8 @@ class ExecutionPlan(TermGraph):
         which describes how many additional rows of `term`'s inputs we need to
         load, and which is determined entirely by `Term` itself.
 
-        Example
-        -------
+        Examples
+        --------
         Our graph contains the following terms:
 
             A = SimpleMovingAverage([USEquityPricing.high], window_length=5)

--- a/zipline/pipeline/visualize.py
+++ b/zipline/pipeline/visualize.py
@@ -219,8 +219,8 @@ def format_attrs(attrs):
     """
     Format key, value pairs from attrs into graphviz attrs format
 
-    Example
-    -------
+    Examples
+    --------
     >>> format_attrs({'key1': 'value1', 'key2': 'value2'})  # doctest: +SKIP
     '[key1=value1, key2=value2]'
     """

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -285,8 +285,8 @@ def chrange(start, stop):
     chars: iterable[str]
         Iterable of strings beginning with start and ending with stop.
 
-    Example
-    -------
+    Examples
+    --------
     >>> chrange('A', 'C')
     ['A', 'B', 'C']
     """
@@ -1106,8 +1106,8 @@ def parameter_space(__fail_fast=False, **params):
     The decorated test function will be called with the cross-product of all
     possible inputs
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from unittest import TestCase
     >>> class SomeTestCase(TestCase):
     ...     @parameter_space(x=[1, 2], y=[2, 3])

--- a/zipline/utils/api_support.py
+++ b/zipline/utils/api_support.py
@@ -68,8 +68,8 @@ def require_not_initialized(exception):
     TradingAlgorithm.initialize.  `exception` will be raised if the method is
     called after initialize.
 
-    Usage
-    -----
+    Examples
+    --------
     @require_not_initialized(SomeException("Don't do that!"))
     def method(self):
         # Do stuff that should only be allowed during initialize.
@@ -90,8 +90,8 @@ def require_initialized(exception):
     TradingAlgorithm.initialize.  `exception` will be raised if the method is
     called before initialize has completed.
 
-    Usage
-    -----
+    Examples
+    --------
     @require_initialized(SomeException("Don't do that!"))
     def method(self):
         # Do stuff that should only be allowed after initialize.
@@ -112,8 +112,8 @@ def disallowed_in_before_trading_start(exception):
     TradingAlgorithm.before_trading_start.  `exception` will be raised if the
     method is called inside `before_trading_start`.
 
-    Usage
-    -----
+    Examples
+    --------
     @disallowed_in_before_trading_start(SomeException("Don't do that!"))
     def method(self):
         # Do stuff that is not allowed inside before_trading_start.

--- a/zipline/utils/cache.py
+++ b/zipline/utils/cache.py
@@ -32,8 +32,8 @@ class CachedObject(object):
         Expiration date of `value`. The cache is considered invalid for dates
         **strictly greater** than `expires`.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from pandas import Timestamp, Timedelta
     >>> expires = Timestamp('2014', tz='UTC')
     >>> obj = CachedObject(1, expires)
@@ -86,8 +86,8 @@ class ExpiringCache(object):
         `__del__`, `__getitem__`, `__setitem__`
         If `None`, than a dict is used as a default.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from pandas import Timestamp, Timedelta
     >>> expires = Timestamp('2014', tz='UTC')
     >>> value = 1

--- a/zipline/utils/calendars/trading_calendar.py
+++ b/zipline/utils/calendars/trading_calendar.py
@@ -859,8 +859,8 @@ def days_at_time(days, t, tz, day_offset=0):
     day_offset : int
         The number of days we want to offset @days by
 
-    Example
-    -------
+    Examples
+    --------
     In the example below, the times switch from 13:45 to 12:45 UTC because
     March 13th is the daylight savings transition for US/Eastern.  All the
     times are still 8:45 when interpreted in US/Eastern.

--- a/zipline/utils/deprecate.py
+++ b/zipline/utils/deprecate.py
@@ -28,8 +28,8 @@ def deprecated(msg=None, stacklevel=2):
     stacklevel : int
         How far up the stack the warning needs to go, before
         showing the relevant calling lines.
-    Usage
-    -----
+    Examples
+    --------
     @deprecated(msg='function_a is deprecated! Use function_b instead.')
     def function_a(*args, **kwargs):
     """

--- a/zipline/utils/functional.py
+++ b/zipline/utils/functional.py
@@ -74,8 +74,8 @@ def mapall(funcs, seq):
     elem : object
         Concatenated result of mapping each ``func`` over ``seq``.
 
-    Example
-    -------
+    Examples
+    --------
     >>> list(mapall([lambda x: x + 1, lambda x: x - 1], [1, 2, 3]))
     [2, 3, 4, 0, 1, 2]
     """
@@ -90,8 +90,8 @@ def same(*values):
 
     Returns True on empty sequences.
 
-    Example
-    -------
+    Examples
+    --------
     >>> same(1, 1, 1, 1)
     True
     >>> same(1, 2, 1)
@@ -128,8 +128,8 @@ def dzip_exact(*dicts):
     ValueError
         If dicts don't all have the same keys.
 
-    Example
-    -------
+    Examples
+    --------
     >>> result = dzip_exact({'a': 1, 'b': 2}, {'a': 3, 'b': 4})
     >>> result == {'a': (1, 3), 'b': (2, 4)}
     True
@@ -273,8 +273,8 @@ def getattrs(value, attrs, default=_no_default):
     result : object
         Result of the lookup sequence.
 
-    Example
-    -------
+    Examples
+    --------
     >>> class EmptyObject(object):
     ...     pass
     ...
@@ -309,8 +309,8 @@ def set_attribute(name, value):
 
     Doesn't change the behavior of the wrapped function.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @set_attribute('__name__', 'foo')
     ... def bar():
     ...     return 3

--- a/zipline/utils/input_validation.py
+++ b/zipline/utils/input_validation.py
@@ -91,8 +91,8 @@ def optionally(preprocessor):
     optional_preprocessor : callable[callable, str, any -> any]
         A preprocessor that delegates to `preprocessor` when `arg is not None`.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> def preprocessor(func, argname, arg):
     ...     if not isinstance(arg, int):
     ...         raise TypeError('arg must be int')
@@ -136,8 +136,8 @@ def ensure_dtype(func, argname, arg):
     """
     Argument preprocessor that converts the input into a numpy dtype.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> import numpy as np
     >>> from zipline.utils.preprocess import preprocess
     >>> @preprocess(dtype=ensure_dtype)
@@ -163,8 +163,8 @@ def ensure_dtype(func, argname, arg):
 def ensure_timezone(func, argname, arg):
     """Argument preprocessor that converts the input into a tzinfo object.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from zipline.utils.preprocess import preprocess
     >>> @preprocess(tz=ensure_timezone)
     ... def foo(tz):
@@ -191,8 +191,8 @@ def ensure_timestamp(func, argname, arg):
     """Argument preprocessor that converts the input into a pandas Timestamp
     object.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from zipline.utils.preprocess import preprocess
     >>> @preprocess(ts=ensure_timestamp)
     ... def foo(ts):
@@ -220,8 +220,8 @@ def expect_dtypes(__funcname=_qualified_name, **named):
     """
     Preprocessing decorator that verifies inputs have expected numpy dtypes.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from numpy import dtype, arange, int8, float64
     >>> @expect_dtypes(x=dtype(int8))
     ... def foo(x, y):
@@ -288,8 +288,8 @@ def expect_kinds(**named):
     """
     Preprocessing decorator that verifies inputs have expected dtype kinds.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from numpy import int64, int32, float32
     >>> @expect_kinds(x='i')
     ... def foo(x):
@@ -351,8 +351,8 @@ def expect_types(__funcname=_qualified_name, **named):
     """
     Preprocessing decorator that verifies inputs have expected types.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @expect_types(x=int, y=str)
     ... def foo(x, y):
     ...    return x, y
@@ -478,8 +478,8 @@ def expect_element(__funcname=_qualified_name, **named):
     Preprocessing decorator that verifies inputs are elements of some
     expected collection.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @expect_element(x=('a', 'b'))
     ... def foo(x):
     ...    return x.upper()
@@ -537,8 +537,8 @@ def expect_bounded(__funcname=_qualified_name, **named):
     ``None`` may be passed as ``min_value`` or ``max_value`` to signify that
     the input is only bounded above or below.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @expect_bounded(x=(1, 5))
     ... def foo(x):
     ...    return x + 1
@@ -616,8 +616,8 @@ def expect_strictly_bounded(__funcname=_qualified_name, **named):
     ``None`` may be passed as ``min_value`` or ``max_value`` to signify that
     the input is only bounded above or below.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @expect_strictly_bounded(x=(1, 5))
     ... def foo(x):
     ...    return x + 1
@@ -711,8 +711,8 @@ def expect_dimensions(__funcname=_qualified_name, **dimensions):
     Preprocessing decorator that verifies inputs are numpy arrays with a
     specific dimensionality.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> from numpy import array
     >>> @expect_dimensions(x=1, y=2)
     ... def foo(x, y):
@@ -770,8 +770,8 @@ def coerce(from_, to, **to_kwargs):
     **to_kwargs
         Additional keywords to forward to every call to ``to``.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @preprocess(x=coerce(float, int), y=coerce(float, int))
     ... def floordiff(x, y):
     ...     return x - y
@@ -803,8 +803,8 @@ def coerce_types(**kwargs):
          Keyword arguments mapping function parameter names to pairs of
          (from_type, to_type).
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @coerce_types(x=(float, int), y=(int, str))
     ... def func(x, y):
     ...     return (x, y)

--- a/zipline/utils/preprocess.py
+++ b/zipline/utils/preprocess.py
@@ -48,8 +48,8 @@ def preprocess(*_unused, **processors):
         `argname` is the name of the argument we're processing.
         `argvalue` is the value of the argument we're processing.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> def _ensure_tuple(func, argname, arg):
     ...     if isinstance(arg, tuple):
     ...         return argvalue
@@ -124,8 +124,8 @@ def call(f):
     f : function
         Function accepting a single argument and returning a replacement.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @preprocess(x=call(lambda x: x + 1))
     ... def foo(x):
     ...     return x

--- a/zipline/utils/sharedoc.py
+++ b/zipline/utils/sharedoc.py
@@ -86,8 +86,8 @@ def templated_docstring(**docs):
     """
     Decorator allowing the use of templated docstrings.
 
-    Usage
-    -----
+    Examples
+    --------
     >>> @templated_docstring(foo='bar')
     ... def my_func(self, foo):
     ...     '''{foo}'''


### PR DESCRIPTION
This pr fixes several typos in docstrings that specify non-existent sphinx sections. For example `Usage` and `Example` have been converted to `Examples`. `Note` has been converted to `Notes`. `Returns:` has been converted to `Returns`. Several minor fixes, for example if there are not enough formatting `~` under a title.

Create a `Pipeline` subsection for built-in factors. The factors have been organized alphabetically.

Include Factor methods such as `winsorize` in documentation. Currently only some are listed and they are all useful to users.

Include documentation and subsection for `PipelineEngine`.

Two non-existent classes have been removed `zipline.assets.AssetFinderCachedEquities` and `zipline.pipeline.data.EarningsCalendar`.