### PR TITLE
TST: Update modified time of market data in test_examples

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,7 +25,7 @@ from zipline.testing import test_resource_path
 from zipline.testing.fixtures import WithTmpDir, ZiplineTestCase
 from zipline.testing.predicates import assert_equal
 from zipline.utils.cache import dataframe_cache
-from zipline.utils.paths import ensure_file
+from zipline.utils.paths import update_modified_time
 
 
 # Otherwise the next line sometimes complains about being run too late.
@@ -57,7 +57,11 @@ class ExamplesTests(WithTmpDir, ZiplineTestCase):
 
         market_data = ('SPY_benchmark.csv', 'treasury_curves.csv')
         for data in market_data:
-            ensure_file(cls.tmpdir.getpath('example_data/root/data/' + data))
+            update_modified_time(
+                cls.tmpdir.getpath(
+                    'example_data/root/data/' + data
+                )
+            )
 
     @parameterized.expand(sorted(examples.EXAMPLE_MODULES))
     def test_example(self, example_name):

--- a/zipline/utils/paths.py
+++ b/zipline/utils/paths.py
@@ -48,7 +48,7 @@ def ensure_directory_containing(path):
 def ensure_file(path):
     """
     Ensure that a file exists. This will create any parent directories needed
-    and create an empty file if it does not exists.
+    and create an empty file if it does not exist.
 
     Parameters
     ----------
@@ -57,6 +57,22 @@ def ensure_file(path):
     """
     ensure_directory_containing(path)
     open(path, 'a+').close()  # touch the file
+
+
+def update_modified_time(path, times=None):
+    """
+    Updates the modified time of an existing file. This will create any
+    parent directories needed and create an empty file if it does not exist.
+
+    Parameters
+    ----------
+    path : str
+        The file path to update.
+    times : tuple
+        A tuple of size two; access time and modified time
+    """
+    ensure_directory_containing(path)
+    os.utime(path, times)
 
 
 def last_modified_time(path):


### PR DESCRIPTION
The `ensure_file` call doesn't actually update the current modified time of the file that we touch, so had to add a util function that calls `os.utime()`; this will fix broken tests as well. 