### PR TITLE
MAINT: Update asset warning

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -4749,9 +4749,11 @@ class TestOrderAfterDelist(WithTradingEnvironment, ZiplineTestCase):
 
             for w in warnings:
                 expected_message = (
-                    'Cannot place order for ASSET{sid}, as it has de-listed. '
+                    'Cannot place order for {asset}, either because your data '
+                    'bundle is not up to date, or the asset has de-listed. '
                     'Any existing positions for this asset will be liquidated '
-                    'on {date}.'.format(sid=sid, date=asset.auto_close_date)
+                    'on {date}.'.format(asset=asset.symbol,
+                                        date=asset.auto_close_date)
                 )
                 self.assertEqual(expected_message, w.message)
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1379,10 +1379,15 @@ class TradingAlgorithm(object):
                 # If we are after the asset's end date or auto close date, warn
                 # the user that they can't place an order for this asset, and
                 # return None.
-                log.warn("Cannot place order for {0}, as it has de-listed. "
-                         "Any existing positions for this asset will be "
-                         "liquidated on "
-                         "{1}.".format(asset.symbol, asset.auto_close_date))
+                log.warn(
+                    ("Cannot place order for {asset}, either because "
+                     "your data bundle is not up to date, "
+                     "or the asset has de-listed. "
+                     "Any existing positions for this asset will be "
+                     "liquidated on {date}."),
+                    asset=asset.symbol,
+                    date=asset.auto_close_date
+                )
 
                 return False
 


### PR DESCRIPTION
Saw this warning when running a zipline backtest earlier:

x-ref #1850 

```
[2017-06-14 18:01:12.479077] WARNING: ZiplineLog: Cannot place order for AAPL, as it has de-listed. Any existing positions for this asset will be liquidated on 2017-06-03 00:00:00+00:00.
```

And thought something broke or something happened to our `quantopian-quandl` bundle. Turns out I just needed to run `zipline ingest` again to have data that's more up to date. Changed the log warning message to reflect that.