### PR TITLE
Change auto close to happen at session end

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -484,13 +484,13 @@ def log_nyse_close(context, data):
         for minute in algo.nyse_opens:
             # each minute should be a nyse session open
             session_label = nyse.minute_to_session_label(minute)
-            session_open = nyse.open_and_close_for_session(session_label)[0]
+            session_open = nyse.session_open(session_label)
             self.assertEqual(session_open, minute)
 
         for minute in algo.nyse_closes:
             # each minute should be a minute before a nyse session close
             session_label = nyse.minute_to_session_label(minute)
-            session_close = nyse.open_and_close_for_session(session_label)[1]
+            session_close = nyse.session_close(session_label)
             self.assertEqual(session_close - timedelta(minutes=1), minute)
 
         # Test that passing an invalid calendar parameter raises an error.
@@ -4212,9 +4212,7 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
         else:
             final_prices = {
                 asset.sid: trade_data_by_sid[asset.sid].loc[
-                    self.trading_calendar.open_and_close_for_session(
-                        asset.end_date
-                    )[1]
+                    self.trading_calendar.session_close(asset.end_date)
                 ].close
                 for asset in assets
             }
@@ -4359,13 +4357,16 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
             )
 
         # Check expected cash.
-        self.assertEqual(algo.cash, expected_cash)
         self.assertEqual(expected_cash, list(output['ending_cash']))
+
+        # The cash recorded by the algo should be behind by a day from the
+        # computed ending cash.
+        expected_cash.insert(3, after_fills)
+        self.assertEqual(algo.cash, expected_cash[:-1])
 
         # Check expected long/short counts.
         # We have longs if order_size > 0.
-        # We have shrots if order_size > 0.
-        self.assertEqual(algo.num_positions, expected_num_positions)
+        # We have shorts if order_size < 0.
         if order_size > 0:
             self.assertEqual(
                 expected_num_positions,
@@ -4385,6 +4386,11 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
                 list(output['longs_count']),
             )
 
+        # The number of positions recorded by the algo should be behind by a
+        # day from the computed long/short counts.
+        expected_num_positions.insert(3, 3)
+        self.assertEqual(algo.num_positions, expected_num_positions[:-1])
+
         # Check expected transactions.
         # We should have a transaction of order_size shares per sid.
         transactions = output['transactions']
@@ -4392,9 +4398,7 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
         self.assertEqual(len(initial_fills), len(assets))
 
         last_minute_of_session = \
-            self.trading_calendar.open_and_close_for_session(
-                self.test_days[1]
-            )[1]
+            self.trading_calendar.session_close(self.test_days[1])
 
         for asset, txn in zip(assets, initial_fills):
             self.assertDictContainsSubset(
@@ -4423,7 +4427,9 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
             {
                 'amount': -order_size,
                 'commission': 0.0,
-                'dt': assets[0].auto_close_date,
+                'dt': self.trading_calendar.session_close(
+                    assets[0].auto_close_date,
+                ),
                 'price': fp0,
                 'sid': assets[0],
                 'order_id': None,  # Auto-close txns emit Nones for order_id.
@@ -4438,7 +4444,9 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
             {
                 'amount': -order_size,
                 'commission': 0.0,
-                'dt': assets[1].auto_close_date,
+                'dt': self.trading_calendar.session_close(
+                    assets[1].auto_close_date,
+                ),
                 'price': fp1,
                 'sid': assets[1],
                 'order_id': None,  # Auto-close txns emit Nones for order_id.
@@ -4471,6 +4479,9 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
             today_session = self.trading_calendar.minute_to_session_label(
                 context.get_datetime()
             )
+            day_after_auto_close = self.trading_calendar.next_session_label(
+                first_asset_auto_close_date,
+            )
 
             if today_session == first_asset_end_date:
                 # Equity 0 will no longer exist tomorrow, so this order will
@@ -4479,6 +4490,10 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
                 context.order(context.sid(0), 10)
                 assert len(context.get_open_orders()) == 1
             elif today_session == first_asset_auto_close_date:
+                # We do not cancel open orders until the end of the auto close
+                # date, so our open order should still exist at this point.
+                assert len(context.get_open_orders()) == 1
+            elif today_session == day_after_auto_close:
                 assert len(context.get_open_orders()) == 0
 
         algo = TradingAlgorithm(
@@ -4498,9 +4513,7 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
         assert len(original_open_orders) == 1
 
         last_close_for_asset = \
-            algo.trading_calendar.open_and_close_for_session(
-                first_asset_end_date
-            )[1]
+            algo.trading_calendar.session_close(first_asset_end_date)
 
         self.assertDictContainsSubset(
             {
@@ -4522,7 +4535,9 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
                 'amount': 10,
                 'commission': 0,
                 'created': last_close_for_asset,
-                'dt': first_asset_auto_close_date,
+                'dt': algo.trading_calendar.session_close(
+                    first_asset_auto_close_date,
+                ),
                 'sid': assets[0],
                 'status': ORDER_STATUS.CANCELLED,
                 'filled': 0,
@@ -4566,18 +4581,18 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
         expected_cash = [initial_cash]
         expected_position_counts = [0]
 
-        # We have the rest of the first sim day, plus the second and third
-        # days' worth of minutes with cash spent.
-        expected_cash.extend([after_fills] * (389 + 390 + 390))
-        expected_position_counts.extend([3] * (389 + 390 + 390))
+        # We have the rest of the first sim day, plus the second, third and
+        # fourth days' worth of minutes with cash spent.
+        expected_cash.extend([after_fills] * (389 + 390 + 390 + 390))
+        expected_position_counts.extend([3] * (389 + 390 + 390 + 390))
 
         # We then have two days with the cash refunded from asset 0.
         expected_cash.extend([after_first_auto_close] * (390 + 390))
         expected_position_counts.extend([2] * (390 + 390))
 
-        # We then have two days with cash refunded from asset 1
-        expected_cash.extend([after_second_auto_close] * (390 + 390))
-        expected_position_counts.extend([1] * (390 + 390))
+        # We then have one day with cash refunded from asset 1.
+        expected_cash.extend([after_second_auto_close] * 390)
+        expected_position_counts.extend([1] * 390)
 
         # Check list lengths first to avoid expensive comparison
         self.assertEqual(len(algo.cash), len(expected_cash))
@@ -4638,7 +4653,9 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
             {
                 'amount': -order_size,
                 'commission': 0.0,
-                'dt': assets[0].auto_close_date,
+                'dt': algo.trading_calendar.session_close(
+                    assets[0].auto_close_date,
+                ),
                 'price': fp0,
                 'sid': assets[0],
                 'order_id': None,  # Auto-close txns emit Nones for order_id.
@@ -4653,7 +4670,9 @@ class TestEquityAutoClose(WithTradingEnvironment, WithTmpDir, ZiplineTestCase):
             {
                 'amount': -order_size,
                 'commission': 0.0,
-                'dt': assets[1].auto_close_date,
+                'dt': algo.trading_calendar.session_close(
+                    assets[1].auto_close_date,
+                ),
                 'price': fp1,
                 'sid': assets[1],
                 'order_id': None,  # Auto-close txns emit Nones for order_id.

--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -831,22 +831,22 @@ class TestMinuteBarDataFuturesCalendar(WithCreateBarData,
 
     def test_can_trade_delisted(self):
         """
-        Test that can_trade returns False for an asset on or after its auto
-        close date.
+        Test that can_trade returns False for an asset after its auto close
+        date.
         """
         auto_closing_asset = self.asset_finder.retrieve_asset(7)
 
         # Our asset's auto close date is 2016-01-20, which means that as of the
-        # market open for the 2016-01-20 session, `can_trade` should return
+        # market open for the 2016-01-21 session, `can_trade` should return
         # False.
         minutes_to_check = [
-            (pd.Timestamp('2016-01-19 00:00:00', tz='UTC'), True),
-            (pd.Timestamp('2016-01-19 23:00:00', tz='UTC'), True),
-            (pd.Timestamp('2016-01-19 23:01:00', tz='UTC'), False),
-            (pd.Timestamp('2016-01-19 23:59:00', tz='UTC'), False),
-            (pd.Timestamp('2016-01-20 00:00:00', tz='UTC'), False),
-            (pd.Timestamp('2016-01-20 00:01:00', tz='UTC'), False),
+            (pd.Timestamp('2016-01-20 00:00:00', tz='UTC'), True),
+            (pd.Timestamp('2016-01-20 23:00:00', tz='UTC'), True),
+            (pd.Timestamp('2016-01-20 23:01:00', tz='UTC'), False),
+            (pd.Timestamp('2016-01-20 23:59:00', tz='UTC'), False),
             (pd.Timestamp('2016-01-21 00:00:00', tz='UTC'), False),
+            (pd.Timestamp('2016-01-21 00:01:00', tz='UTC'), False),
+            (pd.Timestamp('2016-01-22 00:00:00', tz='UTC'), False),
         ]
 
         for info in minutes_to_check:

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -501,7 +501,7 @@ cdef class BarData:
             # asset isn't alive
             return False
 
-        if asset.auto_close_date and session_label >= asset.auto_close_date:
+        if asset.auto_close_date and session_label > asset.auto_close_date:
             return False
 
         if not self._daily_mode:

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from contextlib2 import ExitStack
+from copy import copy
 from logbook import Logger, Processor
 from pandas.tslib import normalize_date
+from zipline.finance.order import ORDER_STATUS
 from zipline.protocol import BarData
 from zipline.utils.api_support import ZiplineAPI
 from six import viewkeys
@@ -99,7 +101,8 @@ class AlgorithmSimulator(object):
         Main generator work loop.
         """
         algo = self.algo
-        emission_rate = algo.perf_tracker.emission_rate
+        perf_tracker = algo.perf_tracker
+        emission_rate = perf_tracker.emission_rate
 
         def every_bar(dt_to_use, current_data=self.current_data,
                       handle_data=algo.event_manager.handle_data):
@@ -112,7 +115,6 @@ class AlgorithmSimulator(object):
             self.simulation_dt = dt_to_use
 
             blotter = algo.blotter
-            perf_tracker = algo.perf_tracker
 
             # handle any transactions and commissions coming out new orders
             # placed in the last bar
@@ -152,13 +154,6 @@ class AlgorithmSimulator(object):
         def once_a_day(midnight_dt, current_data=self.current_data,
                        data_portal=self.data_portal):
 
-            perf_tracker = algo.perf_tracker
-
-            # Get the positions before updating the date so that prices are
-            # fetched for trading close instead of midnight
-            positions = algo.perf_tracker.position_tracker.positions
-            position_assets = algo.asset_finder.retrieve_all(positions)
-
             # set all the timestamps
             self.simulation_dt = midnight_dt
             algo.on_dt_changed(midnight_dt)
@@ -168,10 +163,6 @@ class AlgorithmSimulator(object):
                     midnight_dt, emission_rate=emission_rate,
                     is_interday=True):
                 yield capital_change
-
-            # we want to wait until the clock rolls over to the next day
-            # before cleaning up expired assets.
-            self._cleanup_expired_assets(midnight_dt, position_assets)
 
             # handle any splits that impact any positions or any open orders.
             assets_we_care_about = \
@@ -186,7 +177,7 @@ class AlgorithmSimulator(object):
                     perf_tracker.position_tracker.handle_splits(splits)
 
         def handle_benchmark(date, benchmark_source=self.benchmark_source):
-            algo.perf_tracker.all_benchmark_returns[date] = \
+            perf_tracker.all_benchmark_returns[date] = \
                 benchmark_source.get_value(date)
 
         def on_exit():
@@ -226,11 +217,20 @@ class AlgorithmSimulator(object):
                         yield capital_change_packet
                 elif action == SESSION_END:
                     # End of the session.
+                    positions = perf_tracker.position_tracker.positions
+                    position_assets = algo.asset_finder.retrieve_all(positions)
+                    self._cleanup_expired_assets(dt, position_assets)
+
                     if emission_rate == 'daily':
                         handle_benchmark(normalize_date(dt))
+                    else:
+                        # If the emission rate is minutely then the performance
+                        # update already happened by this point, so if any
+                        # equities were just auto closed do another update.
+                        perf_tracker.update_performance()
                     execute_order_cancellation_policy()
 
-                    yield self._get_daily_message(dt, algo, algo.perf_tracker)
+                    yield self._get_daily_message(dt, algo, perf_tracker)
                 elif action == BEFORE_TRADING_START_BAR:
                     self.simulation_dt = dt
                     algo.on_dt_changed(dt)
@@ -238,11 +238,11 @@ class AlgorithmSimulator(object):
                 elif action == MINUTE_END:
                     handle_benchmark(dt)
                     minute_msg = \
-                        self._get_minute_message(dt, algo, algo.perf_tracker)
+                        self._get_minute_message(dt, algo, perf_tracker)
 
                     yield minute_msg
 
-        risk_message = algo.perf_tracker.handle_simulation_end()
+        risk_message = perf_tracker.handle_simulation_end()
         yield risk_message
 
     def _cleanup_expired_assets(self, dt, position_assets):
@@ -272,14 +272,23 @@ class AlgorithmSimulator(object):
         for asset in assets_to_clear:
             perf_tracker.process_close_position(asset, dt, data_portal)
 
-        # Remove open orders for any sids that have reached their
-        # auto_close_date.
+        # Remove open orders for any sids that have reached their auto close
+        # date. These orders get processed immediately because otherwise they
+        # would not be processed until the first bar of the next day.
         blotter = algo.blotter
-        assets_to_cancel = \
-            set([asset for asset in blotter.open_orders
-                 if past_auto_close_date(asset)])
+        assets_to_cancel = [
+            asset for asset in blotter.open_orders
+            if past_auto_close_date(asset)
+        ]
         for asset in assets_to_cancel:
             blotter.cancel_all_orders_for_asset(asset)
+
+        # Make a copy here so that we are not modifying the list that is being
+        # iterated over.
+        for order in copy(blotter.new_orders):
+            if order.status == ORDER_STATUS.CANCELLED:
+                perf_tracker.process_order(order)
+                blotter.new_orders.remove(order)
 
     def _get_daily_message(self, dt, algo, perf_tracker):
         """


### PR DESCRIPTION
Now that the futures calendar does not run for 24 hours, it makes more sense for futures to auto-close at the end of the day (5pm) rather than midnight UTC. This PR moves the auto-close execution to the end of day _on_ the auto-close date, rather than the night before it. This means that you _can_ trade futures on their auto-close dates now.