### PR TITLE
MAINT: Improve error when missing bcolz file for a sid is missing

### DIFF
--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -35,7 +35,7 @@ from pandas import (
     date_range,
 )
 
-from zipline.data.bar_reader import NoDataOnDate
+from zipline.data.bar_reader import NoDataForSid, NoDataOnDate
 from zipline.data.minute_bars import (
     BcolzMinuteBarMetadata,
     BcolzMinuteBarWriter,
@@ -102,6 +102,11 @@ class BcolzMinuteBarTestCase(WithTradingCalendars,
             metadata.version,
             BcolzMinuteBarMetadata.FORMAT_VERSION,
         )
+
+    def test_no_minute_bars_for_sid(self):
+        minute = self.market_opens[self.test_calendar_start]
+        with self.assertRaises(NoDataForSid):
+            self.reader.get_value(1337, minute, 'close')
 
     def test_write_one_ohlcv(self):
         minute = self.market_opens[self.test_calendar_start]

--- a/zipline/data/bar_reader.py
+++ b/zipline/data/bar_reader.py
@@ -30,6 +30,13 @@ class NoDataAfterDate(NoDataOnDate):
     pass
 
 
+class NoDataForSid(Exception):
+    """
+    Raised when the requested sid is missing from the pricing data.
+    """
+    pass
+
+
 class BarReader(with_metaclass(ABCMeta, object)):
     @abstractproperty
     def data_frequency(self):

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -38,7 +38,7 @@ from zipline.data._minute_bar_internal import (
 
 from zipline.gens.sim_engine import NANOS_IN_MINUTE
 
-from zipline.data.bar_reader import BarReader, NoDataOnDate
+from zipline.data.bar_reader import BarReader, NoDataForSid, NoDataOnDate
 from zipline.data.us_equity_pricing import check_uint32_safe
 from zipline.utils.calendars import get_calendar
 from zipline.utils.cli import maybe_show_progress
@@ -1057,9 +1057,13 @@ class BcolzMinuteBarReader(MinuteBarReader):
         try:
             carray = self._carrays[field][sid]
         except KeyError:
-            carray = self._carrays[field][sid] = \
-                bcolz.carray(rootdir=self._get_carray_path(sid, field),
-                             mode='r')
+            try:
+                carray = self._carrays[field][sid] = bcolz.carray(
+                    rootdir=self._get_carray_path(sid, field),
+                    mode='r',
+                )
+            except IOError:
+                raise NoDataForSid('No minute data for sid {}.'.format(sid))
 
         return carray
 


### PR DESCRIPTION
Replaces the IOError raised by bcolz, which isn't very informative, with
NoDataOnDate.