### PR TITLE
BUG: Fix reference to floating type.

### DIFF
--- a/zipline/pipeline/loaders/blaze/_core.pyx
+++ b/zipline/pipeline/loaders/blaze/_core.pyx
@@ -27,7 +27,7 @@ from zipline.pipeline.common import (
 )
 
 
-cdef bint isnan(floating value):
+cdef bint isnan(np.float64_t value):
     # this isn't defined in libc on windows...
     return value != value
 


### PR DESCRIPTION
Use float64_t instead, since `isnan` is only used when the array's
dtype kind is `'f'`.

Fixes this compilation error:
```
zipline/pipeline/loaders/blaze/_core.pyx:30:16: 'floating' is not a type identifier
```