### PR TITLE
BUG: fix downsampled rowwise reductions

### DIFF
--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -386,9 +386,9 @@ class SimplePipelineEngine(PipelineEngine):
             duplicated = columns[columns.duplicated()].unique()
             raise AssertionError("Duplicated sids: %d" % duplicated)
 
-        # Filter out columns that didn't exist between the requested start and
-        # end dates.
-        existed = lifetimes.iloc[extra_rows:].any()
+        # Filter out columns that didn't exist from the farthest look back
+        # window through the end of the requested dates.
+        existed = lifetimes.any()
         ret = lifetimes.loc[:, existed]
         shape = ret.shape
         assert shape[0] * shape[1] != 0, 'root mask cannot be empty'


### PR DESCRIPTION
When an asset stops existing partway through the downsample period we can get different results for rank (and demean and friends) on the same day if we start the pipeline inside the same downsample period but after the asset stopped existing.