### PR TITLE
No data before date bug in volume roll finder

### DIFF
--- a/zipline/assets/roll_finder.py
+++ b/zipline/assets/roll_finder.py
@@ -198,8 +198,10 @@ class VolumeRollFinder(RollFinder):
         if back_vol > front_vol:
             return back
 
-        gap_start = \
-            front_contract.auto_close_date - (trading_day * self.GRACE_DAYS)
+        gap_start = max(
+            back_contract.start_date,
+            front_contract.auto_close_date - (trading_day * self.GRACE_DAYS),
+        )
         gap_end = prev - trading_day
         if dt < gap_start:
             return front


### PR DESCRIPTION
In the volume roll finder, we look up to a week back from the given date (called the grace period) where we look for double volume flips. It was possible that if the back contract had not started yet in the past week, an exception was thrown.

@yankees714 Mind taking a look? This is a follow up fix to https://github.com/quantopian/zipline/pull/1892. In that first fix we checked existence of the contracts before calling `get_value`, but we also call `get_value` later on that needs the same check.