### PR TITLE
Set RollingLinearRegressionOfReturns factor to be window_safe.

### DIFF
--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -455,6 +455,8 @@ class RollingLinearRegressionOfReturns(RollingLinearRegression):
     :class:`zipline.pipeline.factors.RollingPearsonOfReturns`
     :class:`zipline.pipeline.factors.RollingSpearmanOfReturns`
     """
+    window_safe = True
+
     def __new__(cls,
                 target,
                 returns_length,


### PR DESCRIPTION
As far as I can tell, RollingLinearRegressionOfReturns is window safe, but is not marked as such, preventing it from being used in CustomFactor classes.  I have not tested building zipline with this one-line change, but I successfully subclassed RollingLinearRegressionOfReturns on Quantopian and verified that it functions without error.