### PR TITLE
Allow column names to be different from the underlying expression

### DIFF
--- a/zipline/pipeline/loaders/blaze/_core.pyx
+++ b/zipline/pipeline/loaders/blaze/_core.pyx
@@ -524,6 +524,13 @@ cdef array_for_column(object dtype,
         raise TypeError('unknown column dtype: %r' % input_array.dtype)
 
 
+cpdef str getname(object column):
+    try:
+        return column.metadata['blaze_column_name']
+    except KeyError:
+        return column.name
+
+
 cdef arrays_from_rows(DatetimeIndex_t dates,
                       object data_query_time,
                       object data_query_tz,
@@ -570,7 +577,7 @@ cdef arrays_from_rows(DatetimeIndex_t dates,
             sids,
             column_ixs,
             mask,
-            all_rows[column.name].values.astype(column.dtype),
+            all_rows[getname(column)].values.astype(column.dtype),
             column.missing_value,
             array_kind,
         )

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -194,6 +194,7 @@ from ._core import (  # noqa
     adjusted_arrays_from_rows_without_assets,
     baseline_arrays_from_rows_with_assets,  # reexport
     baseline_arrays_from_rows_without_assets,  # reexport
+    getname,
 )
 
 
@@ -693,7 +694,7 @@ def from_blaze(expr,
 
 
 getdataset = op.attrgetter('dataset')
-getname = op.attrgetter('name')
+
 
 _expr_data_base = namedtuple(
     'ExprData', 'expr deltas checkpoints odo_kwargs'


### PR DESCRIPTION
The primary use case for this is aliasing the `asof_date`, `sid`, or `timestamp` columns without copying the data at read time.