### PR TITLE
ENH: Grow minute file cache to 1550 by default.

### DIFF
--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -899,7 +899,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
     """
     FIELDS = ('open', 'high', 'low', 'close', 'volume')
 
-    def __init__(self, rootdir, sid_cache_size=1000):
+    def __init__(self, rootdir, sid_cache_size=1550):
         self._rootdir = rootdir
 
         metadata = self._get_metadata()


### PR DESCRIPTION
A cache of 1550 allows us to have a tradeable universe of 1500 assets without
destroying ourselves every rebalance.