### PR TITLE
BUG: Fix daily history for minute panel data backtest

### DIFF
--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -23,6 +23,7 @@ from six import iteritems
 
 from zipline.data.resample import (
     minute_frame_to_session_frame,
+    minute_panel_to_session_panel,
     DailyHistoryAggregator,
     MinuteResampleSessionBarReader,
     ReindexMinuteBarReader,
@@ -562,6 +563,25 @@ class TestMinuteToSession(WithEquityMinuteBarData,
             assert_almost_equal(expected.values,
                                 result.values,
                                 err_msg='sid={0}'.format(sid))
+
+    def test_minute_panel_to_session_panel(self):
+        minute_panel = pd.Panel(
+            {sid: self.equity_frames[sid]
+             for sid in self.ASSET_FINDER_EQUITY_SIDS}
+        )
+        expected = pd.Panel(
+            {sid: EXPECTED_SESSIONS[sid]
+             for sid in self.ASSET_FINDER_EQUITY_SIDS}
+        )
+        result = minute_panel_to_session_panel(
+            minute_panel,
+            self.nyse_calendar
+        )
+        for label in expected.minor_axis:
+            print label
+            print expected.loc[:, :, label]
+            print result.loc[:, :, label]
+        assert_almost_equal(expected.values, result.values)
 
 
 class TestResampleSessionBars(WithBcolzFutureMinuteBarReader,

--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -577,10 +577,6 @@ class TestMinuteToSession(WithEquityMinuteBarData,
             minute_panel,
             self.nyse_calendar
         )
-        for label in expected.minor_axis:
-            print label
-            print expected.loc[:, :, label]
-            print result.loc[:, :, label]
         assert_almost_equal(expected.values, result.values)
 
 

--- a/zipline/data/resample.py
+++ b/zipline/data/resample.py
@@ -65,6 +65,59 @@ def minute_frame_to_session_frame(minute_frame, calendar):
     return minute_frame.groupby(calendar.minute_to_session_label).agg(how)
 
 
+def minute_panel_to_session_panel(minute_panel, calendar):
+    """
+    Resample a Panel with minute data into a daily data Panel accepted by
+    PanelBarReader.
+
+    Parameters
+    ----------
+    minute_panel : pd.Panel
+        A pricing data Panel with axes:
+          * items: assets
+          * major_axis: minute pd.DatetimeIndex
+          * minor_axis: labels ['open', 'high', 'low', 'close', 'volume']
+    calendar : zipline.utils.calendars.trading_calendar.TradingCalendar
+        A TradingCalendar on which session labels to resample from minute
+        to session.
+    """
+    def get_first_valid(df):
+        """
+        Return a Series with the first non-nan value in each column.
+
+        On an all-nan column, this function gives nan.
+        """
+        # Indices of first non-nan values
+        idxs = pd.notnull(df).idxmax()
+
+        # Expand indices to one-hot boolean columns
+        indexer = pd.get_dummies(idxs).T.astype(bool)
+
+        # Preserve all indices' values, while others are masked to nan.
+        # Then `.max()` selects the non-nan value in each column.
+        return df.loc[indexer.index][indexer].max()
+
+    def sum_or_nan(df):
+        """
+        Return `df.sum()`, but nan where the whole column is nan.
+        """
+        return df.sum().mask(pd.isnull(df).all(axis=0))
+
+    def aggregator(session_panel):
+        return pd.DataFrame({
+            'open': get_first_valid(session_panel.loc[:, :, 'open']),
+            'close': get_first_valid(session_panel.loc[:, ::-1, 'close']),
+            'high': session_panel.loc[:, :, 'high'].max(),
+            'low': session_panel.loc[:, :, 'low'].min(),
+            'volume': sum_or_nan(session_panel.loc[:, :, 'volume']),
+        }).T
+
+    session_index = calendar.minute_index_to_session_labels(
+        minute_panel.major_axis
+    )
+    return minute_panel.groupby(session_index).agg(aggregator)
+
+
 def minute_to_session(column, close_locs, data, out):
     """
     Resample an array with minute data into an array with session data.


### PR DESCRIPTION
Fixes #1356, #1629.

New function `zipline.data.resample.minute_panel_to_session_panel`.