### PR TITLE
fix blaze core loader adjustment application for stale data

### DIFF
--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -16,7 +16,7 @@ from numpy.testing.utils import assert_array_almost_equal
 from odo import odo
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
-from toolz import keymap, valmap, concatv, concat
+from toolz import keymap, valmap, concatv
 from toolz.curried import operator as op
 
 from zipline.assets.synthetic import make_simple_equity_info

--- a/zipline/utils/pandas_utils.py
+++ b/zipline/utils/pandas_utils.py
@@ -7,6 +7,7 @@ from itertools import product
 import operator as op
 import warnings
 
+import numpy as np
 import pandas as pd
 from distutils.version import StrictVersion
 
@@ -311,3 +312,38 @@ def days_at_time(days, t, tz, day_offset=0):
         seconds=t.second,
     )
     return (days + delta).tz_localize(tz).tz_convert('UTC')
+
+
+def empty_dataframe(*columns):
+    """Create an empty dataframe with columns of particular types.
+
+    Parameters
+    ----------
+    *columns
+        The (column_name, column_dtype) pairs.
+
+    Returns
+    -------
+    typed_dataframe : pd.DataFrame
+        The empty typed dataframe.
+
+    Examples
+    --------
+    >>> df = empty_dataframe(
+    ...     ('a', 'int64'),
+    ...     ('b', 'float64'),
+    ...     ('c', 'datetime64[ns]'),
+    ... )
+
+    >>> df
+    Empty DataFrame
+    Columns: [a, b, c]
+    Index: []
+
+    df.dtypes
+    a             int64
+    b           float64
+    c    datetime64[ns]
+    dtype: object
+    """
+    return pd.DataFrame(np.array([], dtype=list(columns)))


### PR DESCRIPTION
We need to keep track of the asof date stored at index 0 because once we convert date-space to index-space, we cannot disambiguate data that falls before the start of the window. This change fixes a problem where we have an adjustment for a data point from before the first data in a pipeline window which was overwriting a more recent asof date that was written at index 0.