### PR TITLE
DOC: Fix a link and typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Currently supported platforms include:
 Quickstart
 ==========
 
-See our `getting started tutorial <http://www.zipline.io/#quickstart>`_.
+See our `getting started tutorial <http://www.zipline.io/beginner-tutorial.html>`_.
 
 The following code implements a simple dual moving average algorithm.
 

--- a/docs/source/beginner-tutorial.rst
+++ b/docs/source/beginner-tutorial.rst
@@ -90,7 +90,7 @@ finished running you will have access to each variable value you tracked
 with :func:`~zipline.api.record` under the name you provided (we will see this
 further below). You also see how we can access the current price data of the
 AAPL stock in the ``data`` event frame (for more information see
-`here <https://www.quantopian.com/help#api-event-properties>`__.
+`here <https://www.quantopian.com/help#api-event-properties>`__).
 
 Running the algorithm
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There was a wrong link and fixed the link.
The round bracket which does not have the corresponding one existed and I fixed it.