### PR TITLE
ENH: Port AlgorithmResult from Quantopian.

### DIFF
--- a/tests/resources/rebuild_example_data
+++ b/tests/resources/rebuild_example_data
@@ -86,7 +86,6 @@ def eof(*args, **kwargs):
     default=False,
     help="Should we rebuild the input data from Yahoo?",
 )
-
 @click.pass_context
 def main(ctx, rebuild_input):
     """Rebuild the perf data for test_examples
@@ -109,60 +108,53 @@ def main(ctx, rebuild_input):
                  "a future release")
             )
 
-        new_perf_path = d.getpath(
-            'example_data/new_perf/%s' % pd.__version__.replace('.', '-'),
+        new_perf_path = d.getpath('example_data/new_perf/')
+        for name in examples.EXAMPLE_MODULES:
+            c[name] = examples.run_example(name, environ=environ)
+
+        correct_called = [False]
+
+        console = None
+
+        def _exit(*args, **kwargs):
+            console.raw_input = eof
+
+        def correct():
+            correct_called[0] = True
+            _exit()
+
+        expected_perf_path = d.getpath(
+            'example_data/expected_perf/%s' %
+            pd.__version__.replace('.', '-'),
         )
-        c = dataframe_cache(
-            new_perf_path,
-            serialization='pickle:2',
-        )
-        with c:
-            for name in examples.EXAMPLE_MODULES:
-                c[name] = examples.run_example(name, environ=environ)
 
-            correct_called = [False]
+        # allow users to run some analysis to make sure that the new
+        # results check out
+        console = InteractiveConsole({
+            'correct': correct,
+            'exit': _exit,
+            'incorrect': _exit,
+            'new': c,
+            'np': np,
+            'old': dataframe_cache(
+                expected_perf_path,
+                serialization='csv',
+            ),
+            'pd': pd,
+            'cols_to_check': examples._cols_to_check,
+            'changed_results': changed_results,
+        })
+        console.interact(banner)
 
-            console = None
-
-            def _exit(*args, **kwargs):
-                console.raw_input = eof
-
-            def correct():
-                correct_called[0] = True
-                _exit()
-
-            expected_perf_path = d.getpath(
-                'example_data/expected_perf/%s' %
-                pd.__version__.replace('.', '-'),
+        if not correct_called[0]:
+            ctx.fail(
+                '`correct()` was not called! This means that the new'
+                ' results will not be written',
             )
 
-            # allow users to run some analysis to make sure that the new
-            # results check out
-            console = InteractiveConsole({
-                'correct': correct,
-                'exit': _exit,
-                'incorrect': _exit,
-                'new': c,
-                'np': np,
-                'old': dataframe_cache(
-                    expected_perf_path,
-                    serialization='pickle',
-                ),
-                'pd': pd,
-                'cols_to_check': examples._cols_to_check,
-                'changed_results': changed_results,
-            })
-            console.interact(banner)
-
-            if not correct_called[0]:
-                ctx.fail(
-                    '`correct()` was not called! This means that the new'
-                    ' results will not be written',
-                )
-
-            # move the new results to the expected path
-            shutil.rmtree(expected_perf_path)
-            shutil.copytree(new_perf_path, expected_perf_path)
+        # move the new results to the expected path
+        shutil.rmtree(expected_perf_path)
+        shutil.copytree(new_perf_path, expected_perf_path)
 
         # Clear out all the temporary new perf so it doesn't get added to the
         # tarball.

--- a/tests/test_algorithm_result.py
+++ b/tests/test_algorithm_result.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from zipline.algorithm import TradingAlgorithm
+from zipline.result import AlgorithmResult
+import zipline.api as api
+from zipline.testing.predicates import assert_equal
+from zipline.testing.fixtures import WithDataPortal, ZiplineTestCase
+
+
+def T(s):
+    return pd.Timestamp(s, tz='UTC')
+
+
+class ResultTestCase(WithDataPortal, ZiplineTestCase):
+    ASSET_FINDER_EQUITY_SIDS = range(5)
+    START_DATE = T('2017-01-02')
+    END_DATE = T('2017-01-31')
+
+    def test_roundtrip_to_disk(self):
+
+        def initialize(context):
+            context.assets = map(api.sid, self.ASSET_FINDER_EQUITY_SIDS)
+            context.sign = 1
+
+        def handle_data(context, data):
+            for a in context.assets:
+                api.order(a, 1 * context.sign)
+            context.sign *= -1
+
+        algo = TradingAlgorithm(
+            initialize=initialize,
+            handle_data=handle_data,
+            data_frequency='daily',
+            start=self.START_DATE,
+            end=self.START_DATE + (5 * self.trading_calendar.day),
+            env=self.env,
+        )
+        result = algo.run(data=self.data_portal)
+        test_dir = self.tmpdir.getpath('result')
+
+        result.save(test_dir)
+        roundtripped = AlgorithmResult.load(test_dir)
+        assert_equal(roundtripped, result)

--- a/tests/test_continuous_futures.py
+++ b/tests/test_continuous_futures.py
@@ -539,7 +539,7 @@ def record_current_contract(algo, data):
                                 trading_calendar=self.trading_calendar,
                                 env=self.env)
         results = algo.run(self.data_portal)
-        result = results.iloc[0]
+        result = results.recorded_vars.iloc[0]
 
         self.assertEqual(result.primary.symbol,
                          'FOF16',
@@ -548,7 +548,7 @@ def record_current_contract(algo, data):
                          'FOG16',
                          'Secondary should be FOG16 on first session.')
 
-        result = results.iloc[1]
+        result = results.recorded_vars.iloc[1]
         # Second day, primary should switch to FOG
         self.assertEqual(result.primary.symbol,
                          'FOG16',
@@ -559,7 +559,7 @@ def record_current_contract(algo, data):
                          'Secondary should be FOH16 on second session, auto '
                          'close is at beginning of the session.')
 
-        result = results.iloc[2]
+        result = results.recorded_vars.iloc[2]
         # Second day, primary should switch to FOG
         self.assertEqual(result.primary.symbol,
                          'FOG16',
@@ -598,7 +598,7 @@ def record_current_contract(algo, data):
                                 trading_calendar=self.trading_calendar,
                                 env=self.env)
         results = algo.run(self.data_portal)
-        result = results.iloc[0]
+        result = results.recorded_vars.iloc[0]
 
         self.assertEqual(result.primary_len,
                          6,
@@ -633,7 +633,7 @@ def record_current_contract(algo, data):
                          'session.')
 
         # Second day, primary should switch to FOG
-        result = results.iloc[1]
+        result = results.recorded_vars.iloc[1]
 
         self.assertEqual(result.primary_len,
                          5,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -65,7 +65,7 @@ class ExamplesTests(WithTmpDir, ZiplineTestCase):
 
     @parameterized.expand(sorted(examples.EXAMPLE_MODULES))
     def test_example(self, example_name):
-        actual_perf = examples.run_example(
+        result = examples.run_example(
             example_name,
             # This should match the invocation in
             # zipline/tests/resources/rebuild_example_data
@@ -74,7 +74,7 @@ class ExamplesTests(WithTmpDir, ZiplineTestCase):
             },
         )
         assert_equal(
-            actual_perf[examples._cols_to_check],
+            result.daily_performance[examples._cols_to_check],
             self.expected_perf[example_name][examples._cols_to_check],
             # There is a difference in the datetime columns in pandas
             # 0.16 and 0.17 because in 16 they are object and in 17 they are

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -195,8 +195,8 @@ def handle_data(context, data):
     record(dell_signal=data.current(sid(25317), "signal"))
     """)
 
-        self.assertEqual(5, results["ibm_signal"].iloc[-1])
-        self.assertEqual(5, results["dell_signal"].iloc[-1])
+        self.assertEqual(5, results.recorded_vars["ibm_signal"].iloc[-1])
+        self.assertEqual(5, results.recorded_vars["dell_signal"].iloc[-1])
 
     def test_fetch_csv_with_pure_signal_file(self):
         self.responses.add(
@@ -228,7 +228,7 @@ def handle_data(context, data):
     record(cpi=cur_cpi)
             """)
 
-        self.assertEqual(results["cpi"][-1], 203.1)
+        self.assertEqual(results.recorded_vars["cpi"][-1], 203.1)
 
     def test_algo_fetch_csv(self):
         self.responses.add(
@@ -258,9 +258,9 @@ def handle_data(context, data):
         price=data.current(sid(24), "price"))
         """)
 
-        self.assertEqual(5, results["signal"][-1])
-        self.assertEqual(50, results["scaled"][-1])
-        self.assertEqual(24, results["price"][-1])  # fake value
+        self.assertEqual(5, results.recorded_vars["signal"][-1])
+        self.assertEqual(50, results.recorded_vars["scaled"][-1])
+        self.assertEqual(24, results.recorded_vars["price"][-1])  # fake value
 
     def test_algo_fetch_csv_with_extra_symbols(self):
         self.responses.add(
@@ -291,9 +291,9 @@ def handle_data(context, data):
             """
         )
 
-        self.assertEqual(5, results["signal"][-1])
-        self.assertEqual(50, results["scaled"][-1])
-        self.assertEqual(24, results["price"][-1])  # fake value
+        self.assertEqual(5, results.recorded_vars["signal"][-1])
+        self.assertEqual(50, results.recorded_vars["scaled"][-1])
+        self.assertEqual(24, results.recorded_vars["price"][-1])  # fake value
 
     @parameterized.expand([("unspecified", ""),
                            ("none", "usecols=None"),
@@ -328,7 +328,7 @@ def handle_data(context, data):
         """
         results = self.run_algo(code.format(usecols=usecols))
         # 251 trading days in 2006
-        self.assertEqual(len(results), 251)
+        self.assertEqual(len(results.daily_performance), 251)
 
     def test_sources_merge_custom_ticker(self):
         requests_kwargs = {}
@@ -367,8 +367,11 @@ def handle_data(context, data):
     record(aapl=data.current(context.stock, "price"))
         """)
 
-            np.testing.assert_array_equal([24] * 251, results["aapl"])
-            self.assertEqual(337, results["palladium"].iloc[-1])
+            np.testing.assert_array_equal(
+                [24] * 251,
+                results.recorded_vars["aapl"]
+            )
+            self.assertEqual(337, results.recorded_vars["palladium"].iloc[-1])
 
             expected = {
                 'allow_redirects': False,
@@ -430,10 +433,10 @@ def handle_data(context, data):
 
             results = self.run_algo(real_algocode, sim_params=sim_params)
 
-            self.assertEqual(len(results), 3)
-            self.assertEqual(3, results["sid_count"].iloc[0])
-            self.assertEqual(3, results["sid_count"].iloc[1])
-            self.assertEqual(4, results["sid_count"].iloc[2])
+            self.assertEqual(len(results.daily_performance), 3)
+            self.assertEqual(3, results.recorded_vars["sid_count"].iloc[0])
+            self.assertEqual(3, results.recorded_vars["sid_count"].iloc[1])
+            self.assertEqual(4, results.recorded_vars["sid_count"].iloc[2])
 
     def test_fetcher_universe_non_security_return(self):
         self.responses.add(
@@ -537,10 +540,10 @@ def handle_data(context, data):
         """, sim_params=sim_params, data_frequency="minute"
         )
 
-        self.assertEqual(3, len(results))
-        self.assertEqual(3, results["sid_count"].iloc[0])
-        self.assertEqual(3, results["sid_count"].iloc[1])
-        self.assertEqual(4, results["sid_count"].iloc[2])
+        self.assertEqual(3, len(results.daily_performance))
+        self.assertEqual(3, results.recorded_vars["sid_count"].iloc[0])
+        self.assertEqual(3, results.recorded_vars["sid_count"].iloc[1])
+        self.assertEqual(4, results.recorded_vars["sid_count"].iloc[2])
 
     def test_fetcher_in_before_trading_start(self):
         self.responses.add(
@@ -569,7 +572,7 @@ def before_trading_start(context, data):
     record(Short_Interest = data.current(context.stock, 'dtc'))
 """, sim_params=sim_params, data_frequency="minute")
 
-        values = results["Short_Interest"]
+        values = results.recorded_vars["Short_Interest"]
         np.testing.assert_array_equal(values[0:33], np.full(33, np.nan))
         np.testing.assert_array_almost_equal(values[33:44], [1.690317] * 11)
         np.testing.assert_array_almost_equal(values[44:55], [2.811858] * 11)
@@ -608,4 +611,4 @@ def handle_data(context, data):
     assert np.isnan(data.current(context.aapl, 'dtc'))
 """, sim_params=sim_params, data_frequency="minute")
 
-        self.assertEqual(3, len(results))
+        self.assertEqual(3, len(results.daily_performance))

--- a/zipline/examples/buyapple.py
+++ b/zipline/examples/buyapple.py
@@ -39,10 +39,10 @@ def analyze(context=None, results=None):
     import matplotlib.pyplot as plt
     # Plot the portfolio and asset data.
     ax1 = plt.subplot(211)
-    results.portfolio_value.plot(ax=ax1)
+    results.daily_performance.ending_portfolio_value.plot(ax=ax1)
     ax1.set_ylabel('Portfolio value (USD)')
     ax2 = plt.subplot(212, sharex=ax1)
-    results.AAPL.plot(ax=ax2)
+    results.recorded_vars.AAPL.plot(ax=ax2)
     ax2.set_ylabel('AAPL price (USD)')
 
     # Show the plot.

--- a/zipline/examples/dual_ema_talib.py
+++ b/zipline/examples/dual_ema_talib.py
@@ -79,7 +79,7 @@ def analyze(context=None, results=None):
 
     fig = plt.figure()
     ax1 = fig.add_subplot(211)
-    results.portfolio_value.plot(ax=ax1)
+    results.daily_performance.ending_portfolio_value.plot(ax=ax1)
     ax1.set_ylabel('Portfolio value (USD)')
 
     ax2 = fig.add_subplot(212)

--- a/zipline/examples/dual_moving_average.py
+++ b/zipline/examples/dual_moving_average.py
@@ -73,7 +73,7 @@ def analyze(context=None, results=None):
 
     fig = plt.figure()
     ax1 = fig.add_subplot(211)
-    results.portfolio_value.plot(ax=ax1)
+    results.daily_performance.ending_portfolio_value.plot(ax=ax1)
     ax1.set_ylabel('Portfolio value (USD)')
 
     ax2 = fig.add_subplot(212)

--- a/zipline/examples/olmar.py
+++ b/zipline/examples/olmar.py
@@ -151,7 +151,7 @@ def analyze(context=None, results=None):
     import matplotlib.pyplot as plt
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    results.portfolio_value.plot(ax=ax)
+    results.daily_performance.ending_portfolio_value.plot(ax=ax)
     ax.set_ylabel('Portfolio value (USD)')
     plt.show()
 

--- a/zipline/finance/performance/period.py
+++ b/zipline/finance/performance/period.py
@@ -486,7 +486,7 @@ class PerformancePeriod(object):
         # as_portfolio is called in an inner loop,
         # so repeated object creation becomes too expensive
         portfolio = self._portfolio_store
-        # maintaining the old name for the portfolio field for
+        # maintaining the old name for the portofolio field for
         # backward compatibility
         portfolio.capital_used = self.cash_flow
         portfolio.starting_cash = self.starting_cash

--- a/zipline/result.py
+++ b/zipline/result.py
@@ -1,0 +1,301 @@
+from functools import partial
+
+import pandas as pd
+
+from . import result_helpers
+
+TimestampMS = partial(pd.Timestamp, unit='ms', tz='UTC')
+
+
+class AlgorithmResult(object):
+    """In-Memory Container for TradingAlgorithm outputs.
+    """
+    # Top-level metadata.
+    _algo_id = None
+    _benchmark_security = None
+    _capital_base = None
+    _end_date = None
+    _launch_date = None
+    _start_date = None
+
+    # Daily time series.
+    _risk = None
+    _daily_performance = None
+    _cumulative_performance = None
+    _recorded_vars = None
+    _stoppages = None
+
+    # Hierarchical frames.
+    _transactions = None
+    _orders = None
+    _positions = None
+
+    _frames = [
+        'cumulative_performance',
+        'daily_performance',
+        'orders',
+        'positions',
+        'pyfolio_positions',
+        'pyfolio_transactions',
+        'recorded_vars',
+        'risk',
+        'stoppages',
+        'transactions',
+    ]
+    _scalars = [
+        'algo_id',
+        'benchmark_security',
+        'capital_base',
+        'end_date',
+        'launch_date',
+        'start_date',
+    ]
+
+    def __init__(self,
+                 algo_id,
+                 start_date,
+                 end_date,
+                 capital_base,
+                 daily_performance,
+                 cumulative_performance,
+                 risk,
+                 orders,
+                 positions,
+                 transactions,
+                 recorded_vars):
+
+        # Scalars
+        self._algo_id = algo_id
+        self._start_date = start_date
+        self._end_date = end_date
+        self._capital_base = capital_base
+
+        # Single Row per Day Frames
+        self._daily_performance = daily_performance
+        self._cumulative_performance = cumulative_performance
+        self._risk = risk
+        self._recorded_vars = recorded_vars
+
+        # Multiple Row per Day Frames
+        self._orders = orders
+        self._positions = positions
+        self._transactions = transactions
+
+    @classmethod
+    def init_processor(cls):
+        return result_helpers.default_result_stream_processor()
+
+    @classmethod
+    def from_stream(cls, result_iterator, progress_bar, algo_id):
+        """
+        Create an AlgorithmResult from a stream of algorithm result packets.
+        """
+        if progress_bar is None:
+            progress_bar = result_helpers.NoProgressBar()
+
+        processor = cls.init_processor()
+        progress_bar.start()
+
+        for msg in result_iterator:
+            processor.handle_message(msg, progress_bar)
+
+        finalized_results = processor.finalize()
+        progress_bar.finish()
+
+        return cls(algo_id=algo_id, **finalized_results)
+
+    @property
+    def algo_id(self):
+        """
+        Return the algorithm's ID
+        """
+        return self._algo_id
+
+    @property
+    def benchmark_security(self):
+        """
+        Return the security used as a benchmark for this algorithm.
+        """
+        return self._benchmark_security
+
+    @property
+    def capital_base(self):
+        """
+        Return the capital base for this algorithm.
+        """
+        return self._capital_base
+
+    @property
+    def launch_date(self):
+        """
+        The real-world date on which this algorithm launched.
+        """
+        return self._launch_date
+
+    @property
+    def start_date(self):
+        """
+        Return the start date for this algorithm.
+        """
+        return self._start_date
+
+    @property
+    def end_date(self):
+        """
+        Return the end date for this algorithm.
+        """
+        return self._end_date
+
+    @property
+    def stoppages(self):
+        """
+        Return a DataFrame with a daily DatetimeIndex containing
+        the dates where an algo went into exception or cancel
+        """
+        return self._stoppages
+
+    @property
+    def daily_performance(self):
+        """
+        Return a DataFrame with a daily DatetimeIndex containing cumulative
+        performance metrics for the algorithm
+
+        Each row of the returned frame contains the following columns:
+
+        * capital_used
+        * starting_cash
+        * ending_cash
+        * starting_position_value
+        * ending_position_value
+        * pnl
+        * portfolio_value
+        * returns
+        """
+        return self._daily_performance
+
+    @property
+    def cumulative_performance(self):
+        """
+        Return a DataFrame with a daily DatetimeIndex containing cumulative
+        performance metrics for the algorithm.
+
+        Each row of the returned frame contains the following columns:
+
+        * capital_used
+        * starting_cash
+        * ending_cash
+        * starting_position_value
+        * ending_position_value
+        * pnl
+        * portfolio_value
+        * returns
+        """
+        return self._cumulative_performance
+
+    @property
+    def positions(self):
+        """
+        Return a datetime-indexed DataFrame representing a point-in-time
+        record of positions held by the algorithm during the backtest.
+
+        Each row of the returned frame contains the following columns:
+
+        * amount
+        * last_sale_price
+        * cost_basis
+        * sid
+        """
+        return self._positions
+
+    @property
+    def risk(self):
+        """
+        Return a DataFrame with a daily DatetimeIndex representing rolling risk
+        metrics for the algorithm.
+
+        Each row of the returned frame contains the following columns:
+
+        * volatility
+        * period_return
+        * alpha
+        * benchmark_period_return
+        * benchmark_volatility
+        * beta
+        * excess_return
+        * max_drawdown
+        * period_label
+        * sharpe
+        * sortino
+        * trading_days
+        * treasury_period_return
+        """
+        return self._risk
+
+    @property
+    def orders(self):
+        """
+        Return a DataFrame representing a record of all orders made by the
+        algorithm.
+
+        Each row of the returned frame contains the following columns:
+
+        * amount
+        * commission
+        * created_date
+        * last_updated
+        * filled
+        * id
+        * sid
+        * status
+        * limit
+        * limit_reached
+        * stop
+        * stop_reached
+        """
+        return self._orders
+
+    @property
+    def transactions(self):
+        """
+        Return a DataFrame representing a record of transactions that occurred
+        during the life of the algorithm. The returned frame is indexed by the
+        date at which the transaction occurred.
+
+        Each row of the returned frame contains the following columns:
+
+        * amount
+        * commission
+        * date
+        * order_id
+        * price
+        * sid
+        """
+        return self._transactions
+
+    @property
+    def recorded_vars(self):
+        """
+        Return a DataFrame containing the recorded variables for the algorithm.
+        """
+        return self._recorded_vars
+
+    @property
+    def attrs(self):
+        """
+        Return a list of public attributes on this object.
+        """
+        return self.frames + self.scalars
+
+    @property
+    def scalars(self):
+        """
+        Return a list of scalar attributes of on this object.
+        """
+        return self._scalars
+
+    @property
+    def frames(self):
+        """
+        Return a list of DataFrame attributes of on this object.
+        """
+        return self._frames

--- a/zipline/result_helpers.py
+++ b/zipline/result_helpers.py
@@ -1,0 +1,295 @@
+from six import iteritems, viewkeys
+import toolz as tz
+
+import numpy as np
+import pandas as pd
+
+from zipline.utils.numpy_utils import (
+    float64_dtype,
+    int64_dtype,
+    object_dtype,
+    bool_dtype,
+)
+
+
+class ResultStreamProcessor(object):
+    """
+    Helper for converting a Zipline result stream into an AlgorithmResult.
+    """
+    def __init__(self, extractors):
+        self._extractors = extractors
+        self._last_dt = None
+
+    def handle_message(self, message, progress_bar):
+        if 'daily_perf' not in message:
+            # Only process daily perf packets.
+            return
+
+        dt = self._last_dt = message['daily_perf']['period_close'].normalize()
+        for ext in self._extractors:
+            ext.update(dt, message)
+
+    def finalize(self):
+        merged = tz.merge(e.finalize() for e in self._extractors)
+        merged['end_date'] = self._last_dt
+        return merged
+
+
+def default_result_stream_processor():
+    return ResultStreamProcessor([
+        extract_daily_perf(),
+        extract_cumulative_perf(),
+        extract_risk(),
+        extract_orders(),
+        extract_positions(),
+        extract_transactions(),
+        extract_recorded_vars(),
+        extract_top_level_metadata(),
+    ])
+
+
+class SchematizedPayloadExtractor(object):
+
+    def __init__(self, name, path, dtypes, renames):
+        self._name = name
+        self._path = path
+        assert viewkeys(renames) <= viewkeys(dtypes), (
+            "Renames must be a subset of dtypes:\n renames=%s, dtypes=%s"
+            % (renames, dtypes)
+        )
+        self._renames = renames
+        self._dtypes = dtypes
+        self._dts = []
+        self._columns = {k: [] for k in self._dtypes}
+
+    def update(self, dt, top_level_message):
+        columns = self._columns
+        dts = self._dts
+
+        records = tz.get_in(self._path, top_level_message, no_default=True)
+        if not isinstance(records, list):
+            records = (records,)
+
+        for message in records:
+            dts.append(dt)
+            for key in columns:
+                columns[key].append(message[key])
+
+    def finalize(self):
+        index = pd.to_datetime(self._dts, utc=True)
+        dtypes = self._dtypes
+        arrays = {
+            # Apply renames here.
+            self._renames.get(k, k): _to_column(data, dtypes[k])
+            for k, data in iteritems(self._columns)
+        }
+        result = pd.DataFrame(arrays, index=index)
+        return {self._name: result}
+
+
+def _to_column(data, dtype):
+    arr = np.array(data, dtype=dtype)
+    if dtype.kind == 'M':
+        arr = pd.DatetimeIndex(arr, tz='UTC')
+    return arr
+
+
+def extract_daily_perf():
+    path = ['daily_perf']
+    dtypes = {
+        # These fields should be kept in sync with extract_cumulative_perf.
+        'capital_used':    float64_dtype,
+        'ending_cash':     float64_dtype,
+        'ending_value':    float64_dtype,
+        'pnl':             float64_dtype,
+        'portfolio_value': float64_dtype,
+        'returns':         float64_dtype,
+        # These fields are specific to daily perf.
+        'starting_value':  float64_dtype,
+        'starting_cash':   float64_dtype,
+        'period_open':     np.dtype('datetime64[ms]'),
+        'period_close':    np.dtype('datetime64[ms]'),
+    }
+    renames = {
+        'capital_used': 'cash_flow',
+        'ending_value': 'ending_position_value',
+        'portfolio_value': 'ending_portfolio_value',
+        'starting_value': 'starting_position_value',
+    }
+    return SchematizedPayloadExtractor(
+        'daily_performance', path, dtypes, renames
+    )
+
+
+def extract_cumulative_perf():
+    path = ['cumulative_perf']
+    dtypes = {
+        # These fields should be kept in sync with extract_daily_perf.
+        'capital_used':    float64_dtype,
+        'ending_cash':     float64_dtype,
+        'ending_value':    float64_dtype,
+        'pnl':             float64_dtype,
+        'portfolio_value': float64_dtype,
+        'returns':         float64_dtype,
+    }
+    renames = {
+        'capital_used': 'cash_flow',
+        'ending_value': 'ending_position_value',
+        'portfolio_value': 'ending_portfolio_value',
+    }
+    return SchematizedPayloadExtractor(
+        'cumulative_performance', path, dtypes, renames
+    )
+
+
+def extract_risk():
+    path = ['cumulative_risk_metrics']
+    dtypes = {
+        'algo_volatility':         float64_dtype,
+        'algorithm_period_return': float64_dtype,
+        'alpha':                   float64_dtype,
+        'benchmark_period_return': float64_dtype,
+        'benchmark_volatility':    float64_dtype,
+        'beta':                    float64_dtype,
+        'excess_return':           float64_dtype,
+        'max_drawdown':            float64_dtype,
+        'period_label':            np.dtype('datetime64[D]'),
+        'sharpe':                  float64_dtype,
+        'sortino':                 float64_dtype,
+        'treasury_period_return':  float64_dtype,
+    }
+    renames = {
+        'algo_volatility': 'volatility',
+        'algorithm_period_return': 'period_return',
+    }
+    return SchematizedPayloadExtractor('risk', path, dtypes, renames)
+
+
+def extract_orders():
+    path = ['daily_perf', 'orders']
+    dtypes = {
+        'amount': int64_dtype,
+        'commission': float64_dtype,
+        'created': np.dtype('datetime64[ms]'),
+        'dt': np.dtype('datetime64[ms]'),
+        'filled': int64_dtype,
+        'id': object_dtype,
+        'sid': int64_dtype,
+        'status': int64_dtype,
+        'limit': float64_dtype,
+        'limit_reached': bool_dtype,
+        'stop': float64_dtype,
+        'stop_reached': bool_dtype,
+    }
+    renames = {
+        'dt': 'last_modified',
+    }
+    return SchematizedPayloadExtractor('orders', path, dtypes, renames)
+
+
+def extract_positions():
+    path = ['daily_perf', 'positions']
+    dtypes = {
+        'amount': int64_dtype,
+        'last_sale_price': float64_dtype,
+        'cost_basis': float64_dtype,
+        'sid': int64_dtype,
+    }
+    renames = {}
+    return SchematizedPayloadExtractor('positions', path, dtypes, renames)
+
+
+def extract_transactions():
+    path = ['daily_perf', 'transactions']
+    dtypes = {
+        'amount': int64_dtype,
+        'commission': float64_dtype,
+        'dt': np.dtype('datetime64[ms]'),
+        'order_id': object_dtype,
+        'price': float64_dtype,
+        'sid': int64_dtype,
+    }
+    renames = {'dt': 'date'}
+    return SchematizedPayloadExtractor('transactions', path, dtypes, renames)
+
+
+class RecordedVariablePayloadExtractor(object):
+    """
+    Extractor for float-dtype records that may have different sets of keys
+    across records.
+    """
+    def __init__(self, name, path):
+        self._name = name
+        self._path = path
+        self._records = []
+        self._dts = []
+        self._all_keys = set()
+
+    def update(self, dt, top_level_message):
+        self._dts.append(dt)
+        message = tz.get_in(self._path, top_level_message, no_default=True)
+        self._all_keys.update(message)
+        self._records.append(message)
+
+    def finalize(self):
+        return {
+            self._name: pd.DataFrame(
+                index=self._dts,
+                columns=self._all_keys,
+                data=self._records,
+                dtype=float64_dtype,
+            ),
+        }
+
+
+def extract_recorded_vars():
+    return RecordedVariablePayloadExtractor(
+        name='recorded_vars', path=['daily_perf', 'recorded_vars'],
+    )
+
+
+class TopLevelMetaDataExtractor(object):
+    def __init__(self):
+        self._extracted = False
+        self._start_date = None
+        self._capital_base = None
+
+    def update(self, dt, top_level_message):
+        if not self._extracted:
+            self._start_date = top_level_message['period_start']
+            self._capital_base = top_level_message['capital_base']
+
+    def finalize(self):
+        return {
+            'start_date': self._start_date,
+            'capital_base': self._capital_base,
+        }
+
+
+def extract_top_level_metadata():
+    return TopLevelMetaDataExtractor()
+
+
+class ResultsNotAvailable(Exception):
+
+    def __init__(self, algo_id):
+        self.algo_id = algo_id
+
+    def __str__(self):
+        return ("Could not find results for algorithm with id '{}'. "
+                "Please make sure it has run for at least a full day and has "
+                "not experienced any errors.").format(self.algo_id)
+
+
+class NoProgressBar(object):
+    """Dummy standin for result progress bar.
+    """
+
+    def start(self):
+        pass
+
+    def update(self, arg):
+        pass
+
+    def finish(self):
+        pass

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -241,18 +241,6 @@ class TimeoutAlgorithm(TradingAlgorithm):
         pass
 
 
-class RecordAlgorithm(TradingAlgorithm):
-    def initialize(self):
-        self.incr = 0
-
-    def handle_data(self, data):
-        self.incr += 1
-        self.record(incr=self.incr)
-        name = 'name'
-        self.record(name, self.incr)
-        record(name, self.incr, 'name2', 2, name3=self.incr)
-
-
 class TestOrderAlgorithm(TradingAlgorithm):
     def initialize(self):
         self.incr = 0
@@ -702,6 +690,7 @@ class TestPositionWeightsAlgorithm(TradingAlgorithm):
         self.set_slippage(
             us_equities=FixedSlippage(0), us_futures=FixedSlippage(0),
         )
+        self.weights_log = []
 
     def handle_data(self, data):
         if not self.ordered:
@@ -709,7 +698,7 @@ class TestPositionWeightsAlgorithm(TradingAlgorithm):
                 self.order(self.sid(s), amount)
             self.ordered = True
 
-        self.record(position_weights=self.portfolio.current_portfolio_weights)
+        self.weights_log.append(self.portfolio.current_portfolio_weights)
 
 
 class InvalidOrderAlgorithm(TradingAlgorithm):

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -45,9 +45,11 @@ from toolz import dissoc, keyfilter
 import toolz.curried.operator as op
 
 from zipline.testing.core import ensure_doctest
+
 from zipline.dispatch import dispatch
 from zipline.lib.adjustment import Adjustment
 from zipline.lib.labelarray import LabelArray
+from zipline.result import AlgorithmResult
 from zipline.utils.functional import dzip_exact, instance
 from zipline.utils.math_utils import tolerant_equals
 
@@ -276,6 +278,18 @@ def assert_equal(result, expected, path=(), msg='', **kwargs):
         expected,
         _fmt_path(path),
     )
+
+
+@dispatch(AlgorithmResult, AlgorithmResult)
+def assert_algo_result_equal(result, expected, path=(), msg='', **kwargs):
+    for attr in result.scalars + result.frames:
+        assert_equal(
+            getattr(result, attr),
+            getattr(expected, attr),
+            path=path + (attr,),
+            msg=msg,
+            **kwargs
+        )
 
 
 @assert_equal.register(float, float)


### PR DESCRIPTION
I finally got fed up and did this.

Ports the AlgorithmResult class from Quantopian's research
environment. This replaces the old backtest output structure, which was
a DataFrame containing a mix of scalars, dictionaries, and lists of
dictionaries.

`TradingAlgorithm.run` now returns a BacktestResult. Most of the changes
here are updating tests to read values out of this new format instead of
from the old one.

This still needs work to update `test_examples`, which is expecting serialized data in the old format.  This will also require a bunch of maintenance downstream, but I've refactored this some in prepararation for making that less painful.

@dmichalowicz I tagged you as a reviewer because you've worked with the downstream version of this class a bunch, and because a bunch of the tests that ended up getting updated here were yours.

x-ref #955