### PR TITLE
Clear perf tracker

### DIFF
--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1525,14 +1525,20 @@ class TestPortfolio(WithDataPortal, WithSimParams, ZiplineTestCase):
         af = self.asset_finder
         equity_1, future_1004 = af.retrieve_all(sids)
 
+        pt_weights = []
+        # perf tracker is cleared when `run` completes
+
+        def capture_position_weights(algo, stats):
+            pt_weights.extend(algo.perf_tracker.position_weights)
+
         algo = self.algorithm(
             sids_and_amounts=zip(sids, amounts), sim_params=sim_params,
+            analyze=capture_position_weights,
         )
         daily_stats = algo.run(self.data_portal)
 
         # Test that we correctly converted the future contract being held into
         # the appropriate continuous futures.
-        pt_weights = algo.perf_tracker.position_weights
         future_1000, future_1001, future_1002, future_1003 = af.retrieve_all(
             [1000, 1001, 1002, 1003],
         )

--- a/tests/test_tradesimulation.py
+++ b/tests/test_tradesimulation.py
@@ -80,9 +80,6 @@ class TestTradeSimulation(WithTradingEnvironment, ZiplineTestCase):
             num_days=num_days, data_frequency=freq,
             emission_rate=emission_rate)
 
-        def fake_benchmark(self, dt):
-            return 0.01
-
         with patch.object(BenchmarkSource, "get_value",
                           self.fake_minutely_benchmark):
             algo = BeforeTradingAlgorithm(sim_params=params, env=self.env)

--- a/tests/test_tradesimulation.py
+++ b/tests/test_tradesimulation.py
@@ -66,7 +66,7 @@ class TestTradeSimulation(WithTradingEnvironment, ZiplineTestCase):
                           self.fake_minutely_benchmark):
             algo = NoopAlgorithm(sim_params=params, env=self.env)
             algo.run(FakeDataPortal(self.env))
-            self.assertEqual(len(algo.perf_tracker.sim_params.sessions), 1)
+            self.assertEqual(len(algo.sim_params.sessions), 1)
 
     @parameterized.expand([('%s_%s_%s' % (num_sessions, freq, emission_rate),
                             num_sessions, freq, emission_rate)
@@ -89,7 +89,7 @@ class TestTradeSimulation(WithTradingEnvironment, ZiplineTestCase):
             algo.run(FakeDataPortal(self.env))
 
             self.assertEqual(
-                len(algo.perf_tracker.sim_params.sessions),
+                len(algo.sim_params.sessions),
                 num_days
             )
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -738,6 +738,8 @@ class TradingAlgorithm(object):
 
             self.analyze(daily_stats)
         finally:
+            self._account = self._portfolio = None
+            self.perf_tracker = None
             self.data_portal = None
 
         return daily_stats


### PR DESCRIPTION
To fix the failing test on AppVeyor, break reference cycles from:

`TradingAlgorithm -> PerformanceTracker -> Portfolio -> TradingAlgorithm`
and
`TradingAlgorithm -> Portfolio -> TradingAlgorithm`

since these objects hold reference chains to `DataPortal -> SQLiteAdjustmentReader -> connection to adjustments db file`, and that file lives in a temp directory that we can't delete on windows.