### PR TITLE
BUG/MAINT: Adjust get_benchmark_returns to match Google API change

### DIFF
--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numpy as np
+import math
 import pandas as pd
 
 import pandas_datareader.data as pd_reader
@@ -32,13 +32,9 @@ def get_benchmark_returns(symbol, first_date, last_date):
     last_date : pd.Timestamp
         Last date for which we want to get data.
 
-    The furthest date that Google goes back to is 1993-02-01. It has missing
-    data for 2008-12-15, 2009-08-11, and 2012-02-02, so we add data for the
-    dates for which Google is missing data.
-
     We're also now limited to 251 days worth of data per request. If we make a
-    request for data that extends past 251 trading days, we'll generate an
-    empty Series that fills in the remaining days that were requested.
+    request for data that extends past 251 trading days, we'll figure out how
+    many more requests we need to make and then make those requests in sequence.
 
     first_date is **not** included because we need the close from day N - 1 to
     compute the returns for day N.
@@ -51,19 +47,25 @@ def get_benchmark_returns(symbol, first_date, last_date):
     )
 
     given_first = data.index[0].tz_localize('UTC')
+    _, num_requests = math.modf(
+        (given_first - first_date).days / max_days
+    )
 
-    if first_date != given_first:
-        first_date = first_date
-        dates = pd.date_range(first_date, given_first)
-        zeros = np.zeros(len(dates))
-        empty_series = pd.Series(
-            index=dates,
-            data=zeros,
-            name='Close',
-        )
+    new_data = pd.Series()
+
+    if given_first != first_date:
+        for n in num_requests:
+            tmp_data = pd_reader.DataReader(
+                symbol,
+                'google',
+                first_date,
+                given_first,
+            )
+            new_data.append(tmp_data['Close'])
+            given_first = new_data.index[0].tz_localize('UTC')
 
     data = data['Close']
-    data = empty_series.append(data)
-    data = data.fillna(method='ffill')
+    data = new_data.append(data)
+    data.fillna(method='ffill', inplace=True)
 
     return data.sort_index().tz_localize('UTC').pct_change().iloc[1:]

--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import numpy as np
 import pandas as pd
 
@@ -36,9 +37,9 @@ def get_benchmark_returns(symbol, first_date, last_date):
     data for 2008-12-15, 2009-08-11, and 2012-02-02, so we add data for the
     dates for which Google is missing data.
 
-    We're also limited to 4000 days worth of data per request. If we make a
-    request for data that extends past 4000 trading days, we'll still only
-    receive 4000 days of data.
+    We're also now limited to 251 days worth of data per request. If we make a
+    request for data that extends past 251 trading days, we'll generate an
+    empty Series that fills in the remaining days that were requested.
 
     first_date is **not** included because we need the close from day N - 1 to
     compute the returns for day N.
@@ -50,12 +51,20 @@ def get_benchmark_returns(symbol, first_date, last_date):
         last_date
     )
 
+    given_first = data.index[0].tz_localize('UTC')
+
+    if first_date != given_first:
+        first_date = first_date
+        dates = pd.date_range(first_date, given_first)
+        zeros = np.zeros(len(dates))
+        empty_series = pd.Series(
+            index=dates,
+            data=zeros,
+            name='Close',
+        )
+
     data = data['Close']
-
-    data[pd.Timestamp('2008-12-15')] = np.nan
-    data[pd.Timestamp('2009-08-11')] = np.nan
-    data[pd.Timestamp('2012-02-02')] = np.nan
-
+    data = empty_series.append(data)
     data = data.fillna(method='ffill')
 
-    return data.sort_index().tz_localize('UTC').pct_change(1).iloc[1:]
+    return data.sort_index().tz_localize('UTC').pct_change().iloc[1:]

--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import datetime
 import numpy as np
 import pandas as pd
 

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -177,8 +177,13 @@ class AlgorithmSimulator(object):
                     perf_tracker.position_tracker.handle_splits(splits)
 
         def handle_benchmark(date, benchmark_source=self.benchmark_source):
-            perf_tracker.all_benchmark_returns[date] = \
-                benchmark_source.get_value(date)
+            try:
+                perf_tracker.all_benchmark_returns[date] = \
+                    benchmark_source.get_value(date)
+            except ValueError:
+                # XXX: Strange error here where 2016-09-28 returns two values
+                # NaN and inf, when calling get_value
+                pass
 
         def on_exit():
             # Remove references to algo, data portal, et al to break cycles


### PR DESCRIPTION
This zeros out any dates that come before the 251 day limit that google sets, if we request > 251 days worth of benchmark data.