### PR TITLE
DOC: Distinct warnings for benchmark and treasury fetchers

### DIFF
--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -234,7 +234,7 @@ def ensure_benchmark_data(symbol, first_date, last_date, now, trading_day,
         logger.exception('Failed to cache the new benchmark returns')
         raise
     if not has_data_for_dates(data, first_date, last_date):
-        logger.warn("Still don't have expected data after redownload!")
+        logger.warn("Still don't have expected benchmark data after redownload!")
     return data
 
 
@@ -285,7 +285,7 @@ def ensure_treasury_data(symbol, first_date, last_date, now, environ=None):
     except (OSError, IOError, HTTPError):
         logger.exception('failed to cache treasury data')
     if not has_data_for_dates(data, first_date, last_date):
-        logger.warn("Still don't have expected data after redownload!")
+        logger.warn("Still don't have expected treasury data after redownload!")
     return data
 
 

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -283,7 +283,13 @@ def ensure_treasury_data(symbol, first_date, last_date, now, environ=None):
 
     # If no cached data was found or it was missing any dates then download the
     # necessary data.
-    logger.info('Downloading treasury data for {symbol!r}.', symbol=symbol)
+    logger.info(
+        ('Downloading treasury data for {symbol!r} '
+            'from {first_date} to {last_date}'),
+        symbol=symbol,
+        first_date=first_date,
+        last_date=last_date
+    )
 
     try:
         data = loader_module.get_treasury_data(first_date, last_date)

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -234,7 +234,13 @@ def ensure_benchmark_data(symbol, first_date, last_date, now, trading_day,
         logger.exception('Failed to cache the new benchmark returns')
         raise
     if not has_data_for_dates(data, first_date, last_date):
-        logger.warn("Still don't have expected benchmark data after redownload!")
+        logger.warn(
+            ("Still don't have expected benchmark data for {symbol!r} "
+                "from {first_date} to {last_date} after redownload!"),
+            symbol=symbol,
+            first_date=first_date - trading_day,
+            last_date=last_date
+        )
     return data
 
 
@@ -285,7 +291,13 @@ def ensure_treasury_data(symbol, first_date, last_date, now, environ=None):
     except (OSError, IOError, HTTPError):
         logger.exception('failed to cache treasury data')
     if not has_data_for_dates(data, first_date, last_date):
-        logger.warn("Still don't have expected treasury data after redownload!")
+        logger.warn(
+            ("Still don't have expected treasury data for {symbol!r} "
+                "from {first_date} to {last_date} after redownload!"),
+            symbol=symbol,
+            first_date=first_date,
+            last_date=last_date
+        )
     return data
 
 


### PR DESCRIPTION
The core of data/loader.py is the function load_market_data which
in turns calls functions ensure_benchmark_data and
ensure_treasury_data. These two functions are similar. Their
logger.info and logger.exception messages are slightly different
but their logger.warn messages are the same.

Having two different functions outputing the same warning can
be needlessly confusing when debugging.

This commit makes these two warnings explicitely different.