### PR TITLE
ENH: --force-redownload optional parameter.

### DIFF
--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -178,6 +178,13 @@ def ipython_only(option):
     default=False,
     help='Print the algorithm to stdout.',
 )
+@click.option(
+    '--force-redownload',
+    is_flag=True,
+    default=False,
+    help='Loading market data has a cooldown of 1 hour. If '
+    '--force-redownload is set to True, redownloading will be forced',
+)
 @ipython_only(click.option(
     '--local-namespace/--no-local-namespace',
     is_flag=True,
@@ -197,7 +204,8 @@ def run(ctx,
         end,
         output,
         print_algo,
-        local_namespace):
+        local_namespace,
+        force_redownload=False):
     """Run a backtest for the given algorithm.
     """
     # check that the start and end dates are passed correctly
@@ -238,6 +246,7 @@ def run(ctx,
         print_algo=print_algo,
         local_namespace=local_namespace,
         environ=os.environ,
+        force_redownload=force_redownload,
     )
 
     if output == '-':

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -84,6 +84,7 @@ class TradingEnvironment(object):
         asset_db_path=':memory:',
         future_chain_predicates=CHAIN_PREDICATES,
         environ=None,
+        force_redownload=False,
     ):
 
         self.bm_symbol = bm_symbol
@@ -97,6 +98,7 @@ class TradingEnvironment(object):
             trading_calendar.day,
             trading_calendar.schedule.index,
             self.bm_symbol,
+            force_redownload=force_redownload,
         )
 
         self.exchange_tz = exchange_tz

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -63,7 +63,8 @@ def _run(handle_data,
          output,
          print_algo,
          local_namespace,
-         environ):
+         environ,
+         force_redownload=False):
     """Run a backtest for the given algorithm.
 
     This is shared between the cli and :func:`zipline.run_algo`.
@@ -129,7 +130,8 @@ def _run(handle_data,
                 "invalid url %r, must begin with 'sqlite:///'" %
                 str(bundle_data.asset_finder.engine.url),
             )
-        env = TradingEnvironment(asset_db_path=connstr, environ=environ)
+        env = TradingEnvironment(asset_db_path=connstr, environ=environ,
+                                 force_redownload=force_redownload)
         first_trading_day =\
             bundle_data.equity_minute_bar_reader.first_trading_day
         data = DataPortal(
@@ -152,7 +154,8 @@ def _run(handle_data,
                 "No PipelineLoader registered for column %s." % column
             )
     else:
-        env = TradingEnvironment(environ=environ)
+        env = TradingEnvironment(environ=environ,
+                                 force_redownload=force_redownload)
         choose_loader = None
 
     perf = TradingAlgorithm(
@@ -358,4 +361,5 @@ def run_algorithm(start,
         print_algo=False,
         local_namespace=False,
         environ=environ,
+        force_redownload=False,
     )


### PR DESCRIPTION
zipline run calls function load_market_data. This function has a
cooldown of 1 hour. If it downloaded data less than 1 hour ago it won't
download again.

This has an inconvenient side-effect: if zipline run is executed,
data is not cached, data is downloaded but for some reason data is
still not present after download (like what happens with issue #1965),
and if then the issue is fixed, zipline run can still not be executed until
the cooldown time has expired. This can then lead users to open
new issues which seem related to the original one, but are not (see
for example issue #1957 and discussion therein).

This commit adds an optional --force-redownload flag to zipline run.
The default is set to false.