### PR TITLE
ENH: Fix Pandas 0.19.2 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,13 @@ env:
     #   See https://docs.travis-ci.com/api#external-apis.
     - secure: "W2tTHoZYLuEjoIMI/K3adv7QW7yx4iVOIkVOn73jUkv3IlyZZ+BraL0hBw5Dh/iBA9PnO1qOKeRFLDDfDza/1S+2QxZMBmJ8HAkcZehbtTPdCgn/+CYSlauUlJ2izxgnXFw49qJDllQWtwsK2PEuvHrir6wbdElkXKvIJoD7jQ4="
     - CONDA_ROOT_PYTHON_VERSION: "2.7"
-  matrix:
-    - NUMPY_VERSION=1.11.1 SCIPY_VERSION=0.17.1
+    - NUMPY_VERSION=1.11.1
+    - PANDAS_VERSION=0.18.1
+    - SCIPY_VERSION=0.17.1
+matrix:
+  include:
+    - python: 3.5
+      env: PANDAS_VERSION=0.19.2
 cache:
   directories:
     - $HOME/.cache/.pip/
@@ -29,6 +34,10 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
+  - sed -i "s/numpy==.*/numpy==$NUMPY_VERSION/" etc/requirements.txt
+  - sed -i "s/pandas==.*/pandas==$PANDAS_VERSION/" etc/requirements.txt
+  - sed -i "s/scipy==.*/scipy==$SCIPY_VERSION/" etc/requirements.txt
+  - cat etc/requirements.txt
 install:
   - conda info -a
   - conda install conda=4.3.25 conda-build=3.0.15 anaconda-client=1.6.3 --yes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,12 @@ environment:
       NUMPY_VERSION: "1.11.1"
       SCIPY_VERSION: "0.17.1"
 
+    - PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+      PANDAS_VERSION: "0.19.2"
+      NUMPY_VERSION: "1.11.1"
+      SCIPY_VERSION: "0.17.1"
+
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).
 platform:

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def _filter_requirements(lines_iter, filter_names=None,
 
 REQ_UPPER_BOUNDS = {
     'bcolz': '<1',
-    'pandas': '<0.19',
+    'pandas': '<0.20',
 }
 
 

--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -15,7 +15,6 @@ import numpy as np
 from numpy.testing.utils import assert_array_almost_equal
 from odo import odo
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
 from toolz import keymap, valmap, concatv
 from toolz.curried import operator as op
 
@@ -39,7 +38,11 @@ from zipline.testing import (
     tmp_asset_finder,
 )
 from zipline.testing.fixtures import WithAssetFinder
-from zipline.testing.predicates import assert_equal, assert_isidentical
+from zipline.testing.predicates import (
+    assert_equal,
+    assert_frame_equal,
+    assert_isidentical,
+)
 from zipline.utils.numpy_utils import float64_dtype, int64_dtype
 from zipline.utils.pandas_utils import empty_dataframe
 
@@ -779,6 +782,7 @@ class BlazeToPipelineTestCase(WithAssetFinder, ZiplineTestCase):
             result.sort_index(axis=1),
             _utc_localize_index_level_0(expected.sort_index(axis=1)),
             check_dtype=False,
+            check_categorical=False,
         )
 
     def _test_id_macro(self, df, dshape, expected, finder, add, dates=None):

--- a/tests/pipeline/test_events.py
+++ b/tests/pipeline/test_events.py
@@ -346,7 +346,7 @@ class EventsLoaderEmptyTestCase(WithAssetFinder,
             columns=EventDataSet.columns,
         )
 
-        assert_equal(results, expected)
+        assert_equal(results, expected, check_categorical=False)
 
 
 class EventsLoaderTestCase(WithAssetFinder,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -2294,6 +2294,7 @@ def handle_data(context, data):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
 
             algo = TradingAlgorithm(
                 script=algocode,

--- a/tests/test_api_shim.py
+++ b/tests/test_api_shim.py
@@ -314,6 +314,7 @@ class TestAPIShim(WithCreateBarData,
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
             algo = self.create_algo(sid_accessor_algo)
             algo.run(self.data_portal)
@@ -343,6 +344,7 @@ class TestAPIShim(WithCreateBarData,
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
             algo = self.create_algo(data_items_algo)
             algo.run(self.data_portal)
@@ -368,6 +370,7 @@ class TestAPIShim(WithCreateBarData,
     def test_iterate_data(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
             algo = self.create_algo(simple_algo)
@@ -399,6 +402,7 @@ class TestAPIShim(WithCreateBarData,
     def test_history(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
             sim_params = self.sim_params.create_new(
@@ -441,6 +445,7 @@ class TestAPIShim(WithCreateBarData,
     def test_simple_transforms(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
             sim_params = SimulationParameters(
@@ -512,6 +517,7 @@ class TestAPIShim(WithCreateBarData,
     def test_manipulation(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("ignore", PerformanceWarning)
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
             algo = self.create_algo(simple_algo)
@@ -534,6 +540,7 @@ class TestAPIShim(WithCreateBarData,
 
     def test_reference_empty_position_by_int(self):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
             algo = self.create_algo(reference_missing_position_by_int_algo)
@@ -548,6 +555,7 @@ class TestAPIShim(WithCreateBarData,
 
     def test_reference_empty_position_by_unexpected_type(self):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("default", ZiplineDeprecationWarning)
 
             algo = self.create_algo(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,7 +17,6 @@ import tarfile
 
 import matplotlib
 from nose_parameterized import parameterized
-import pandas as pd
 
 from zipline import examples
 from zipline.data.bundles import register, unregister
@@ -48,10 +47,7 @@ class ExamplesTests(WithTmpDir, ZiplineTestCase):
             tar.extractall(cls.tmpdir.path)
 
         cls.expected_perf = dataframe_cache(
-            cls.tmpdir.getpath(
-                'example_data/expected_perf/%s' %
-                pd.__version__.replace('.', '-'),
-            ),
+            cls.tmpdir.getpath('example_data/expected_perf/0-18-1'),
             serialization='pickle',
         )
 


### PR DESCRIPTION
Pandas 0.19 [fixes some issues with Python 3.6 compatibility](https://github.com/pandas-dev/pandas/issues?q=label%3A%22Python+3.6%22+is%3Aclosed). It also adds new features and performance improvements. 0.19 is already 1 year old, so I guess it is already well-tested.

Note:

- Had to add an ugly fix in `tests/test_examples.py` as I was not able to `rebuild_example_data`. Guess #1965 is related.
- Not sure the `check_categorical=False` is the best way to fix the tests. But I think a better fix would require deeper work (i.e.: remove the use of `None`/`NaN` in categorical data, as Pandas already warns about its future deprecation).