### PR TITLE
DEP: Avoid float type index (expected int)

### DIFF
--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -536,7 +536,7 @@ class ExchangeCalendarTestBase(object):
         # pick two sessions
         session_count = len(self.calendar.schedule.index)
 
-        first_idx = session_count / 3
+        first_idx = session_count // 3
         second_idx = 2 * first_idx
 
         first_session_label = self.calendar.schedule.index[first_idx]

--- a/tests/pipeline/test_events.py
+++ b/tests/pipeline/test_events.py
@@ -437,7 +437,7 @@ class EventsLoaderTestCase(WithAssetFinder,
         # is not in our window. The results should be computed the same as if
         # we had computed across the entire window and then sliced after the
         # computation.
-        dates = self.trading_days[len(self.trading_days) / 2:]
+        dates = self.trading_days[len(self.trading_days) // 2:]
         results = engine.run_pipeline(
             Pipeline({c.name: c.latest for c in EventDataSet.columns}),
             start_date=dates[0],


### PR DESCRIPTION
Using a non-integer number instead of an integer will result in an error in the future. Should not break backwards compatibility. Should remove related `VisibleDeprecationWarning` warnings.

Also, a step forward to allow upgrading Pandas version to >=0.19. (#1975)