### PR TITLE
ENH: Load futures from bundles.

### DIFF
--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -104,8 +104,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
         @self.register('bundle', create_writers=False)
         def bundle_ingest(environ,
                           asset_db_writer,
-                          minute_bar_writer,
-                          daily_bar_writer,
+                          equities_minute_bar_writer,
+                          equities_daily_bar_writer,
+                          futures_minute_bar_writer,
+                          futures_daily_bar_writer,
                           adjustment_writer,
                           calendar,
                           start_session,
@@ -114,8 +116,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
                           show_progress,
                           output_dir):
             assert_is_none(asset_db_writer)
-            assert_is_none(minute_bar_writer)
-            assert_is_none(daily_bar_writer)
+            assert_is_none(equities_minute_bar_writer)
+            assert_is_none(equities_daily_bar_writer)
+            assert_is_none(futures_minute_bar_writer)
+            assert_is_none(futures_daily_bar_writer)
             assert_is_none(adjustment_writer)
             called[0] = True
 
@@ -161,8 +165,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
         )
         def bundle_ingest(environ,
                           asset_db_writer,
-                          minute_bar_writer,
-                          daily_bar_writer,
+                          equities_minute_bar_writer,
+                          equities_daily_bar_writer,
+                          futures_minute_bar_writer,
+                          futures_daily_bar_writer,
                           adjustment_writer,
                           calendar,
                           start_session,
@@ -173,8 +179,8 @@ class BundleCoreTestCase(WithInstanceTmpDir,
             assert_is(environ, self.environ)
 
             asset_db_writer.write(equities=equities)
-            minute_bar_writer.write(minute_bar_data)
-            daily_bar_writer.write(daily_bar_data)
+            equities_minute_bar_writer.write(minute_bar_data)
+            equities_daily_bar_writer.write(daily_bar_data)
             adjustment_writer.write(splits=splits)
 
             assert_is_instance(calendar, TradingCalendar)
@@ -285,8 +291,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
         def bundle_ingest_create_writers(
                 environ,
                 asset_db_writer,
-                minute_bar_writer,
-                daily_bar_writer,
+                equities_minute_bar_writer,
+                equities_daily_bar_writer,
+                futures_minute_bar_writer,
+                futures_daily_bar_writer,
                 adjustment_writer,
                 calendar,
                 start_session,
@@ -295,8 +303,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
                 show_progress,
                 output_dir):
             self.assertIsNotNone(asset_db_writer)
-            self.assertIsNotNone(minute_bar_writer)
-            self.assertIsNotNone(daily_bar_writer)
+            self.assertIsNotNone(equities_minute_bar_writer)
+            self.assertIsNotNone(equities_daily_bar_writer)
+            self.assertIsNotNone(futures_minute_bar_writer)
+            self.assertIsNotNone(futures_daily_bar_writer)
             self.assertIsNotNone(adjustment_writer)
 
             equities = make_simple_equity_info(
@@ -374,8 +384,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
                            end_session=pd.Timestamp('2014', tz='UTC'))
             def _(environ,
                   asset_db_writer,
-                  minute_bar_writer,
-                  daily_bar_writer,
+                  equities_minute_bar_writer,
+                  equities_daily_bar_writer,
+                  futures_minute_bar_writer,
+                  futures_daily_bar_writer,
                   adjustment_writer,
                   calendar,
                   start_session,

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -145,6 +145,7 @@ RegisteredBundle = namedtuple(
 BundleData = namedtuple(
     'BundleData',
     'asset_finder equity_minute_bar_reader equity_daily_bar_reader '
+    'future_minute_bar_reader future_daily_bar_reader '
     'adjustment_reader',
 )
 
@@ -527,6 +528,12 @@ def _make_bundle_core():
                 minute_equity_path(name, timestr, environ=environ),
             ),
             equity_daily_bar_reader=BcolzDailyBarReader(
+                daily_equity_path(name, timestr, environ=environ),
+            ),
+            future_minute_bar_reader=BcolzMinuteBarReader(
+                minute_equity_path(name, timestr, environ=environ),
+            ),
+            future_daily_bar_reader=BcolzDailyBarReader(
                 daily_equity_path(name, timestr, environ=environ),
             ),
             adjustment_reader=SQLiteAdjustmentReader(

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -56,14 +56,14 @@ def daily_equity_path(bundle_name, timestr, environ=None):
 
 def minute_future_path(bundle_name, timestr, environ=None):
     return pth.data_path(
-        minute_equity_relative(bundle_name, timestr, environ),
+        minute_future_relative(bundle_name, timestr, environ),
         environ=environ,
     )
 
 
 def daily_future_path(bundle_name, timestr, environ=None):
     return pth.data_path(
-        daily_equity_relative(bundle_name, timestr, environ),
+        daily_future_relative(bundle_name, timestr, environ),
         environ=environ,
     )
 
@@ -575,10 +575,10 @@ def _make_bundle_core():
                 daily_equity_path(name, timestr, environ=environ),
             ),
             future_minute_bar_reader=BcolzMinuteBarReader(
-                minute_equity_path(name, timestr, environ=environ),
+                minute_future_path(name, timestr, environ=environ),
             ),
             future_daily_bar_reader=BcolzDailyBarReader(
-                daily_equity_path(name, timestr, environ=environ),
+                daily_future_path(name, timestr, environ=environ),
             ),
             adjustment_reader=SQLiteAdjustmentReader(
                 adjustment_db_path(name, timestr, environ=environ),

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -437,14 +437,13 @@ def _make_bundle_core():
                     end_session,
                     minutes_per_day=bundle.minutes_per_day,
                 )
-                futures_minute_bar_writer = BcolzMinuteBarWriter(
+                futures_daily_bar_writer = BcolzDailyBarWriter(
                     wd.ensure_dir(*daily_future_relative(
                         name, timestr, environ=environ)
                     ),
                     calendar,
                     start_session,
                     end_session,
-                    minutes_per_day=bundle.minutes_per_day,
                 )
                 futures_minute_bar_writer = BcolzMinuteBarWriter(
                     wd.ensure_dir(*minute_future_relative(

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -277,8 +277,10 @@ def gen_symbol_data(api_key,
 @bundles.register('quandl')
 def quandl_bundle(environ,
                   asset_db_writer,
-                  minute_bar_writer,
-                  daily_bar_writer,
+                  equities_minute_bar_writer,
+                  equities_daily_bar_writer,
+                  futures_minute_bar_writer,
+                  futures_daily_bar_writer,
                   adjustment_writer,
                   calendar,
                   start_session,
@@ -301,7 +303,7 @@ def quandl_bundle(environ,
     dividends = []
 
     asset_db_writer.write(metadata)
-    daily_bar_writer.write(
+    equities_daily_bar_writer.write(
         gen_symbol_data(
             api_key,
             cache,
@@ -382,8 +384,10 @@ ONE_MEGABYTE = 1024 * 1024
 @bundles.register('quantopian-quandl', create_writers=False)
 def quantopian_quandl_bundle(environ,
                              asset_db_writer,
-                             minute_bar_writer,
-                             daily_bar_writer,
+                             equities_minute_bar_writer,
+                             equities_daily_bar_writer,
+                             futures_minute_bar_writer,
+                             futures_daily_bar_writer,
                              adjustment_writer,
                              calendar,
                              start_session,

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -138,6 +138,8 @@ def _run(handle_data,
             first_trading_day=first_trading_day,
             equity_minute_reader=bundle_data.equity_minute_bar_reader,
             equity_daily_reader=bundle_data.equity_daily_bar_reader,
+            future_minute_reader=bundle_data.future_minute_bar_reader,
+            future_daily_reader=bundle_data.future_daily_bar_reader,
             adjustment_reader=bundle_data.adjustment_reader,
         )
 


### PR DESCRIPTION
Currently only equities can be loaded from bundles. There are at least two
reasons for this. First, on write `zipline/data/bundles/core.py` ingest()
does not distinguish between equities and futures; instead all ingestions
are made into folders `daily_equities.bcolz` and `minute_equities.bcolz`.
Second, on read only equities readers are being passed into DataPortal.

This commit addresses the second issue.

This works well for data bundles containing futures exclusively. It does
not fix the bigger issue of supporting bundles which contain both equities
and futures.