### PR TITLE
Mark slow tests

### DIFF
--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -34,6 +34,7 @@ from zipline.errors import (
     InvalidCalendarName,
 )
 
+from zipline.testing import slow
 from zipline.testing.predicates import assert_equal
 from zipline.utils.calendars import (
     deregister_calendar,
@@ -264,6 +265,7 @@ class ExchangeCalendarTestBase(object):
             prev_close_answer
         )
 
+    @slow
     def test_next_prev_open_close(self):
         # for each session, check:
         # - the minute before the open (if gaps exist between sessions)
@@ -358,6 +360,7 @@ class ExchangeCalendarTestBase(object):
                     self.calendar.previous_minute(hour_after_close)
                 )
 
+    @slow
     def test_minute_to_session_label(self):
         for idx, info in enumerate(self.answers[1:-2].iterrows()):
             session_label = info[1].name
@@ -452,6 +455,7 @@ class ExchangeCalendarTestBase(object):
         (2, 0),
         (2, 1),
     ])
+    @slow
     def test_minute_index_to_session_labels(self, interval, offset):
         minutes = self.calendar.minutes_for_sessions_in_range(
             pd.Timestamp('2011-01-04', tz='UTC'),
@@ -664,6 +668,7 @@ class ExchangeCalendarTestBase(object):
         self.assertEqual(2, self.calendar.session_distance(sessions[0],
                                                            sessions[-1]))
 
+    @slow
     def test_open_and_close_for_session(self):
         for index, row in self.answers.iterrows():
             session_label = row.name

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -75,6 +75,7 @@ from zipline.testing import (
     OpenPrice,
     parameter_space,
     product_upper_triangle,
+    slow,
 )
 from zipline.testing.fixtures import (
     WithAdjustmentReader,
@@ -839,6 +840,7 @@ class FrameInputTestCase(WithTradingEnvironment, ZiplineTestCase):
     def make_frame(self, data):
         return DataFrame(data, columns=self.assets, index=self.dates)
 
+    @slow
     def test_compute_with_adjustments(self):
         dates, asset_ids = self.dates, self.asset_ids
         low, high = USEquityPricing.low, USEquityPricing.high

--- a/tests/pipeline/test_events.py
+++ b/tests/pipeline/test_events.py
@@ -24,7 +24,7 @@ from zipline.pipeline.loaders.utils import (
     normalize_timestamp_to_query_time,
     previous_event_indexer,
 )
-from zipline.testing import check_arrays, ZiplineTestCase
+from zipline.testing import check_arrays, slow, ZiplineTestCase
 from zipline.testing.fixtures import (
     WithAssetFinder,
     WithTradingSessions,
@@ -645,6 +645,7 @@ class EventLoaderUtilsTestCase(ZiplineTestCase):
     # Test with timezones on either side of the meridian
     @parameterized.expand([(expected_us, 'US/Eastern', us_dates),
                            (expected_russia, 'Europe/Moscow', moscow_dates)])
+    @slow
     def test_normalize_to_query_time(self, expected, tz, dates):
         # Order matters in pandas 0.18.2. Prior to that, using tz_convert on
         # a DatetimeIndex with DST/EST timestamps mixed resulted in some of

--- a/tests/pipeline/test_events.py
+++ b/tests/pipeline/test_events.py
@@ -397,6 +397,7 @@ class EventsLoaderTestCase(WithAssetFinder,
         # This method exists to be overridden by BlazeEventsLoaderTestCase
         return EventsLoader(events, next_value_columns, previous_value_columns)
 
+    @slow
     def test_load_with_trading_calendar(self):
         engine = SimplePipelineEngine(
             lambda x: self.loader,
@@ -426,6 +427,7 @@ class EventsLoaderTestCase(WithAssetFinder,
             else:
                 raise AssertionError("Unexpected column %s." % c)
 
+    @slow
     def test_load_properly_forward_fills(self):
         engine = SimplePipelineEngine(
             lambda x: self.loader,

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -51,7 +51,7 @@ from zipline.pipeline.loaders.equity_pricing_loader import (
     USEquityPricingLoader,
 )
 from zipline.testing import (
-    str_to_seconds
+    slow, str_to_seconds,
 )
 from zipline.testing import (
     create_empty_splits_mergers_frame,
@@ -591,6 +591,7 @@ class PipelineAlgorithmTestCase(WithBcolzEquityDailyBarReaderFromCSVs,
         (True,),
         (False,),
     ])
+    @slow
     def test_handle_adjustment(self, set_screen):
         AAPL, MSFT, BRK_A = assets = self.assets
 

--- a/tests/pipeline/test_quarters_estimates.py
+++ b/tests/pipeline/test_quarters_estimates.py
@@ -1160,6 +1160,7 @@ class WithEstimateWindows(WithEstimates):
         cls.timelines = cls.make_expected_timelines()
 
     @parameterized.expand(window_test_cases)
+    @slow
     def test_estimate_windows_at_quarter_boundaries(self,
                                                     start_date,
                                                     num_announcements_out):
@@ -2452,6 +2453,7 @@ class WithAdjustmentBoundaries(WithEstimates):
                           sid_4_splits])
 
     @parameterized.expand(split_adjusted_asof_dates)
+    @slow
     def test_boundaries(self, split_date):
         dataset = QuartersEstimates(1)
         loader = self.loader(split_adjusted_asof=split_date)

--- a/tests/pipeline/test_quarters_estimates.py
+++ b/tests/pipeline/test_quarters_estimates.py
@@ -37,13 +37,17 @@ from zipline.pipeline.loaders.earnings_estimates import (
     PreviousSplitAdjustedEarningsEstimatesLoader,
     split_normalized_quarters,
 )
+from zipline.testing import slow
 from zipline.testing.fixtures import (
     WithAdjustmentReader,
     WithTradingSessions,
     ZiplineTestCase,
 )
-from zipline.testing.predicates import assert_equal, assert_raises_regex
-from zipline.testing.predicates import assert_frame_equal
+from zipline.testing.predicates import (
+    assert_equal,
+    assert_frame_equal,
+    assert_raises_regex,
+)
 from zipline.utils.numpy_utils import datetime64ns_dtype
 from zipline.utils.numpy_utils import float64_dtype
 
@@ -581,6 +585,7 @@ class WithEstimatesTimeZero(WithEstimates):
                               comparable_date):
         return pd.DataFrame()
 
+    @slow
     def test_estimates(self):
         dataset = QuartersEstimates(1)
         engine = SimplePipelineEngine(

--- a/zipline/testing/__init__.py
+++ b/zipline/testing/__init__.py
@@ -40,6 +40,7 @@ from .core import (  # noqa
     read_compressed,
     seconds_to_timestamp,
     security_list_copy,
+    slow,
     str_to_seconds,
     subtest,
     temp_pipeline_engine,

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -17,6 +17,7 @@ import tempfile
 from logbook import TestHandler
 from mock import patch
 from nose.tools import nottest
+from nose.plugins.attrib import attr
 from numpy.testing import assert_allclose, assert_array_equal
 import pandas as pd
 from six import itervalues, iteritems, with_metaclass
@@ -1573,3 +1574,7 @@ class OpenPrice(CustomFactor):
 
     def compute(self, today, assets, out, open):
         out[:] = open
+
+
+# Marker for skipping slow tests.
+slow = attr('slow')


### PR DESCRIPTION
Adds a marker that makes it easier to skip slow tests.  Slow tests are still run by default, but can be skipped by passing `-a '!slow'` to nosetests.

Currently the skipped tests take a total of around 30-40s, out of 280s
on my machine. Not sure if that's valuable enough to bother...