### PR TITLE
ENH: Add default index names to pipeline results

### DIFF
--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -4,12 +4,13 @@ Tests BoundColumn attributes and methods.
 from contextlib2 import ExitStack
 from unittest import TestCase
 
-from pandas import date_range, DataFrame
+from pandas import date_range, DataFrame, Index
 from pandas.util.testing import assert_frame_equal
 
 from zipline.lib.labelarray import LabelArray
 from zipline.pipeline import Pipeline
 from zipline.pipeline.data.testing import TestingDataSet as TDS
+from zipline.pipeline.engine import DATE_INDEX_NAME, SID_INDEX_NAME
 from zipline.testing import chrange, temp_pipeline_engine
 from zipline.utils.pandas_utils import ignore_pandas_nan_categorical_warning
 
@@ -39,7 +40,9 @@ class LatestTestCase(TestCase):
         loader = self.engine.get_loader(column)
 
         index = self.calendar[slice_]
-        columns = self.assets
+        index.name = DATE_INDEX_NAME
+        columns = Index(self.assets, name=SID_INDEX_NAME)
+
         values = loader.values(column.dtype, self.calendar, self.sids)[slice_]
 
         if column.dtype.kind in ('O', 'S', 'U'):
@@ -54,8 +57,8 @@ class LatestTestCase(TestCase):
 
         return DataFrame(
             loader.values(column.dtype, self.calendar, self.sids)[slice_],
-            index=self.calendar[slice_],
-            columns=self.assets,
+            index=index,
+            columns=columns,
         )
 
     def test_latest(self):

--- a/tests/pipeline/test_downsampling.py
+++ b/tests/pipeline/test_downsampling.py
@@ -15,6 +15,7 @@ from zipline.pipeline import (
     SimplePipelineEngine,
 )
 from zipline.pipeline.data.testing import TestingDataSet
+from zipline.pipeline.engine import PIPELINE_INDEX_NAMES
 from zipline.pipeline.factors import SimpleMovingAverage
 from zipline.pipeline.filters.smoothing import All
 from zipline.testing import ZiplineTestCase, parameter_space, ExplodingObject
@@ -609,7 +610,7 @@ class DownsampledPipelineTestCase(WithSeededRandomPipelineEngine,
         all_sessions = self.nyse_sessions
         compute_dates = all_sessions[
             all_sessions.slice_indexer('2014-06-05', '2015-01-06')
-        ]
+        ].set_names([PIPELINE_INDEX_NAMES[0]])
         start_date, end_date = compute_dates[[0, -1]]
 
         pipe = Pipeline({

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -26,6 +26,7 @@ from pandas import (
     Categorical,
     DataFrame,
     date_range,
+    Index,
     Int64Index,
     MultiIndex,
     Series,
@@ -43,7 +44,7 @@ from zipline.lib.labelarray import LabelArray
 from zipline.pipeline import CustomFactor, Pipeline
 from zipline.pipeline.data import Column, DataSet, USEquityPricing
 from zipline.pipeline.data.testing import TestingDataSet
-from zipline.pipeline.engine import SimplePipelineEngine
+from zipline.pipeline.engine import PIPELINE_INDEX_NAMES, SimplePipelineEngine
 from zipline.pipeline.factors import (
     AverageDollarVolume,
     EWMA,
@@ -197,6 +198,7 @@ class WithConstantInputs(WithTradingEnvironment):
             sids=cls.asset_ids,
         )
         cls.assets = cls.asset_finder.retrieve_all(cls.asset_ids)
+        cls.index_names = PIPELINE_INDEX_NAMES
 
 
 class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
@@ -292,7 +294,10 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
             expected_sids = asset_ids[asset_ids <= asset_id]
             expected_assets = finder.retrieve_all(expected_sids)
             expected_result = DataFrame(
-                index=MultiIndex.from_product([dates, expected_assets]),
+                index=MultiIndex.from_product(
+                    [dates, expected_assets],
+                    names=self.index_names,
+                ),
                 data=tile(expected_sids.astype(float), [len(dates)]),
                 columns=['f'],
             )
@@ -405,25 +410,28 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
             dates[-1],
         )
 
+        index = dates.set_names([self.index_names[0]])
+        columns = Index(self.assets, name=self.index_names[1])
+
         high_low_result = results['high_low'].unstack()
         expected_high_low = 3.0 * (constants[high] - constants[low])
         assert_frame_equal(
             high_low_result,
-            DataFrame(expected_high_low, index=dates, columns=self.assets),
+            DataFrame(expected_high_low, index=index, columns=columns),
         )
 
         open_close_result = results['open_close'].unstack()
         expected_open_close = 3.0 * (constants[open] - constants[close])
         assert_frame_equal(
             open_close_result,
-            DataFrame(expected_open_close, index=dates, columns=self.assets),
+            DataFrame(expected_open_close, index=index, columns=columns),
         )
 
         avg_result = results['avg'].unstack()
         expected_avg = (expected_high_low + expected_open_close) / 2.0
         assert_frame_equal(
             avg_result,
-            DataFrame(expected_avg, index=dates, columns=self.assets),
+            DataFrame(expected_avg, index=index, columns=columns),
         )
 
     def test_masked_factor(self):
@@ -452,7 +460,11 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
 
         def create_expected_results(expected_value, mask):
             expected_values = where(mask, expected_value, nan)
-            return DataFrame(expected_values, index=dates, columns=assets)
+            return DataFrame(
+                expected_values,
+                index=dates.set_names([self.index_names[0]]),
+                columns=Index(assets, name=self.index_names[1]),
+            )
 
         cascading_mask = AssetIDPlusDay() < (asset_ids[-1] + dates[0].day)
         expected_cascading_mask_result = make_cascading_boolean_array(
@@ -597,7 +609,10 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
                 ('open_attribute', open_attribute_expected)):
             column_results = results[colname].unstack()
             expected_results = DataFrame(
-                expected_values, index=dates, columns=assets, dtype=float64,
+                expected_values,
+                index=dates.set_names([self.index_names[0]]),
+                columns=Index(assets, name=self.index_names[1]),
+                dtype=float64,
             )
             assert_frame_equal(column_results, expected_results)
 
@@ -616,7 +631,11 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
 
         def create_expected_results(expected_value, mask):
             expected_values = where(mask, expected_value, nan)
-            return DataFrame(expected_values, index=dates, columns=assets)
+            return DataFrame(
+                expected_values,
+                index=dates.set_names([self.index_names[0]]),
+                columns=Index(assets, name=self.index_names[1]),
+            )
 
         cascading_mask = AssetIDPlusDay() < (asset_ids[-1] + dates[0].day)
         expected_cascading_mask_result = make_cascading_boolean_array(
@@ -677,7 +696,10 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
         close_values = [constants[USEquityPricing.close]] * num_assets
         expected_values = [list(zip(open_values, close_values))] * num_dates
         expected_results = DataFrame(
-            expected_values, index=dates, columns=assets, dtype=float64,
+            expected_values,
+            index=dates.set_names([self.index_names[0]]),
+            columns=Index(assets, name=self.index_names[1]),
+            dtype=float64,
         )
 
         multiple_outputs = MultipleOutputs()
@@ -700,7 +722,11 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
             expected_values = full(
                 (num_dates, num_assets), expected_value, float64,
             )
-            return DataFrame(expected_values, index=dates, columns=assets)
+            return DataFrame(
+                expected_values,
+                index=dates.set_names([self.index_names[0]]),
+                columns=Index(assets, name=self.index_names[1]),
+            )
 
         for window_length in range(1, 3):
             sum_, diff = OpenCloseSumAndDiff(
@@ -782,7 +808,10 @@ class ConstantInputTestCase(WithConstantInputs, ZiplineTestCase):
                        * pipe_col.window_length)
                 for name, pipe_col in iteritems(columns)}
 
-        index = MultiIndex.from_product([self.dates[2:], self.assets])
+        index = MultiIndex.from_product(
+            [self.dates[2:], self.assets],
+            names=self.index_names
+        )
 
         def expected_for_col(col):
             val = vals[col]
@@ -837,7 +866,11 @@ class FrameInputTestCase(WithTradingEnvironment, ZiplineTestCase):
         return self.make_frame(True)
 
     def make_frame(self, data):
-        return DataFrame(data, columns=self.assets, index=self.dates)
+        return DataFrame(
+            data,
+            index=Index(self.dates, name=PIPELINE_INDEX_NAMES[0]),
+            columns=Index(self.assets, name=PIPELINE_INDEX_NAMES[1]),
+        )
 
     def test_compute_with_adjustments(self):
         dates, asset_ids = self.dates, self.asset_ids
@@ -953,6 +986,7 @@ class SyntheticBcolzTestCase(WithAdjustmentReader,
             cls.bcolz_equity_daily_bar_reader,
             cls.adjustment_reader,
         )
+        cls.index_names = PIPELINE_INDEX_NAMES
 
     def write_nans(self, df):
         """
@@ -1024,11 +1058,17 @@ class SyntheticBcolzTestCase(WithAdjustmentReader,
         ).mean(
         ).values
 
+        # dates_to_test is dates[window_length:]
+        expected_index = dates_to_test.set_names([self.index_names[0]])
+        expected_columns = Index(
+            self.asset_finder.retrieve_all(asset_ids),
+            name=self.index_names[1]
+        )
         expected = DataFrame(
             # Truncate off the extra rows needed to compute the SMAs.
             expected_raw[window_length:],
-            index=dates_to_test,  # dates_to_test is dates[window_length:]
-            columns=self.asset_finder.retrieve_all(asset_ids),
+            index=expected_index,
+            columns=expected_columns,
         )
         self.write_nans(expected)
         result = results['sma'].unstack()
@@ -1065,12 +1105,17 @@ class SyntheticBcolzTestCase(WithAdjustmentReader,
             dates_to_test[-1],
         )
 
+        expected_index = dates_to_test.set_names([self.index_names[0]])
+        expected_columns = Index(
+            self.asset_finder.retrieve_all(asset_ids),
+            name=self.index_names[1]
+        )
         # We expect NaNs when the asset was undefined, otherwise 0 everywhere,
         # since the input is always increasing.
         expected = DataFrame(
             data=zeros((len(dates_to_test), len(asset_ids)), dtype=float),
-            index=dates_to_test,
-            columns=self.asset_finder.retrieve_all(asset_ids),
+            index=expected_index,
+            columns=expected_columns,
         )
         self.write_nans(expected)
         result = results['drawdown'].unstack()
@@ -1100,8 +1145,11 @@ class ParameterizedFactorTestCase(WithTradingEnvironment, ZiplineTestCase):
             data=arange(len(dates) * len(sids), dtype=float).reshape(
                 len(dates), len(sids),
             ),
-            index=dates,
-            columns=cls.asset_finder.retrieve_all(sids),
+            index=dates.set_names([PIPELINE_INDEX_NAMES[0]]),
+            columns=Index(
+                cls.asset_finder.retrieve_all(sids),
+                name=PIPELINE_INDEX_NAMES[1],
+            ),
         )
         cls.raw_data_with_nans = cls.raw_data.where((cls.raw_data % 2) != 0)
 
@@ -1318,9 +1366,14 @@ class StringColumnTestCase(WithSeededRandomPipelineEngine,
             end_date,
         )
         expected_labels = LabelArray(expected_raw_data, col.missing_value)
+        expected_index = run_dates.set_names([PIPELINE_INDEX_NAMES[0]])
+        expected_columns = Index(
+            self.asset_finder.retrieve_all(self.asset_finder.sids),
+            name=PIPELINE_INDEX_NAMES[1],
+        )
         expected_final_result = expected_labels.as_categorical_frame(
-            index=run_dates,
-            columns=self.asset_finder.retrieve_all(self.asset_finder.sids),
+            index=expected_index,
+            columns=expected_columns,
         )
         assert_frame_equal(result.c.unstack(), expected_final_result)
 
@@ -1353,16 +1406,18 @@ class WindowSafetyPropagationTestCase(WithSeededRandomPipelineEngine,
         )
         results = self.run_pipeline(pipe, start_date, end_date).unstack()
 
+        expected_columns = Index(
+            self.asset_finder.retrieve_all(self.ASSET_FINDER_EQUITY_SIDS),
+            name=PIPELINE_INDEX_NAMES[1],
+        )
         expected_ranks = DataFrame(
             self.raw_expected_values(
                 col,
                 dates[-19],
                 dates[-1],
             ),
-            index=dates[-19:],
-            columns=self.asset_finder.retrieve_all(
-                self.ASSET_FINDER_EQUITY_SIDS,
-            )
+            index=dates[-19:].set_names([PIPELINE_INDEX_NAMES[0]]),
+            columns=expected_columns,
         ).rank(axis='columns')
 
         # All three expressions should be equivalent and evaluate to this.

--- a/tests/pipeline/test_events.py
+++ b/tests/pipeline/test_events.py
@@ -17,6 +17,7 @@ from zipline.pipeline.common import (
     SID_FIELD_NAME,
 )
 from zipline.pipeline.data import DataSet, Column
+from zipline.pipeline.engine import PIPELINE_INDEX_NAMES
 from zipline.pipeline.loaders.events import EventsLoader
 from zipline.pipeline.loaders.blaze.events import BlazeEventsLoader
 from zipline.pipeline.loaders.utils import (
@@ -342,7 +343,10 @@ class EventsLoaderEmptyTestCase(WithAssetFinder,
         dates = self.trading_days
 
         expected = self.frame_containing_all_missing_values(
-            index=pd.MultiIndex.from_product([dates, assets]),
+            index=pd.MultiIndex.from_product(
+                [dates, assets],
+                names=PIPELINE_INDEX_NAMES,
+            ),
             columns=EventDataSet.columns,
         )
 

--- a/tests/pipeline/test_statistical.py
+++ b/tests/pipeline/test_statistical.py
@@ -11,6 +11,7 @@ from numpy import (
 from pandas import (
     DataFrame,
     date_range,
+    Index,
     Int64Index,
     Timestamp,
 )
@@ -22,7 +23,7 @@ from zipline.errors import IncompatibleTerms, NonExistentAssetInTimeFrame
 from zipline.pipeline import CustomFactor, Pipeline
 from zipline.pipeline.data import USEquityPricing
 from zipline.pipeline.data.testing import TestingDataSet
-from zipline.pipeline.engine import SimplePipelineEngine
+from zipline.pipeline.engine import PIPELINE_INDEX_NAMES, SimplePipelineEngine
 from zipline.pipeline.factors import (
     Returns,
     RollingLinearRegressionOfReturns,
@@ -55,6 +56,7 @@ class StatisticalBuiltInsTestCase(WithTradingEnvironment, ZiplineTestCase):
     sids = ASSET_FINDER_EQUITY_SIDS = Int64Index([1, 2, 3])
     START_DATE = Timestamp('2015-01-31', tz='UTC')
     END_DATE = Timestamp('2015-03-01', tz='UTC')
+    index_names = PIPELINE_INDEX_NAMES
 
     @classmethod
     def init_class_fixtures(cls):
@@ -198,17 +200,20 @@ class StatisticalBuiltInsTestCase(WithTradingEnvironment, ZiplineTestCase):
                         my_asset_returns, other_asset_returns,
                     )[0]
 
+            expected_index = dates[start_date_index:
+                end_date_index + 1].set_names([self.index_names[0]])
+            expected_columns = Index(assets, name=self.index_names[1])
             expected_pearson_results = DataFrame(
                 data=where(expected_mask, expected_pearson_results, nan),
-                index=dates[start_date_index:end_date_index + 1],
-                columns=assets,
+                index=expected_index,
+                columns=expected_columns,
             )
             assert_frame_equal(pearson_results, expected_pearson_results)
 
             expected_spearman_results = DataFrame(
                 data=where(expected_mask, expected_spearman_results, nan),
-                index=dates[start_date_index:end_date_index + 1],
-                columns=assets,
+                index=expected_index,
+                columns=expected_columns,
             )
             assert_frame_equal(spearman_results, expected_spearman_results)
 
@@ -299,12 +304,15 @@ class StatisticalBuiltInsTestCase(WithTradingEnvironment, ZiplineTestCase):
                         expected_output_results[output][day, asset_column] = \
                             expected_regression_results[i]
 
+            expected_index = dates[start_date_index:
+                end_date_index + 1].set_names(self.index_names[0])
+            expected_columns = Index(assets, name=self.index_names[1])
             for output in outputs:
                 output_result = output_results[output]
                 expected_output_result = DataFrame(
                     where(expected_mask, expected_output_results[output], nan),
-                    index=dates[start_date_index:end_date_index + 1],
-                    columns=assets,
+                    index=expected_index,
+                    columns=expected_columns,
                 )
                 assert_frame_equal(output_result, expected_output_result)
 
@@ -392,6 +400,7 @@ class StatisticalMethodsTestCase(WithSeededRandomPipelineEngine,
     sids = ASSET_FINDER_EQUITY_SIDS = Int64Index([1, 2, 3])
     START_DATE = Timestamp('2015-01-31', tz='UTC')
     END_DATE = Timestamp('2015-03-01', tz='UTC')
+    index_names = PIPELINE_INDEX_NAMES
 
     @classmethod
     def init_class_fixtures(cls):
@@ -692,17 +701,22 @@ class StatisticalMethodsTestCase(WithSeededRandomPipelineEngine,
                     asset_returns_5, asset_returns_10,
                 )[0]
 
+        expected_index = dates[start_date_index:end_date_index + 1].set_names(
+            self.index_names[0]
+        )
+        expected_columns = Index(assets, name=self.index_names[1])
+
         expected_pearson_results = DataFrame(
             data=expected_pearson_results,
-            index=dates[start_date_index:end_date_index + 1],
-            columns=assets,
+            index=expected_index,
+            columns=expected_columns,
         )
         assert_frame_equal(pearson_results, expected_pearson_results)
 
         expected_spearman_results = DataFrame(
             data=expected_spearman_results,
-            index=dates[start_date_index:end_date_index + 1],
-            columns=assets,
+            index=expected_index,
+            columns=expected_columns,
         )
         assert_frame_equal(spearman_results, expected_spearman_results)
 
@@ -794,11 +808,15 @@ class StatisticalMethodsTestCase(WithSeededRandomPipelineEngine,
                     expected_output_results[output][day, asset_column] = \
                         expected_regression_results[i]
 
+        expected_index = dates[start_date_index:end_date_index + 1].set_names(
+            [self.index_names[0]]
+        )
+        expected_columns = Index(assets, name=self.index_names[1])
         for output in outputs:
             output_result = output_results[output]
             expected_output_result = DataFrame(
                 expected_output_results[output],
-                index=dates[start_date_index:end_date_index + 1],
-                columns=assets,
+                index=expected_index,
+                columns=expected_columns,
             )
             assert_frame_equal(output_result, expected_output_result)

--- a/zipline/lib/labelarray.py
+++ b/zipline/lib/labelarray.py
@@ -359,7 +359,13 @@ class LabelArray(ndarray):
             )
 
         return pd.Series(
-            index=pd.MultiIndex.from_product([index, columns]),
+            index=pd.MultiIndex.from_product(
+                [index, columns],
+                names=[
+                    getattr(index, 'name', None),
+                    getattr(columns, 'name', None)
+                ],
+            ),
             data=self.ravel().as_categorical(name=name),
         ).unstack()
 

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -32,6 +32,11 @@ from zipline.utils.pandas_utils import categorical_df_concat
 from zipline.utils.sharedoc import copydoc
 
 
+DATE_INDEX_NAME = 'dates'
+SID_INDEX_NAME = 'sid'
+PIPELINE_INDEX_NAMES = (DATE_INDEX_NAME, SID_INDEX_NAME)
+
+
 class PipelineEngine(with_metaclass(ABCMeta)):
 
     @abstractmethod
@@ -579,7 +584,10 @@ class SimplePipelineEngine(PipelineEngine):
                     name: array([], dtype=arr.dtype)
                     for name, arr in iteritems(data)
                 },
-                index=MultiIndex.from_arrays([empty_dates, empty_assets]),
+                index=MultiIndex.from_arrays(
+                    [empty_dates, empty_assets],
+                    names=PIPELINE_INDEX_NAMES,
+                ),
             )
 
         resolved_assets = array(self._finder.retrieve_all(assets))
@@ -597,7 +605,10 @@ class SimplePipelineEngine(PipelineEngine):
 
         return DataFrame(
             data=final_columns,
-            index=MultiIndex.from_arrays([dates_kept, assets_kept]),
+            index=MultiIndex.from_arrays(
+                [dates_kept, assets_kept],
+                names=PIPELINE_INDEX_NAMES,
+            ),
         ).tz_localize('UTC', level=0)
 
     def _validate_compute_chunk_params(self, dates, assets, initial_workspace):


### PR DESCRIPTION
Improve legibility of pipeline result manipulations by adding names to the multi-index.