### PR TITLE
ENH: Fail better on AssetFinder(nonexistent_path).

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -19,6 +19,7 @@ Tests for the zipline.assets package
 from contextlib import contextmanager
 from datetime import timedelta
 from functools import partial
+import os
 import pickle
 import sys
 from types import GetSetDescriptorType
@@ -82,6 +83,7 @@ from zipline.testing.fixtures import (
     WithAssetFinder,
     ZiplineTestCase,
     WithTradingCalendars,
+    WithTmpDir,
 )
 from zipline.utils.range import range
 
@@ -1585,3 +1587,18 @@ class TestVectorizedSymbolLookup(WithAssetFinder, ZiplineTestCase):
             results,
             [af.lookup_symbol(sym, dt, fuzzy=True) for sym in syms],
         )
+
+
+class TestAssetFinderPreprocessors(WithTmpDir, ZiplineTestCase):
+
+    def test_asset_finder_doesnt_silently_create_useless_empty_files(self):
+        nonexistent_path = self.tmpdir.getpath('nothing_here')
+
+        with self.assertRaises(ValueError) as e:
+            AssetFinder(nonexistent_path)
+        expected = "SQLite file {!r} doesn't exist.".format(nonexistent_path)
+        self.assertEqual(str(e.exception), expected)
+
+        # sqlite3.connect will create an empty file if you connect somewhere
+        # nonexistent. Test that we don't do that.
+        self.assertFalse(os.path.exists(nonexistent_path))

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1592,7 +1592,7 @@ class TestVectorizedSymbolLookup(WithAssetFinder, ZiplineTestCase):
 class TestAssetFinderPreprocessors(WithTmpDir, ZiplineTestCase):
 
     def test_asset_finder_doesnt_silently_create_useless_empty_files(self):
-        nonexistent_path = self.tmpdir.getpath('nothing_here')
+        nonexistent_path = self.tmpdir.getpath(self.id() + '__nothing_here')
 
         with self.assertRaises(ValueError) as e:
             AssetFinder(nonexistent_path)

--- a/zipline/assets/asset_db_migrations.py
+++ b/zipline/assets/asset_db_migrations.py
@@ -10,7 +10,7 @@ from zipline.utils.preprocess import preprocess
 from zipline.utils.sqlite_utils import coerce_string_to_eng
 
 
-@preprocess(engine=coerce_string_to_eng)
+@preprocess(engine=coerce_string_to_eng(require_exists=True))
 def downgrade(engine, desired_version):
     """Downgrades the assets db at the given engine to the desired version.
 

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -358,7 +358,7 @@ class AssetDBWriter(object):
     """
     DEFAULT_CHUNK_SIZE = SQLITE_MAX_VARIABLE_NUMBER
 
-    @preprocess(engine=coerce_string_to_eng)
+    @preprocess(engine=coerce_string_to_eng(require_exists=False))
     def __init__(self, engine):
         self.engine = engine
 

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -266,7 +266,7 @@ class AssetFinder(object):
     # reference to an AssetFinder.
     PERSISTENT_TOKEN = "<AssetFinder>"
 
-    @preprocess(engine=coerce_string_to_eng)
+    @preprocess(engine=coerce_string_to_eng(require_exists=True))
     def __init__(self, engine, future_chain_predicates=CHAIN_PREDICATES):
         self.engine = engine
         metadata = sa.MetaData(bind=engine)

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -1280,7 +1280,7 @@ class SQLiteAdjustmentReader(object):
     :class:`zipline.data.us_equity_pricing.SQLiteAdjustmentWriter`
     """
 
-    @preprocess(conn=coerce_string_to_conn)
+    @preprocess(conn=coerce_string_to_conn(require_exists=True))
     def __init__(self, conn):
         self.conn = conn
 


### PR DESCRIPTION
Make the AssetFinder fail with a clearer error if you construct and
AssetFinder pointing to a file path that doesnt exist.

The current implementation fails with:

```
InvalidRequestError: Could not reflect: requested table(s) not available in sqlite:///<filepath>
```

which makes it look like the error was that the db was corrupted, when
the actual error was just that the file didn't even exist. This is made
worse by the fact that sqlite3 will actually create an empty file when
you call `connect`, which further propagates the appearance of having
previously had a bad file.