### PR TITLE
MAINT: Mark quantiles() and friends window_safe.

### DIFF
--- a/zipline/pipeline/classifiers/classifier.py
+++ b/zipline/pipeline/classifiers/classifier.py
@@ -407,6 +407,7 @@ class Everything(Classifier):
     window_length = 0
     inputs = ()
     missing_value = -1
+    window_safe = True
 
     def _compute(self, arrays, dates, assets, mask):
         return where(
@@ -424,6 +425,7 @@ class Quantiles(SingleInputMixin, Classifier):
     dtype = int64_dtype
     window_length = 0
     missing_value = -1
+    window_safe = True
 
     def _compute(self, arrays, dates, assets, mask):
         data = arrays[0]
@@ -465,6 +467,7 @@ class Relabel(SingleInputMixin, Classifier):
             dtype=term.dtype,
             mask=term.mask,
             relabeler=relabeler,
+            window_safe=term.window_safe,
         )
 
     def _compute(self, arrays, dates, assets, mask):


### PR DESCRIPTION
This is at least as reasonable as marking `rank()` as window_safe, which
we allow.

xref: https://github.com/quantopian/zipline/issues/1999