### PR TITLE
PERF: Add a new factor that just computes beta.

### DIFF
--- a/tests/pipeline/test_statistical.py
+++ b/tests/pipeline/test_statistical.py
@@ -331,6 +331,19 @@ class StatisticalBuiltInsTestCase(WithTradingEnvironment, ZiplineTestCase):
         )
         assert_equal(results['simple'], results['complex'], check_names=False)
 
+    def test_simple_beta_allowed_missing_calculation(self):
+        for percentage, expected in [(0.651, 65),
+                                     (0.659, 65),
+                                     (0.66, 66),
+                                     (0.0, 0),
+                                     (1.0, 100)]:
+            beta = SimpleBeta(
+                target=self.my_asset,
+                regression_length=100,
+                allowed_missing_percentage=percentage,
+            )
+            self.assertEqual(beta.params['allowed_missing_count'], expected)
+
     def test_correlation_and_regression_with_bad_asset(self):
         """
         Test that `RollingPearsonOfReturns`, `RollingSpearmanOfReturns` and
@@ -408,6 +421,47 @@ class StatisticalBuiltInsTestCase(WithTradingEnvironment, ZiplineTestCase):
                 returns_length=3,
                 regression_length=1,
             )
+
+    def test_simple_beta_input_validation(self):
+        with self.assertRaises(TypeError) as e:
+            SimpleBeta(
+                target="SPY",
+                regression_length=100,
+                allowed_missing_percentage=0.5,
+            )
+        result = str(e.exception)
+        expected = (
+            "SimpleBeta() expected a value of type"
+            " zipline.assets._assets.Asset for argument 'target',"
+            " but got str instead."
+        )
+        self.assertEqual(result, expected)
+
+        with self.assertRaises(ValueError) as e:
+            SimpleBeta(
+                target=self.my_asset,
+                regression_length=1,
+                allowed_missing_percentage=0.5,
+            )
+        result = str(e.exception)
+        expected = (
+            "SimpleBeta() expected a value greater than or equal to 3"
+            " for argument 'regression_length', but got 1 instead."
+        )
+        self.assertEqual(result, expected)
+
+        with self.assertRaises(ValueError) as e:
+            SimpleBeta(
+                target=self.my_asset,
+                regression_length=100,
+                allowed_missing_percentage=50,
+            )
+        result = str(e.exception)
+        expected = (
+            "SimpleBeta() expected a value inclusively between 0.0 and 1.0 "
+            "for argument 'allowed_missing_percentage', but got 50 instead."
+        )
+        self.assertEqual(result, expected)
 
 
 class StatisticalMethodsTestCase(WithSeededRandomPipelineEngine,
@@ -830,7 +884,10 @@ class StatisticalMethodsTestCase(WithSeededRandomPipelineEngine,
 class VectorizedBetaTestCase(ZiplineTestCase):
 
     def compare_with_empyrical(self, dependents, independent):
-        result = vectorized_beta(dependents, independent)
+        INFINITY = 1000000  # close enough
+        result = vectorized_beta(
+            dependents, independent, allowed_missing=INFINITY,
+        )
         expected = np.array([
             empyrical_beta(dependents[:, i].ravel(), independent.ravel())
             for i in range(dependents.shape[1])
@@ -838,29 +895,123 @@ class VectorizedBetaTestCase(ZiplineTestCase):
         assert_equal(result, expected, array_decimal=7)
         return result
 
-    @parameter_space(seed=[1, 2, 3])
-    def test_vectorized_beta_matches_empyrical_beta_aligned(self, seed):
+    @parameter_space(seed=[1, 2, 3], __fail_fast=True)
+    def test_matches_empyrical_beta_aligned(self, seed):
         rand = np.random.RandomState(seed)
+
         true_betas = np.array([-0.5, 0.0, 0.5, 1.0, 1.5])
-        independent = as_column(np.linspace(-5., 5., 20))
-        noise = as_column(rand.uniform(-.1, .1, 20))
+        independent = as_column(np.linspace(-5., 5., 30))
+        noise = as_column(rand.uniform(-.1, .1, 30))
         dependents = 1.0 + true_betas * independent + noise
 
         result = self.compare_with_empyrical(dependents, independent)
         self.assertTrue((np.abs(result - true_betas) < 0.01).all())
 
-    @parameter_space(seed=[1, 2, 3])
-    def test_vectorized_beta_nan_handling_matches_empyrical(self, seed):
+    @parameter_space(seed=[1, 2, 3], __fail_fast=True)
+    def test_nan_handling_matches_empyrical(self, seed):
         rand = np.random.RandomState(seed)
+
         true_betas = np.array([-0.5, 0.0, 0.5, 1.0, 1.5])
-        independent = as_column(np.linspace(-5., 5., 20))
-        noise = as_column(rand.uniform(-.1, .1, 20))
+        independent = as_column(np.linspace(-5., 5., 30))
+        noise = as_column(rand.uniform(-.1, .1, 30))
         dependents = 1.0 + true_betas * independent + noise
 
         # Fill 20% of the input arrays with nans randomly.
         dependents[rand.uniform(0, 1, dependents.shape) < 0.2] = nan
         independent[rand.uniform(0, 1, independent.shape) < 0.2] = nan
 
+        # Sanity check that we actually inserted some nans.
+        self.assertTrue(np.count_nonzero(np.isnan(dependents)) > 0)
+        self.assertTrue(np.count_nonzero(np.isnan(independent)) > 0)
+
         result = self.compare_with_empyrical(dependents, independent)
+
+        # compare_with_empyrical uses requred_observations=0, so we shouldn't
+        # have any nans in the output even though we had some in the input.
         self.assertTrue(not np.isnan(result).any())
+
+        # We should still have reasonable beta estimates.
         self.assertTrue((np.abs(result - true_betas) < 0.01).all())
+
+    @parameter_space(nan_offset=[-1, 0, 1])
+    def test_produce_nans_when_too_much_missing_data(self, nan_offset):
+        rand = np.random.RandomState(42)
+
+        true_betas = np.array([-0.5, 0.0, 0.5, 1.0, 1.5])
+        independent = as_column(np.linspace(-5., 5., 30))
+        noise = as_column(rand.uniform(-.1, .1, 30))
+        dependents = 1.0 + true_betas * independent + noise
+
+        # Write nans in a triangular pattern into the middle of the dependent
+        # array.
+        nan_grid = np.array([[1, 0, 0, 0, 0],
+                             [1, 1, 0, 0, 0],
+                             [1, 1, 1, 0, 0],
+                             [1, 1, 1, 1, 0],
+                             [1, 1, 1, 1, 1]], dtype=bool)
+        num_nans = nan_grid.sum(axis=0)
+        # Move the grid around in the parameterized tests. The positions
+        # shouldn't matter.
+        dependents[10 + nan_offset:15 + nan_offset][nan_grid] = np.nan
+
+        for allowed_missing in range(7):
+            results = vectorized_beta(dependents, independent, allowed_missing)
+            for i, expected in enumerate(true_betas):
+                result = results[i]
+                expect_nan = num_nans[i] > allowed_missing
+                true_beta = true_betas[i]
+                if expect_nan:
+                    self.assertTrue(np.isnan(result))
+                else:
+                    self.assertTrue(np.abs(result - true_beta) < 0.01)
+
+    def test_allowed_missing_doesnt_double_count(self):
+        # Test that allowed_missing only counts a row as missing one
+        # observation if it's missing in both the dependent and independent
+        # variable.
+        rand = np.random.RandomState(42)
+        true_betas = np.array([-0.5, 0.0, 0.5, 1.0, 1.5])
+        independent = as_column(np.linspace(-5., 5., 30))
+        noise = as_column(rand.uniform(-.1, .1, 30))
+        dependents = 1.0 + true_betas * independent + noise
+
+        # Each column has three nans in the grid.
+        dependent_nan_grid = np.array([[0, 1, 1, 1, 0],
+                                       [0, 0, 1, 1, 1],
+                                       [1, 0, 0, 1, 1],
+                                       [1, 1, 0, 0, 1],
+                                       [1, 1, 1, 0, 0]], dtype=bool)
+        # There's are also two nans in the independent data.
+        independent_nan_grid = np.array([[0],
+                                         [0],
+                                         [1],
+                                         [1],
+                                         [0]], dtype=bool)
+
+        dependents[10:15][dependent_nan_grid] = np.nan
+        independent[10:15][independent_nan_grid] = np.nan
+
+        # With only two allowed missing values, everything should come up nan,
+        # because column has at least 3 nans in the dependent data.
+        result3 = vectorized_beta(dependents, independent, allowed_missing=2)
+        assert_equal(np.isnan(result3),
+                     np.array([True, True, True, True, True]))
+
+        # With three allowed missing values, the first and last columns should
+        # produce a value, because they have nans at the same rows where the
+        # independent data has nans.
+        result4 = vectorized_beta(dependents, independent, allowed_missing=3)
+        assert_equal(np.isnan(result4),
+                     np.array([False, True, True, True, False]))
+
+        # With four allowed missing values, everything but the middle column
+        # should produce a value. The middle column will have 5 nans because
+        # the dependent nans have no overlap with the independent nans.
+        result5 = vectorized_beta(dependents, independent, allowed_missing=4)
+        assert_equal(np.isnan(result5),
+                     np.array([False, False, True, False, False]))
+
+        # With six allowed missing values, everything should produce a value.
+        result6 = vectorized_beta(dependents, independent, allowed_missing=5)
+        assert_equal(np.isnan(result6),
+                     np.array([False, False, False, False, False]))

--- a/tests/pipeline/test_statistical.py
+++ b/tests/pipeline/test_statistical.py
@@ -431,11 +431,11 @@ class StatisticalBuiltInsTestCase(WithTradingEnvironment, ZiplineTestCase):
             )
         result = str(e.exception)
         expected = (
-            "SimpleBeta() expected a value of type"
-            " zipline.assets._assets.Asset for argument 'target',"
+            r"SimpleBeta\(\) expected a value of type"
+            " .*Asset for argument 'target',"
             " but got str instead."
         )
-        self.assertEqual(result, expected)
+        self.assertRegexpMatches(result, expected)
 
         with self.assertRaises(ValueError) as e:
             SimpleBeta(

--- a/tests/pipeline/test_statistical.py
+++ b/tests/pipeline/test_statistical.py
@@ -981,7 +981,7 @@ class VectorizedBetaTestCase(ZiplineTestCase):
                                        [1, 0, 0, 1, 1],
                                        [1, 1, 0, 0, 1],
                                        [1, 1, 1, 0, 0]], dtype=bool)
-        # There's are also two nans in the independent data.
+        # There are also two nans in the independent data.
         independent_nan_grid = np.array([[0],
                                          [0],
                                          [1],

--- a/zipline/pipeline/factors/__init__.py
+++ b/zipline/pipeline/factors/__init__.py
@@ -27,6 +27,7 @@ from .statistical import (
     RollingLinearRegressionOfReturns,
     RollingPearsonOfReturns,
     RollingSpearmanOfReturns,
+    SimpleBeta,
 )
 from .technical import (
     Aroon,
@@ -68,6 +69,7 @@ __all__ = [
     'RollingPearsonOfReturns',
     'RollingSpearmanOfReturns',
     'RSI',
+    'SimpleBeta',
     'SimpleMovingAverage',
     'TrueRange',
     'VWAP',

--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -596,7 +596,7 @@ def vectorized_beta(dependents, independent, allowed_missing, out=None):
     N, M = dependents.shape
 
     if out is None:
-        out = np.full(M, np.nan)
+        out = np.full(M, nan)
 
     # Copy N times as a column vector and fill with nans to have the same
     # missing value pattern as the dependent variable.

--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -495,7 +495,9 @@ class SimpleBeta(CustomFactor, StandardOutputs):
         Number of days of daily returns to use for the regression.
     allowed_missing_percentage : float, optional
         Percentage of returns observations that are allowed to be missing when
-        calculating betas. Default is 25%.
+        calculating betas. Assets with more than this percentage of returns
+        observations missing will produce values of NaN. Default behavior is
+        that 25% of inputs can be missing.
     """
     window_safe = True
     dtype = float64_dtype
@@ -606,7 +608,7 @@ def vectorized_beta(dependents, independent, allowed_missing, out=None):
     # shape: (M,)
     covariances = nanmean(ind_residual * dep_residual, axis=0)
 
-    # We end up with different variances here in each column because each
+    # We end up with different variances in each column here because each
     # column may have a different subset of the data dropped due to missing
     # data in the corresponding dependent column.
     # shape: (M,)
@@ -615,6 +617,8 @@ def vectorized_beta(dependents, independent, allowed_missing, out=None):
     # shape: (M,)
     np.divide(covariances, independent_variances, out=out)
 
+    # Write nans back to locations where we have more then allowed number of
+    # missing entries.
     nanlocs = isnan(independent).sum(axis=0) > allowed_missing
     out[nanlocs] = nan
 

--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -504,8 +504,8 @@ class SimpleBeta(CustomFactor, StandardOutputs):
     params = ('allowed_missing_count',)
 
     @expect_types(
-        regression_length=int,
         target=Asset,
+        regression_length=int,
         allowed_missing_percentage=(int, float),
         __funcname='SimpleBeta',
     )

--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -546,11 +546,26 @@ class SimpleBeta(CustomFactor, StandardOutputs):
             out=out,
         )
 
-    def __repr__(self):
-        return "{}(window_length={}, allowed_missing={})".format(
+    def short_repr(self):
+        return "{}({!r}, {}, {})".format(
             type(self).__name__,
+            str(self.target.symbol),  # coerce from unicode to str in py2.
             self.window_length,
-            self.params['allowed_missing'],
+            self.params['allowed_missing_count'],
+        )
+
+    @property
+    def target(self):
+        """Get the target of the beta calculation.
+        """
+        return self.inputs[1].asset
+
+    def __repr__(self):
+        return "{}({}, length={}, allowed_missing={})".format(
+            type(self).__name__,
+            self.target,
+            self.window_length,
+            self.params['allowed_missing_count'],
         )
 
 

--- a/zipline/pipeline/factors/statistical.py
+++ b/zipline/pipeline/factors/statistical.py
@@ -522,9 +522,9 @@ class SimpleBeta(CustomFactor, StandardOutputs):
             window_length=2,
             mask=(AssetExists() | SingleAsset(asset=target)),
         )
-        allowed_missing_count = int(np.floor(
+        allowed_missing_count = int(
             allowed_missing_percentage * regression_length
-        ))
+        )
         return super(SimpleBeta, cls).__new__(
             cls,
             inputs=[daily_returns, daily_returns[target]],

--- a/zipline/pipeline/term.py
+++ b/zipline/pipeline/term.py
@@ -737,6 +737,12 @@ class Slice(ComputableTerm):
         return windows[0][:, [asset_column]]
 
     @property
+    def asset(self):
+        """Get the asset whose data is selected by this slice.
+        """
+        return self._asset
+
+    @property
     def _downsampled_type(self):
         raise NotImplementedError(
             'downsampling of slices is not yet supported'


### PR DESCRIPTION
This is a little over 1100x faster (!) than using
`RollingLinearRegressionOfReturns` on my machine.

Profiling output for a 1-month pipeline using both terms for with a
90-day lookback:

```
Tue Nov 21 02:05:48 2017    pipebench/perf/betas.stats

         57724856 function calls (57689155 primitive calls) in 92.342 seconds

   Ordered by: cumulative time
   List reduced from 1212 to 3 due to restriction <'statistical.py'>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       21    0.612    0.029   95.461    4.546 statistical.py:194(compute)
   172201    0.407    0.000   94.843    0.001 statistical.py:201(regress)
       21    0.048    0.002    0.082    0.004 statistical.py:500(compute)
```

- The `compute` function that takes 95 seconds is `RollingLinearRetressionOfReturns`.
- The `compute` function that takes 0.082 seconds is the new implementation.