### PR TITLE
DOC: Fix Gitter link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ All contributions, bug reports, bug fixes, documentation improvements, enhanceme
 
 If you are looking to start working with the Zipline codebase, navigate to the GitHub `issues` tab and start looking through interesting issues. Sometimes there are issues labeled as `Beginner Friendly <https://github.com/quantopian/zipline/issues?q=is%3Aissue+is%3Aopen+label%3A%22Beginner+Friendly%22>`_ or `Help Wanted <https://github.com/quantopian/zipline/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22>`_.
 
-Feel free to ask questions on the `mailing list <https://groups.google.com/forum/#!forum/zipline>`_ or on `Gitter <gitter.im/quantopian/zipline>`_.
+Feel free to ask questions on the `mailing list <https://groups.google.com/forum/#!forum/zipline>`_ or on `Gitter <https://gitter.im/quantopian/zipline>`_.
 
 
 


### PR DESCRIPTION
Fix Gitter link in README which currently takes to a 404 page on GitHub because it doesn't start with `https://`