### PR TITLE
MAINT: Pass calendars to DataPortal

### DIFF
--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -7,10 +7,7 @@ import pandas as pd
 from six import text_type
 
 from zipline.data import bundles as bundles_module
-from zipline.utils.calendars.calendar_utils import (
-    get_calendar,
-    default_calendar_names
-)
+from zipline.utils.calendars.calendar_utils import get_calendar
 from zipline.utils.compat import wraps
 from zipline.utils.cli import Date, Timestamp
 from zipline.utils.run_algo import _run, load_extensions
@@ -179,7 +176,6 @@ def ipython_only(option):
 @click.option(
     '--trading-calendar',
     metavar='TRADING-CALENDAR',
-    type=click.Choice(default_calendar_names),
     default='NYSE',
     help="The calendar you want to use e.g. LSE. NYSE is the default."
 )

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -54,7 +54,6 @@ from zipline.data.history_loader import (
     MinuteHistoryLoader,
 )
 from zipline.data.us_equity_pricing import NoDataOnDate
-
 from zipline.utils.math_utils import (
     nansum,
     nanmean,
@@ -155,6 +154,7 @@ class DataPortal(object):
                  daily_history_prefetch_length=_DEF_D_HIST_PREFETCH):
 
         self.trading_calendar = trading_calendar
+
         self.asset_finder = asset_finder
 
         self._adjustment_reader = adjustment_reader

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -113,6 +113,9 @@ def _run(handle_data,
         else:
             click.echo(algotext)
 
+    if trading_calendar is None:
+        trading_calendar = get_calendar('NYSE')
+
     if bundle is not None:
         bundle_data = load(
             bundle,
@@ -134,7 +137,8 @@ def _run(handle_data,
         first_trading_day =\
             bundle_data.equity_minute_bar_reader.first_trading_day
         data = DataPortal(
-            env.asset_finder, get_calendar("NYSE"),
+            env.asset_finder,
+            trading_calendar=trading_calendar,
             first_trading_day=first_trading_day,
             equity_minute_reader=bundle_data.equity_minute_bar_reader,
             equity_daily_reader=bundle_data.equity_daily_bar_reader,
@@ -155,9 +159,6 @@ def _run(handle_data,
     else:
         env = TradingEnvironment(environ=environ)
         choose_loader = None
-
-    if not trading_calendar:
-        trading_calendar = get_calendar('NYSE')
 
     perf = TradingAlgorithm(
         namespace=namespace,


### PR DESCRIPTION
Following the posts in #2018, should fix that issue


When we enter the `DataPortal()` setup in `zipline/zipline/data/data_portal.py(296)`, and call

```
# Get the first trading minute
self._first_trading_minute, _ = (
    self.trading_calendar.open_and_close_for_session(
    self._first_trading_day
)
```

We error at this point, if we're using a custom `TradingCalendar` because we actually only pass the `NYSE` calendar to the `DataPortal()` in `zipline/utils/run_algo.py` , so I changed the line to pass the calendar received from the CLI:

```
--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -134,7 +134,8 @@ def _run(handle_data,
         first_trading_day =\
             bundle_data.equity_minute_bar_reader.first_trading_day
         data = DataPortal(
-            env.asset_finder, get_calendar("NYSE"),
+            env.asset_finder,
+            trading_calendar=trading_calendar,
             first_trading_day=first_trading_day,
             equity_minute_reader=bundle_data.equity_minute_bar_reader,
             equity_daily_reader=bundle_data.equity_daily_bar_reader,
```