### PR TITLE
MAINT: Move _shift_dates to pipeline utils as shift_dates

### DIFF
--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -21,10 +21,10 @@ from zipline.data.us_equity_pricing import (
     SQLiteAdjustmentReader,
 )
 from zipline.lib.adjusted_array import AdjustedArray
-from zipline.errors import NoFurtherDataError
 from zipline.utils.calendars import get_calendar
 
 from .base import PipelineLoader
+from .utils import shift_dates
 
 UINT32_MAX = iinfo(uint32).max
 
@@ -69,7 +69,7 @@ class USEquityPricingLoader(PipelineLoader):
         # be known at the start of each date.  We assume that the latest data
         # known on day N is the data from day (N - 1), so we shift all query
         # dates back by a day.
-        start_date, end_date = _shift_dates(
+        start_date, end_date = shift_dates(
             self._all_sessions, dates[0], dates[-1], shift=1,
         )
         colnames = [c.name for c in columns]
@@ -93,48 +93,3 @@ class USEquityPricingLoader(PipelineLoader):
                 c.missing_value,
             )
         return out
-
-
-def _shift_dates(dates, start_date, end_date, shift):
-    try:
-        start = dates.get_loc(start_date)
-    except KeyError:
-        if start_date < dates[0]:
-            raise NoFurtherDataError(
-                msg=(
-                    "Pipeline Query requested data starting on {query_start}, "
-                    "but first known date is {calendar_start}"
-                ).format(
-                    query_start=str(start_date),
-                    calendar_start=str(dates[0]),
-                )
-            )
-        else:
-            raise ValueError("Query start %s not in calendar" % start_date)
-
-    # Make sure that shifting doesn't push us out of the calendar.
-    if start < shift:
-        raise NoFurtherDataError(
-            msg=(
-                "Pipeline Query requested data from {shift}"
-                " days before {query_start}, but first known date is only "
-                "{start} days earlier."
-            ).format(shift=shift, query_start=start_date, start=start),
-        )
-
-    try:
-        end = dates.get_loc(end_date)
-    except KeyError:
-        if end_date > dates[-1]:
-            raise NoFurtherDataError(
-                msg=(
-                    "Pipeline Query requesting data up to {query_end}, "
-                    "but last known date is {calendar_end}"
-                ).format(
-                    query_end=end_date,
-                    calendar_end=dates[-1],
-                )
-            )
-        else:
-            raise ValueError("Query end %s not in calendar" % end_date)
-    return dates[start - shift], dates[end - shift]


### PR DESCRIPTION
So that it can be used by other loaders that need to shift the dates
of pipeline outputs.