### PR TITLE
ENH: Use IEX Trading data instead of pandas-datareader

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -547,7 +547,7 @@ class TradingAlgorithm(object):
         else:
             benchmark_asset = None
             # get benchmark info from trading environment, which defaults to
-            # downloading data from Yahoo.
+            # downloading data from IEX Trading.
             benchmark_returns = self.trading_environment.benchmark_returns
         return BenchmarkSource(
             benchmark_asset=benchmark_asset,

--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -12,10 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numpy as np
+import json
 import pandas as pd
-
-import pandas_datareader.data as pd_reader
+import requests
 
 
 def get_benchmark_returns(symbol, first_date, last_date):
@@ -43,19 +42,14 @@ def get_benchmark_returns(symbol, first_date, last_date):
     first_date is **not** included because we need the close from day N - 1 to
     compute the returns for day N.
     """
-    data = pd_reader.DataReader(
-        symbol,
-        'google',
-        first_date,
-        last_date
+    r = requests.get(
+        'https://api.iextrading.com/1.0/stock/{}/chart/5y'.format(symbol)
     )
+    data = json.loads(r.text)
 
-    data = data['Close']
+    df = pd.DataFrame(data)
 
-    data[pd.Timestamp('2008-12-15')] = np.nan
-    data[pd.Timestamp('2009-08-11')] = np.nan
-    data[pd.Timestamp('2012-02-02')] = np.nan
+    df.index = pd.DatetimeIndex(df['date'])
+    df = df['close']
 
-    data = data.fillna(method='ffill')
-
-    return data.sort_index().tz_localize('UTC').pct_change(1).iloc[1:]
+    return df.sort_index().tz_localize('UTC').pct_change(1).iloc[1:]

--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -17,30 +17,18 @@ import pandas as pd
 import requests
 
 
-def get_benchmark_returns(symbol, first_date, last_date):
+def get_benchmark_returns(symbol):
     """
-    Get a Series of benchmark returns from Google associated with `symbol`.
+    Get a Series of benchmark returns from IEX associated with `symbol`.
     Default is `SPY`.
 
     Parameters
     ----------
     symbol : str
         Benchmark symbol for which we're getting the returns.
-    first_date : pd.Timestamp
-        First date for which we want to get data.
-    last_date : pd.Timestamp
-        Last date for which we want to get data.
 
-    The furthest date that Google goes back to is 1993-02-01. It has missing
-    data for 2008-12-15, 2009-08-11, and 2012-02-02, so we add data for the
-    dates for which Google is missing data.
-
-    We're also limited to 4000 days worth of data per request. If we make a
-    request for data that extends past 4000 trading days, we'll still only
-    receive 4000 days of data.
-
-    first_date is **not** included because we need the close from day N - 1 to
-    compute the returns for day N.
+    The data is provided by IEX (https://iextrading.com/), and we can
+    get up to 5 years worth of data.
     """
     r = requests.get(
         'https://api.iextrading.com/1.0/stock/{}/chart/5y'.format(symbol)

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -97,7 +97,7 @@ def load_market_data(trading_day=None, trading_days=None, bm_symbol='SPY',
     Load benchmark returns and treasury yield curves for the given calendar and
     benchmark symbol.
 
-    Benchmarks are downloaded as a Series from Google Finance.  Treasury curves
+    Benchmarks are downloaded as a Series from IEX Trading.  Treasury curves
     are US Treasury Bond rates and are downloaded from 'www.federalreserve.gov'
     by default.  For Canadian exchanges, a loader for Canadian bonds from the
     Bank of Canada is also available.
@@ -115,8 +115,8 @@ def load_market_data(trading_day=None, trading_days=None, bm_symbol='SPY',
         A calendar of trading days.  Also used for determining what cached
         dates we should expect to have cached. Defaults to the NYSE calendar.
     bm_symbol : str, optional
-        Symbol for the benchmark index to load.  Defaults to 'SPY', the Google
-        ticker for the S&P 500.
+        Symbol for the benchmark index to load. Defaults to 'SPY', the ticker
+        for the S&P 500, provided by IEX Trading.
 
     Returns
     -------
@@ -224,11 +224,7 @@ def ensure_benchmark_data(symbol, first_date, last_date, now, trading_day,
     )
 
     try:
-        data = get_benchmark_returns(
-            symbol,
-            first_date - trading_day,
-            last_date,
-        )
+        data = get_benchmark_returns(symbol)
         data.to_csv(get_data_filepath(filename, environ))
     except (OSError, IOError, HTTPError):
         logger.exception('Failed to cache the new benchmark returns')


### PR DESCRIPTION
Got fed up with the breaking/removal of Google & Yahoo Finance APIs, and so since we've been using pandas-datareader to get data from those APIs I removed that dependency for when we want to get data for a specific benchmark (in this case `SPY`).

 I changed our data source to IEX which will give us up to 5 years worth of data. It has really great documentation and seems like its a lot more reliable.

Should fix:
- https://github.com/quantopian/zipline/issues/2029
- https://github.com/quantopian/zipline/issues/2024
- https://github.com/quantopian/zipline/issues/1965
- https://github.com/quantopian/zipline/issues/2002
- https://github.com/quantopian/zipline/issues/2036
- https://github.com/quantopian/zipline/issues/2030

And should be better than PR https://github.com/quantopian/zipline/pull/1972