### PR TITLE
DOC: Add CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,10 @@
+Contributing to Zipline
+=======================
+For developers of Zipline, people who want to contribute to the Zipline codebase or documentation, or people who want to install from source and make local changes to their copy of Zipline, please refer to the `Development Guidelines`__ if you would like to contribute.
+
+All contributions, bug reports, bug fixes, documentation improvements, enhancements and ideas are welcome. We `track issues`__ on `GitHub`__ and also have a `mailing list`__ where you can ask questions.
+
+__ https://github.com/quantopian/zipline/issues
+__ https://github.com/
+__ https://groups.google.com/forum/#!forum/zipline
+__ http://www.zipline.io/development-guidelines.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,7 +4,7 @@ For developers of Zipline, people who want to contribute to the Zipline codebase
 
 All contributions, bug reports, bug fixes, documentation improvements, enhancements and ideas are welcome. We `track issues`__ on `GitHub`__ and also have a `mailing list`__ where you can ask questions.
 
+__ http://www.zipline.io/development-guidelines.html
 __ https://github.com/quantopian/zipline/issues
 __ https://github.com/
 __ https://groups.google.com/forum/#!forum/zipline
-__ http://www.zipline.io/development-guidelines.html


### PR DESCRIPTION
Often times people will look for `CONTRIBUTING` files in the GitHub repos to find information for how to contribute to different projects. GitHub also encourages maintainers to have this file in their repo to raise higher community standards.

My hypothesis is that if we add this it'll also be another way for people to find their way over to the Development Guidelines and contribute.