### PR TITLE
PERF: Reduces memory footprint of Quandl WIKI Prices bundle

### DIFF
--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -44,34 +44,34 @@ def load_data_table(file,
         file_names = zip_file.namelist()
         assert len(file_names) == 1, "Expected a single file from Quandl."
         wiki_prices = file_names.pop()
-        table_file = zip_file.open(wiki_prices)
-        if show_progress:
-            log.info('Parsing raw data.')
-        data_table = pd.read_csv(
-            table_file,
-            parse_dates=['date'],
-            index_col=index_col,
-            usecols=[
-                'ticker',
-                'date',
-                'open',
-                'high',
-                'low',
-                'close',
-                'volume',
-                'ex-dividend',
-                'split_ratio'
-            ],
-            na_values=['NA']
-        ).rename(
-            columns={
-                'ticker': 'symbol',
-                'ex-dividend': 'ex_dividend'
-            }
-        )
-        table_file.close()
+        with zip_file.open(wiki_prices) as table_file:
+            if show_progress:
+                log.info('Parsing raw data.')
+            data_table = pd.read_csv(
+                table_file,
+                parse_dates=['date'],
+                index_col=index_col,
+                usecols=[
+                    'ticker',
+                    'date',
+                    'open',
+                    'high',
+                    'low',
+                    'close',
+                    'volume',
+                    'ex-dividend',
+                    'split_ratio',
+                ],
+            )
 
-    data_table['symbol'] = data_table['symbol'].astype('category')
+    data_table.rename(
+        columns={
+            'ticker': 'symbol',
+            'ex-dividend': 'ex_dividend',
+        },
+        inplace=True,
+        copy=False,
+    )
     return data_table
 
 
@@ -118,46 +118,52 @@ def gen_asset_metadata(data, show_progress):
     if show_progress:
         log.info('Generating asset metadata.')
 
-    asset_metadata = data.groupby(
+    data = data.groupby(
         by='symbol'
     ).agg(
         {'date': [np.min, np.max]}
-    ).reset_index()
-    asset_metadata['start_date'] = asset_metadata.date.amin
-    asset_metadata['end_date'] = asset_metadata.date.amax
-    del asset_metadata['date']
-    asset_metadata.columns = asset_metadata.columns.get_level_values(0)
+    )
+    data.reset_index(inplace=True)
+    data['start_date'] = data.date.amin
+    data['end_date'] = data.date.amax
+    del data['date']
+    data.columns = data.columns.get_level_values(0)
 
-    asset_metadata['exchange'] = 'QUANDL'
-    asset_metadata['auto_close_date'] = \
-        asset_metadata['end_date'].values + pd.Timedelta(days=1)
-    return asset_metadata
+    data['exchange'] = 'QUANDL'
+    data['auto_close_date'] = data['end_date'].values + pd.Timedelta(days=1)
+    return data
 
 
 def parse_splits(data, show_progress):
     if show_progress:
         log.info('Parsing split data.')
 
-    split_ratios = data.split_ratio
-    return pd.DataFrame({
-        'ratio': 1.0 / split_ratios[split_ratios != 1],
-        'effective_date': data.date,
-        'sid': pd.factorize(data.symbol)[0]
-    }).dropna()
+    data['split_ratio'] = 1.0 / data.split_ratio
+    data.rename(
+        columns={
+            'split_ratio': 'ratio',
+            'date': 'effective_date',
+        },
+        inplace=True,
+        copy=False,
+    )
+    return data
 
 
 def parse_dividends(data, show_progress):
     if show_progress:
         log.info('Parsing dividend data.')
 
-    divs = data.ex_dividend
-    df = pd.DataFrame({
-        'amount': divs[divs != 0],
-        'ex_date': data.date,
-        'sid': pd.factorize(data.symbol)[0]
-    }).dropna()
-    df['record_date'] = df['declared_date'] = df['pay_date'] = pd.NaT
-    return df
+    data['record_date'] = data['declared_date'] = data['pay_date'] = pd.NaT
+    data.rename(
+        columns={
+            'ex_dividend': 'amount',
+            'date': 'ex_date',
+        },
+        inplace=True,
+        copy=False,
+    )
+    return data
 
 
 def parse_pricing_and_vol(data,
@@ -186,7 +192,7 @@ def quandl_bundle(environ,
                   show_progress,
                   output_dir):
     """
-    quandl_bundle builds a data bundle using Quandl's WIKI Prices dataset.
+    quandl_bundle builds a daily dataset using Quandl's WIKI Prices dataset.
 
     For more information on Quandl's API and how to obtain an API key,
     please visit https://docs.quandl.com/docs#section-authentication
@@ -216,14 +222,23 @@ def quandl_bundle(environ,
     )
 
     raw_data.reset_index(inplace=True)
-
+    raw_data['symbol'] = raw_data['symbol'].astype('category')
+    raw_data['sid'] = raw_data.symbol.cat.codes
     adjustment_writer.write(
         splits=parse_splits(
-            raw_data[['symbol', 'date', 'split_ratio']],
+            raw_data[[
+                'sid',
+                'date',
+                'split_ratio',
+            ]].loc[raw_data.split_ratio != 1],
             show_progress=show_progress
         ),
         dividends=parse_dividends(
-            raw_data[['symbol', 'date', 'ex_dividend']],
+            raw_data[[
+                'sid',
+                'date',
+                'ex_dividend',
+            ]].loc[raw_data.ex_dividend != 0],
             show_progress=show_progress
         )
     )


### PR DESCRIPTION
Refactored some of the helper methods in the Quandl bundle to be more memory efficient. Memory peaks now at ~2500 MiB, with a constant memory consumption of ~2000 MiB. 
```
Filename: /Users/ernestoeperez88/zipline_master/zipline/data/bundles/quandl.py

Line #    Mem usage    Increment   Line Contents
================================================
   186    167.3 MiB    167.3 MiB   @bundles.register('quandl')
   187                             @profile
   188                             def quandl_bundle(environ,
   189                                               asset_db_writer,
   190                                               minute_bar_writer,
   191                                               daily_bar_writer,
   192                                               adjustment_writer,
   193                                               calendar,
   194                                               start_session,
   195                                               end_session,
   196                                               cache,
   197                                               show_progress,
   198                                               output_dir):
   199                                 """
   200                                 quandl_bundle builds a data bundle using Quandl's WIKI Prices dataset.
   201                             
   202                                 For more information on Quandl's API and how to obtain an API key,
   203                                 please visit https://docs.quandl.com/docs#section-authentication
   204                                 """
   205    167.3 MiB      0.0 MiB       raw_data = fetch_data_table(
   206    167.3 MiB      0.0 MiB           environ.get('QUANDL_API_KEY'),
   207    167.3 MiB      0.0 MiB           show_progress,
   208   1666.3 MiB   1499.0 MiB           environ.get('QUANDL_DOWNLOAD_ATTEMPTS', 5)
   209                                 )
   210   1666.3 MiB      0.0 MiB       asset_metadata = gen_asset_metadata(
   211   1666.4 MiB      0.1 MiB           raw_data[['symbol', 'date']],
   212   2430.2 MiB    763.8 MiB           show_progress
   213                                 )
   214   2202.9 MiB   -227.3 MiB       asset_db_writer.write(asset_metadata)
   215                             
   216   2202.9 MiB      0.0 MiB       symbol_map = asset_metadata.symbol
   217   2202.9 MiB      0.0 MiB       sessions = calendar.sessions_in_range(start_session, end_session)
   218                             
   219   2261.1 MiB     58.2 MiB       raw_data.set_index(['date', 'symbol'], inplace=True)
   220   2261.1 MiB      0.0 MiB       daily_bar_writer.write(
   221   2261.1 MiB      0.0 MiB           parse_pricing_and_vol(
   222   2261.1 MiB      0.0 MiB               raw_data,
   223   2261.1 MiB      0.0 MiB               sessions,
   224   2261.1 MiB      0.0 MiB               symbol_map
   225                                     ),
   226   1426.1 MiB   -835.0 MiB           show_progress=show_progress
   227                                 )
   228                             
   229   1904.5 MiB    478.4 MiB       raw_data.reset_index(inplace=True)
   230   1942.8 MiB     38.3 MiB       raw_data['symbol'] = raw_data['symbol'].astype('category')
   231   1942.8 MiB      0.0 MiB       raw_data['sid'] = raw_data.symbol.cat.codes
   232   1942.8 MiB      0.0 MiB       adjustment_writer.write(
   233   1942.8 MiB      0.0 MiB           splits=parse_splits(
   234   1942.8 MiB      0.0 MiB               pd.DataFrame(
   235   1942.8 MiB      0.0 MiB                   raw_data[[
   236   1942.8 MiB      0.0 MiB                       'sid',
   237   1942.8 MiB      0.0 MiB                       'date',
   238   1942.8 MiB      0.0 MiB                       'split_ratio',
   239   1942.8 MiB      0.0 MiB                   ]].loc[raw_data.split_ratio != 1]
   240                                         ),
   241   1942.8 MiB      0.0 MiB               show_progress=show_progress
   242                                     ),
   243   1942.8 MiB      0.0 MiB           dividends=parse_dividends(
   244   1942.8 MiB      0.0 MiB               pd.DataFrame(
   245   1942.8 MiB      0.0 MiB                   raw_data[[
   246   1942.8 MiB      0.0 MiB                       'sid',
   247   1942.8 MiB      0.0 MiB                       'date',
   248   1854.0 MiB    -88.8 MiB                       'ex_dividend',
   249   1872.4 MiB     18.4 MiB                   ]].loc[raw_data.ex_dividend != 0]
   250                                         ),
   251   1506.9 MiB   -365.5 MiB               show_progress=show_progress
   252                                     )
   253                                 )
```