### PR TITLE
BUG: cal attribute of aggregate rules was not being propagated

### DIFF
--- a/tests/events/test_events.py
+++ b/tests/events/test_events.py
@@ -136,8 +136,8 @@ class TestUtils(TestCase):
 class TestEventManager(TestCase):
     def setUp(self):
         self.em = EventManager()
-        self.event1 = Event(Always(), lambda context, data: None)
-        self.event2 = Event(Always(), lambda context, data: None)
+        self.event1 = Event(Always())
+        self.event2 = Event(Always())
 
     def test_add_event(self):
         self.em.add_event(self.event1)
@@ -162,9 +162,7 @@ class TestEventManager(TestCase):
                 return True
 
         for r in [CountingRule] * 5:
-                self.em.add_event(
-                    Event(r(), lambda context, data: None)
-                )
+            self.em.add_event(Event(r()))
 
         self.em.handle_data(None, None, datetime.datetime.now())
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -1064,7 +1064,7 @@ class TradingAlgorithm(object):
 
         return csv_data_source
 
-    def add_event(self, rule=None, callback=None):
+    def add_event(self, rule, callback):
         """Adds an event to the algorithm's EventManager.
 
         Parameters


### PR DESCRIPTION
Otherwise algos crash with
```python
AttributeError: 'BeforeClose' object has no attribute 'cal' 
```
if a function is scheduled with, e.g.
```python
schedule_function(
    func=my_func,
    date_rule=date_rules.every_day(),
    time_rule=time_rules.market_close(minutes=30) & time_rules.every_minute(),
)
```