### PR TITLE
Create MinLeverage control

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -70,6 +70,7 @@ from zipline.finance.controls import (
     MaxOrderSize,
     MaxPositionSize,
     MaxLeverage,
+    MinLeverage,
     RestrictedListOrder
 )
 from zipline.finance.execution import (
@@ -2232,6 +2233,22 @@ class TradingAlgorithm(object):
             be no maximum.
         """
         control = MaxLeverage(max_leverage)
+        self.register_account_control(control)
+
+    @api_method
+    def set_min_leverage(self, min_leverage, grace_period):
+        """
+        Set a limit on the minimum leverage of the algorithm.
+
+        Parameters
+        ----------
+        min_leverage : float
+            The minimum leverage for the algorithm.
+        grace_period : pd.Timedelta
+            The offset from the start date used to enforce a minimum leverage.
+        """
+        deadline = self.sim_params.start_session + grace_period
+        control = MinLeverage(min_leverage, deadline)
         self.register_account_control(control)
 
     ####################

--- a/zipline/api.pyi
+++ b/zipline/api.pyi
@@ -633,6 +633,20 @@ def set_max_leverage(max_leverage):
         be no maximum.
     """
 
+def set_min_leverage(min_leverage, timedelta):
+
+    """
+    Set a limit on the minimum leverage of the algorithm.
+
+    Parameters
+    ----------
+    min_leverage : float
+        The minimum leverage for the algorithm. If not provided there will
+        be no minimum.
+    timedelta : pd.Timedelta
+        The offset from the start date used to enforce a minimum leverage
+    """
+
 def set_max_order_count(max_count, on_error='fail'):
     """Set a limit on the number of orders that can be placed in a single
     day.

--- a/zipline/finance/controls.py
+++ b/zipline/finance/controls.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import abc
 import logbook
+from datetime import datetime
 
 import pandas as pd
 
@@ -23,6 +24,11 @@ from zipline.errors import (
     AccountControlViolation,
     TradingControlViolation,
 )
+from zipline.utils.input_validation import (
+    expect_bounded,
+    expect_types,
+)
+
 
 log = logbook.Logger('TradingControl')
 
@@ -424,4 +430,45 @@ class MaxLeverage(AccountControl):
         Fail if the leverage is greater than the allowed leverage.
         """
         if _account.leverage > self.max_leverage:
+            self.fail()
+
+
+class MinLeverage(AccountControl):
+    """AccountControl representing a limit on the minimum leverage allowed
+    by the algorithm after a threshold period of time.
+
+    Parameters
+    ----------
+    min_leverage : float
+        The gross leverage in decimal form.
+    deadline : datetime
+        The date the min leverage must be achieved by.
+
+    For example, min_leverage=2 limits an algorithm to trading at minimum
+    double the account value by the deadline date.
+    """
+
+    @expect_types(
+        __funcname='MinLeverage',
+        min_leverage=(int, float),
+        deadline=datetime
+    )
+    @expect_bounded(__funcname='MinLeverage', min_leverage=(0, None))
+    def __init__(self, min_leverage, deadline):
+        super(MinLeverage, self).__init__(min_leverage=min_leverage,
+                                          deadline=deadline)
+        self.min_leverage = min_leverage
+        self.deadline = deadline
+
+    def validate(self,
+                 _portfolio,
+                 account,
+                 algo_datetime,
+                 _algo_current_data):
+        """
+        Make validation checks if we are after the deadline.
+        Fail if the leverage is less than the min leverage.
+        """
+        if algo_datetime > self.deadline and \
+           account.leverage < self.min_leverage:
             self.fail()

--- a/zipline/test_algorithms.py
+++ b/zipline/test_algorithms.py
@@ -485,6 +485,13 @@ class SetMaxLeverageAlgorithm(TradingAlgorithm):
         self.set_max_leverage(max_leverage=max_leverage)
 
 
+class SetMinLeverageAlgorithm(TradingAlgorithm):
+    def initialize(self, min_leverage, grace_period):
+        self.set_min_leverage(
+            min_leverage=min_leverage, grace_period=grace_period
+        )
+
+
 ############################
 # TradingControl Test Algos#
 ############################


### PR DESCRIPTION
Similar to `MaxLeverage` create a `MinLeverage` control.  

`MinLeverage` takes a float as well as a deadline date.  `MinLeverage` validations will only happen after the algorithm has reached the deadline date.  This allows algorithms enough time to reach their min leverage because it may take time for them to have a non zero leverage.