### PR TITLE
MAINT: Provides better error message when QUANDL_API_KEY isn't set

### DIFF
--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -197,8 +197,14 @@ def quandl_bundle(environ,
     For more information on Quandl's API and how to obtain an API key,
     please visit https://docs.quandl.com/docs#section-authentication
     """
+    api_key = environ.get('QUANDL_API_KEY')
+    if api_key is None:
+        raise ValueError(
+            "Please set your QUANDL_API_KEY environment variable and retry."
+        )
+
     raw_data = fetch_data_table(
-        environ.get('QUANDL_API_KEY'),
+        api_key,
         show_progress,
         environ.get('QUANDL_DOWNLOAD_ATTEMPTS', 5)
     )


### PR DESCRIPTION
Quandl's new API for the WIKI Prices dataset requires an API key.
Omitting the API key when running 'zipline ingest' caused:
HTTPError: HTTP Error 400: Bad Request

The new message asks for QUANDL_API_KEY to be set before
running the ingest process again. 