### PR TITLE
ENH/BUG: Make emission_rate configurable in run_algorithm

### DIFF
--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -54,6 +54,7 @@ def _run(handle_data,
          algotext,
          defines,
          data_frequency,
+         emission_rate,
          capital_base,
          data,
          bundle,
@@ -170,6 +171,7 @@ def _run(handle_data,
             end=end,
             capital_base=capital_base,
             data_frequency=data_frequency,
+            emission_rate=emission_rate,
             trading_calendar=trading_calendar,
         ),
         **{
@@ -255,6 +257,7 @@ def run_algorithm(start,
                   before_trading_start=None,
                   analyze=None,
                   data_frequency='daily',
+                  emission_rate='daily',
                   data=None,
                   bundle=None,
                   bundle_timestamp=None,
@@ -290,6 +293,8 @@ def run_algorithm(start,
         performance data.
     data_frequency : {'daily', 'minute'}, optional
         The data frequency to run the algorithm at.
+    emission_rate : {'daily', 'minute'}, optional
+        The emission rate to run the algorithm at.
     data : pd.DataFrame, pd.Panel, or DataPortal, optional
         The ohlcv data to run the backtest with.
         This argument is mutually exclusive with:
@@ -358,6 +363,7 @@ def run_algorithm(start,
         algotext=None,
         defines=(),
         data_frequency=data_frequency,
+        emission_rate=emission_rate,
         capital_base=capital_base,
         data=data,
         bundle=bundle,


### PR DESCRIPTION
Currently, `emission_rate` in sim_params defaults to `daily`.

Defaulting to `daily` breaks minute-level benchmarks for `set_benchmark` (See https://github.com/quantopian/zipline/issues/1827).

Alternatives to exposing `emission_rate` to fix this benchmark issue seems to be either:
- Set something in `set_benchmark` to specify the benchmark's rate (ex: `set_benchmark(0, benchmark_frequency='minute')`)
- Default it to be the same as `data_frequency` - seems wrong

Let me know what I can add in terms of tests if this is a good approach.