### PR TITLE
BUG: get_last_traded_dt expects a trading day

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1599,8 +1599,16 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
 
         # January 5 2015 is the first day, and there is volume only every
         # 10 minutes.
+
+        # January 6 has the same volume pattern and is used here to ensure we
+        # ffill correctly from the previous day when there is no volume yet
+        # today.
+
+        # January 12 is a Monday, ensuring we ffill correctly when the previous
+        # day is not a trading day.
         for day_idx, day in enumerate([pd.Timestamp('2015-01-05', tz='UTC'),
-                                       pd.Timestamp('2015-01-06', tz='UTC')]):
+                                       pd.Timestamp('2015-01-06', tz='UTC'),
+                                       pd.Timestamp('2015-01-12', tz='UTC')]):
 
             session_minutes = self.trading_calendar.minutes_for_session(day)
 
@@ -1620,7 +1628,7 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                     (equity_minutes[-1], 391.0),   # Last minute of exchange
                     (session_minutes[-1], 391.0),  # Last minute of day
                 ])
-            else:
+            elif day_idx == 1:
                 minutes_to_test = OrderedDict([
                     (session_minutes[0], 391.0),   # ffill from yesterday
                     (equity_minutes[0], 391.0),    # ...
@@ -1628,6 +1636,13 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                     (equity_minutes[9], 401.0),    # New price today
                     (equity_minutes[-1], 781.0),   # Last minute of exchange
                     (session_minutes[-1], 781.0),  # Last minute of day
+                ])
+            else:
+                minutes_to_test = OrderedDict([
+                    (session_minutes[0], 1951.0),  # ffill from previous week
+                    (equity_minutes[0], 1951.0),   # ...
+                    (equity_minutes[8], 1951.0),   # ...
+                    (equity_minutes[9], 1961.0),   # New price today
                 ])
 
             for minute, expected in minutes_to_test.items():
@@ -1641,8 +1656,17 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
                     'minute',
                 )[self.ASSET3]
 
-                self.assertEqual(len(window), bar_count)
-                np.testing.assert_allclose(window[-1], expected)
+                self.assertEqual(
+                    len(window),
+                    bar_count,
+                    "Unexpected window length at {}. Expected {}, but was {}."
+                    .format(minute, bar_count, len(window))
+                )
+                np.testing.assert_allclose(
+                    window[-1],
+                    expected,
+                    err_msg="at minute {}".format(minute),
+                )
 
 
 class NoPrefetchMinuteEquityHistoryTestCase(MinuteEquityHistoryTestCase):

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -939,7 +939,7 @@ class DataPortal(object):
                 # volume in today's minute bars yet, we need to use the
                 # previous day's ffilled daily price. Using today's daily price
                 # could yield a value from later today.
-                history_start -= pd.Timedelta(days=1)
+                history_start -= self.trading_calendar.day
 
             initial_values = []
             for asset in df.columns[assets_with_leading_nan]:


### PR DESCRIPTION
Otherwise we get back NaN.

The consumer of `history_start` is the later call to `self.get_last_traded_dt`, which returns `NaN` for non-trading days.

We were so close to catching this in the [previous PR](https://github.com/quantopian/zipline/pull/2074#discussion_r159711938)...

@ehebert @yankees714 Is `DataPortal.trading_calendar` good enough here, or do we need to look up a calendar per asset (and/or per reader)?