### PR TITLE
labelarray boundary condition

### DIFF
--- a/tests/test_labelarray.py
+++ b/tests/test_labelarray.py
@@ -434,7 +434,7 @@ class LabelArrayTestCase(ZiplineTestCase):
         # uint8
         categories = create_categories(8, plus_one=False)
         arr = LabelArray(
-            [],
+            categories,
             missing_value=categories[0],
             categories=categories,
         )
@@ -449,7 +449,7 @@ class LabelArrayTestCase(ZiplineTestCase):
         # just over uint8
         categories = create_categories(8, plus_one=True)
         arr = LabelArray(
-            [],
+            categories,
             missing_value=categories[0],
             categories=categories,
         )
@@ -459,7 +459,8 @@ class LabelArrayTestCase(ZiplineTestCase):
         # fits in uint16
         categories = create_categories(16, plus_one=False)
         arr = LabelArray(
-            [], missing_value=categories[0],
+            categories,
+            missing_value=categories[0],
             categories=categories,
         )
         self.assertEqual(arr.itemsize, 2)
@@ -473,7 +474,7 @@ class LabelArrayTestCase(ZiplineTestCase):
         # just over uint16
         categories = create_categories(16, plus_one=True)
         arr = LabelArray(
-            [],
+            categories,
             missing_value=categories[0],
             categories=categories,
         )
@@ -487,6 +488,20 @@ class LabelArrayTestCase(ZiplineTestCase):
 
         # NOTE: we could do this for 32 and 64; however, no one has enough RAM
         # or time for that.
+
+    def test_known_categories_without_missing_at_boundary(self):
+        # This tests the case where we have exactly 256 unique categories but
+        # we didn't include the missing value in the categories.
+        categories = self.create_categories(8, plus_one=False)
+
+        arr = LabelArray(
+            categories,
+            None,
+            categories=categories,
+        )
+        self.check_roundtrip(arr)
+        # the missing value pushes us into 2 byte storage
+        self.assertEqual(arr.itemsize, 2)
 
     def test_narrow_condense_back_to_valid_size(self):
         categories = ['a'] * (2 ** 8 + 1)

--- a/zipline/lib/_factorize.pyx
+++ b/zipline/lib/_factorize.pyx
@@ -63,9 +63,6 @@ cdef factorize_strings_known_impl(np.ndarray[object] values,
                                   object missing_value,
                                   bint sort,
                                   np.ndarray[unsigned_integral] codes):
-    if missing_value not in categories:
-        categories.insert(0, missing_value)
-
     if sort:
         categories = sorted(categories, key=_NoneFirstSortKey)
 
@@ -91,6 +88,9 @@ cpdef factorize_strings_known_categories(np.ndarray[object] values,
     Any entries not in the specified categories will be given the code for
     `missing_value`.
     """
+    if missing_value not in categories:
+        categories.insert(0, missing_value)
+
     cdef Py_ssize_t ncategories = len(categories)
     cdef Py_ssize_t nvalues = len(values)
     if ncategories <= 2 ** 8:
@@ -134,7 +134,6 @@ cpdef factorize_strings_known_categories(np.ndarray[object] values,
 
 
 cdef factorize_strings_impl(np.ndarray[object] values,
-                            Py_ssize_t nvalues,
                             object missing_value,
                             bint sort,
                             np.ndarray[unsigned_integral] codes):
@@ -144,7 +143,7 @@ cdef factorize_strings_impl(np.ndarray[object] values,
     cdef Py_ssize_t i, code
     cdef object key = None
 
-    for i in range(nvalues):
+    for i in range(len(values)):
         key = values[i]
         code = reverse_categories.get(key, -1)
         if code == -1:
@@ -165,11 +164,13 @@ cdef factorize_strings_impl(np.ndarray[object] values,
     if sort:
         # This is all adapted from pandas.core.algorithms.factorize.
         ncategories = len(categories_array)
-        sorter = np.zeros(ncategories, dtype=np.int64)
+        sorter = np.empty(ncategories, dtype=np.int64)
 
         # Don't include missing_value in the argsort, because None is
         # unorderable with bytes/str in py3. Always just sort it to 0.
         sorter[1:] = categories_array[1:].argsort() + 1
+        sorter[0] = 0
+
         reverse_indexer = np.empty(ncategories, dtype=codes.dtype)
         reverse_indexer.put(sorter, np.arange(ncategories))
 
@@ -204,45 +205,43 @@ cpdef factorize_strings(np.ndarray[object] values,
     cdef np.ndarray categories_array
     cdef dict reverse_categories
 
-    if nvalues <= 2 ** 8:
+    # use exclusive less than because we need to account for the possibility
+    # that the missing value is not in values
+    if nvalues < 2 ** 8:
         # we won't try to shrink because the ``codes`` array cannot get any
         # smaller
         return factorize_strings_impl[np.uint8_t](
             values,
-            nvalues,
             missing_value,
             sort,
             np.empty(nvalues, dtype=np.uint8)
         )
-    elif nvalues <= 2 ** 16:
+    elif nvalues < 2 ** 16:
         (codes,
          categories_array,
          reverse_categories) = factorize_strings_impl[np.uint16_t](
             values,
-            nvalues,
             missing_value,
             sort,
-            np.empty(nvalues, np.uint16),
+            np.empty(nvalues, dtype=np.uint16),
         )
-    elif nvalues <= 2 ** 32:
+    elif nvalues < 2 ** 32:
         (codes,
          categories_array,
          reverse_categories) = factorize_strings_impl[np.uint32_t](
             values,
-            nvalues,
             missing_value,
             sort,
-            np.empty(nvalues, np.uint32),
+            np.empty(nvalues, dtype=np.uint32),
         )
-    elif nvalues <= 2 ** 64:
+    elif nvalues < 2 ** 64:
         (codes,
          categories_array,
          reverse_categories) = factorize_strings_impl[np.uint64_t](
             values,
-            nvalues,
             missing_value,
             sort,
-            np.empty(nvalues, np.uint64),
+            np.empty(nvalues, dtype=np.uint64),
         )
     else:
         # unreachable

--- a/zipline/pipeline/loaders/blaze/_core.pyx
+++ b/zipline/pipeline/loaders/blaze/_core.pyx
@@ -276,7 +276,7 @@ cdef _array_for_column_impl(object dtype,
     if column_type is object:
         # for object columns we need to maintain the unique values for the
         # categories
-        categories = set()
+        categories = {missing_value}
 
     cdef Py_ssize_t n
     for n in range(size if len(out_array) else 0):


### PR DESCRIPTION
fix an issue where labelarray construction checked the size of the categories to compute the word size before injecting the missing value.