### PR TITLE
MAINT: Latest pandas-datareader requires a newer pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ def _filter_requirements(lines_iter, filter_names=None,
 REQ_UPPER_BOUNDS = {
     'bcolz': '<1',
     'pandas': '<0.19',
+    'pandas-datareader': '<0.6',  # 0.6.0 requires pandas >=0.19.2
     'networkx': '<2.0',
 }
 
@@ -268,6 +269,7 @@ def setup_requirements(requirements_path, module_names, strict_bounds,
             % (module_names, module_lines)
         )
     return module_lines
+
 
 conda_build = os.path.basename(sys.argv[0]) in ('conda-build',  # unix
                                                 'conda-build-script.py')  # win


### PR DESCRIPTION
than zipline supports.

For https://github.com/quantopian/zipline/issues/2102