### PR TITLE
Improve price performance for 1000+ asset universes.

### DIFF
--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -648,38 +648,52 @@ class DataPortal(object):
     def _get_minute_spot_value(self, asset, column, dt, ffill=False):
         reader = self._get_pricing_reader('minute')
 
-        if ffill:
+        if not ffill:
+            try:
+                return reader.get_value(asset.sid, dt, column)
+            except NoDataOnDate:
+                if column != 'volume':
+                    return np.nan
+                else:
+                    return 0
+        else:
+            try:
+                # Optimize the best case scenario of a liquid asset
+                # returning a valid price.
+                result = reader.get_value(asset.sid, dt, column)
+                if column != 'volume':
+                    if not pd.isnull(result):
+                        return result
+                else:
+                    if result != 0:
+                        return result
+            except NoDataOnDate:
+                # Handling of no data for the desired date is done by the
+                # forward filling logic.
+                # The last trade may occur on a previous day.
+                pass
             # If forward filling, we want the last minute with values (up to
             # and including dt).
             query_dt = reader.get_last_traded_dt(asset, dt)
 
             if pd.isnull(query_dt):
                 # no last traded dt, bail
-                if column == 'volume':
-                    return 0
-                else:
+                if column != 'volume':
                     return np.nan
-        else:
-            # If not forward filling, we just want dt.
-            query_dt = dt
+                else:
+                    return 0
 
-        try:
             result = reader.get_value(asset.sid, query_dt, column)
-        except NoDataOnDate:
-            if column == 'volume':
-                return 0
-            else:
-                return np.nan
 
-        if not ffill or (dt == query_dt) or (dt.date() == query_dt.date()):
-            return result
+            if (dt == query_dt) or (dt.date() == query_dt.date()):
+                return result
 
-        # the value we found came from a different day, so we have to adjust
-        # the data if there are any adjustments on that day barrier
-        return self.get_adjusted_value(
-            asset, column, query_dt,
-            dt, "minute", spot_value=result
-        )
+            # the value we found came from a different day, so we have to
+            # adjust the data if there are any adjustments on that day barrier
+            return self.get_adjusted_value(
+                asset, column, query_dt,
+                dt, "minute", spot_value=result
+            )
 
     def _get_daily_spot_value(self, asset, column, dt):
         reader = self._get_pricing_reader('daily')

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -656,44 +656,44 @@ class DataPortal(object):
                     return np.nan
                 else:
                     return 0
-        else:
-            try:
-                # Optimize the best case scenario of a liquid asset
-                # returning a valid price.
-                result = reader.get_value(asset.sid, dt, column)
-                if column != 'volume':
-                    if not pd.isnull(result):
-                        return result
-                else:
-                    if result != 0:
-                        return result
-            except NoDataOnDate:
-                # Handling of no data for the desired date is done by the
-                # forward filling logic.
-                # The last trade may occur on a previous day.
-                pass
-            # If forward filling, we want the last minute with values (up to
-            # and including dt).
-            query_dt = reader.get_last_traded_dt(asset, dt)
 
-            if pd.isnull(query_dt):
-                # no last traded dt, bail
-                if column != 'volume':
-                    return np.nan
-                else:
-                    return 0
+        try:
+            # Optimize the best case scenario of a liquid asset
+            # returning a valid price.
+            result = reader.get_value(asset.sid, dt, column)
+            if column != 'volume':
+                if not pd.isnull(result):
+                    return result
+            else:
+                if result != 0:
+                    return result
+        except NoDataOnDate:
+            # Handling of no data for the desired date is done by the
+            # forward filling logic.
+            # The last trade may occur on a previous day.
+            pass
+        # If forward filling, we want the last minute with values (up to
+        # and including dt).
+        query_dt = reader.get_last_traded_dt(asset, dt)
 
-            result = reader.get_value(asset.sid, query_dt, column)
+        if pd.isnull(query_dt):
+            # no last traded dt, bail
+            if column != 'volume':
+                return np.nan
+            else:
+                return 0
 
-            if (dt == query_dt) or (dt.date() == query_dt.date()):
-                return result
+        result = reader.get_value(asset.sid, query_dt, column)
 
-            # the value we found came from a different day, so we have to
-            # adjust the data if there are any adjustments on that day barrier
-            return self.get_adjusted_value(
-                asset, column, query_dt,
-                dt, "minute", spot_value=result
-            )
+        if (dt == query_dt) or (dt.date() == query_dt.date()):
+            return result
+
+        # the value we found came from a different day, so we have to
+        # adjust the data if there are any adjustments on that day barrier
+        return self.get_adjusted_value(
+            asset, column, query_dt,
+            dt, "minute", spot_value=result
+        )
 
     def _get_daily_spot_value(self, asset, column, dt):
         reader = self._get_pricing_reader('daily')

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -657,16 +657,14 @@ class DataPortal(object):
                 else:
                     return 0
 
+        # At this point the pairing of column='close' and ffill=True is
+        # assumed.
         try:
             # Optimize the best case scenario of a liquid asset
             # returning a valid price.
             result = reader.get_value(asset.sid, dt, column)
-            if column != 'volume':
-                if not pd.isnull(result):
-                    return result
-            else:
-                if result != 0:
-                    return result
+            if not pd.isnull(result):
+                return result
         except NoDataOnDate:
             # Handling of no data for the desired date is done by the
             # forward filling logic.
@@ -678,10 +676,7 @@ class DataPortal(object):
 
         if pd.isnull(query_dt):
             # no last traded dt, bail
-            if column != 'volume':
-                return np.nan
-            else:
-                return 0
+            return np.nan
 
         result = reader.get_value(asset.sid, query_dt, column)
 

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -1140,7 +1140,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
         return self._pos_to_minute(minute_pos)
 
     def _find_last_traded_position(self, asset, dt):
-        volumes = self._open_minute_file('volume', asset)
+        volumes = self._open_minute_file('close', asset)
         start_date_minute = asset.start_date.value / NANOS_IN_MINUTE
         dt_minute = dt.value / NANOS_IN_MINUTE
 

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -1140,7 +1140,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
         return self._pos_to_minute(minute_pos)
 
     def _find_last_traded_position(self, asset, dt):
-        volumes = self._open_minute_file('close', asset)
+        volumes = self._open_minute_file('volume', asset)
         start_date_minute = asset.start_date.value / NANOS_IN_MINUTE
         dt_minute = dt.value / NANOS_IN_MINUTE
 


### PR DESCRIPTION
Improve performance for algorithms which consider and/or hold positions for 1000+ assets, especially liquid assets.

PERF: Optimize price for liquid assets.

When using `price`, the call to `last_traded_dt` for every value retrieved
became a noticeable bottleneck in algorithms which used over 1000 assets.

Instead of calling `last_traded_dt` before every retrieval of a `close` for the
`price` field, assume that `close` will retrieve a non-empty value, and then
forward fill if it is empty.

This change optimizes for the case of a tradeable universe which is predominately
composed of liquid assets.

EDIT: (The PR originally had a change to which column is used for the minute bar reader's `last_traded_dt`, but it was removed; to be implemented in a separate PR.)