### PR TITLE
MAINT: Pass asset instead of sid to dispatch reader.

### DIFF
--- a/zipline/assets/roll_finder.py
+++ b/zipline/assets/roll_finder.py
@@ -96,7 +96,7 @@ class RollFinder(with_metaclass(ABCMeta, object)):
         else:
             first = front
         first_contract = oc.sid_to_contract[first]
-        rolls = [((first_contract >> offset).contract.sid, None)]
+        rolls = [((first_contract >> offset).contract, None)]
         tc = self.trading_calendar
         sessions = tc.sessions_in_range(tc.minute_to_session_label(start),
                                         tc.minute_to_session_label(end))
@@ -115,7 +115,7 @@ class RollFinder(with_metaclass(ABCMeta, object)):
         session = sessions[-1]
 
         while session > start and curr is not None:
-            front = curr.contract.sid
+            front = curr.contract
             back = rolls[0][0]
             prev_c = curr.prev
             while session > start:
@@ -127,7 +127,7 @@ class RollFinder(with_metaclass(ABCMeta, object)):
                     # TODO: Instead of listing each contract with its roll date
                     # as tuples, create a series which maps every day to the
                     # active contract on that day.
-                    rolls.insert(0, ((curr >> offset).contract.sid, session))
+                    rolls.insert(0, ((curr >> offset).contract, session))
                     break
                 session = prev
             curr = curr.prev

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -634,7 +634,7 @@ class DataPortal(object):
 
         if not ffill:
             try:
-                return reader.get_value(asset.sid, dt, column)
+                return reader.get_value(asset, dt, column)
             except NoDataOnDate:
                 if column != 'volume':
                     return np.nan
@@ -646,7 +646,7 @@ class DataPortal(object):
         try:
             # Optimize the best case scenario of a liquid asset
             # returning a valid price.
-            result = reader.get_value(asset.sid, dt, column)
+            result = reader.get_value(asset, dt, column)
             if not pd.isnull(result):
                 return result
         except NoDataOnDate:
@@ -662,7 +662,7 @@ class DataPortal(object):
             # no last traded dt, bail
             return np.nan
 
-        result = reader.get_value(asset.sid, query_dt, column)
+        result = reader.get_value(asset, query_dt, column)
 
         if (dt == query_dt) or (dt.date() == query_dt.date()):
             return result

--- a/zipline/data/dispatch_bar_reader.py
+++ b/zipline/data/dispatch_bar_reader.py
@@ -91,8 +91,7 @@ class AssetDispatchBarReader(with_metaclass(ABCMeta)):
     def first_trading_day(self):
         return max(r.first_trading_day for r in self._readers.values())
 
-    def get_value(self, sid, dt, field):
-        asset = self._asset_finder.retrieve_asset(sid)
+    def get_value(self, asset, dt, field):
         r = self._readers[type(asset)]
         return r.get_value(asset, dt, field)
 

--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -221,14 +221,14 @@ class ContinuousFutureAdjustmentReader(object):
         adjs = {}
 
         for front, back in sliding_window(2, rolls):
-            front_sid, roll_dt = front
-            back_sid = back[0]
+            front_contract, roll_dt = front
+            back_contract = back[0]
             dt = tc.previous_session_label(roll_dt)
             if self._frequency == 'minute':
                 dt = tc.open_and_close_for_session(dt)[1]
                 roll_dt = tc.open_and_close_for_session(roll_dt)[0]
-            partitions.append((front_sid,
-                               back_sid,
+            partitions.append((front_contract,
+                               back_contract,
                                dt,
                                roll_dt))
         for partition in partitions:


### PR DESCRIPTION
So that the asset does not need to be re-retrieved from the asset finder, pass
assets to the dispatch reader's `get_value`.

### Other Notes

This was noticed during an investigation into calling `get_spot_value` every bar.
There is a small performance benefit (<1% improvement in runtime for an algo that references 1000 assets every minute).
Regardless of the performance gain, making the dispatch reader's `get_value` expect an `Asset` type cleans up the use of the `BarReader` interface.