### PR TITLE
MAINT: kill the metrics tracker at the end of the simulation

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -932,7 +932,7 @@ class AssetFinderTestCase(WithTradingCalendars, ZiplineTestCase):
         post_map = finder.map_identifier_index_to_sids(pre_map, dt)
         self.assertListEqual([1, 2, 200, 201], post_map)
         for sid in post_map:
-            self.assertIsInstance(sid, int)
+            self.assertIsInstance(sid, integer_types)
 
         # Change order and check mapping again
         pre_map = [asset201, asset2, asset200, asset1]

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -736,6 +736,7 @@ class TradingAlgorithm(object):
             self.analyze(daily_stats)
         finally:
             self.data_portal = None
+            self.metrics_tracker = None
 
         return daily_stats
 

--- a/zipline/finance/metrics/tracker.py
+++ b/zipline/finance/metrics/tracker.py
@@ -103,14 +103,14 @@ class MetricsTracker(object):
         )
 
         if emission_rate == 'minute':
-            def progress():
+            def progress(self):
                 return 1.0  # a fake value
         else:
-            def progress():
+            def progress(self):
                 return self._session_count / self._total_session_count
 
         # don't compare these strings over and over again!
-        self.progress = progress
+        self._progress = progress
 
         # bind all of the hooks from the passed metric objects.
         for hook in self._hooks:
@@ -228,7 +228,7 @@ class MetricsTracker(object):
                 'period_open': self._first_session,
                 'period_close': self._last_session,
             },
-            'progress': self.progress(),
+            'progress': self._progress(self),
             'cumulative_risk_metrics': {},
         }
         ledger = self._ledger
@@ -312,7 +312,7 @@ class MetricsTracker(object):
                 'period_open': self._first_session,
                 'period_close': self._last_session,
             },
-            'progress': self.progress(),
+            'progress': self._progress(self),
             'cumulative_risk_metrics': {},
         }
         ledger = self._ledger


### PR DESCRIPTION
This releases the benchmark source, which releases the data portal, which
releases the locks on the on disk files.