### PR TITLE
fix type error caused by: df[mask] = 0

### DIFF
--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -160,7 +160,7 @@ def winsorise_uint32(df, invalid_data_behavior, column, *columns):
                 stacklevel=3,  # one extra frame for `expect_element`
             )
 
-    df[mask] = 0
+    df = df.where(~mask, other=0)
     return df
 
 


### PR DESCRIPTION
When `mask` is all `False`, pandas will raise TypeError: Cannot do inplace boolean setting on mixed-types with a non np.nan value.

Reproduce when import csvdir_equities from a .csv file, like below:

```
date,time,close,high,low,match,open,volume,turnover,matchitems
2018/04/04,2018/4/04,172.07,172.41,166.13,172.07,166.88,24573593,0,0
2018/04/05,2018/4/05,172.57,176.56,171.17,172.57,175.48,18250947,0,0