### PR TITLE
DOC: add import to beginner tutorial to fix NameError

### DIFF
--- a/docs/source/beginner-tutorial.rst
+++ b/docs/source/beginner-tutorial.rst
@@ -843,6 +843,7 @@ Let's look at the strategy which should make this clear:
 
 
    from zipline.api import order_target, record, symbol
+   import matplotlib.pyplot as plt
 
    def initialize(context):
        context.i = 0


### PR DESCRIPTION
The DMA cross-over working example was missing an import of `matplotlib.pyplot` which led to a `NameError: global name 'plt' is not defined` when running in an iPython notebook. 