### PR TITLE
Support pandas 0.22, from_csv warning, %zipline -f algo.py in notebook

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ install:
   - ps: $env:BCOLZ_VERSION=(sls "bcolz==(.*)" .\etc\requirements.txt -ca).matches.groups[1].value
   - ps: $env:NUMEXPR_VERSION=(sls "numexpr==(.*)" .\etc\requirements.txt -ca).matches.groups[1].value
   - ps: $env:TALIB_VERSION=(sls "TA-Lib==(.*)" .\etc\requirements_talib.txt -ca).matches.groups[1].value
-  - conda create -n testenv --yes -q --use-local pip python=%PYTHON_VERSION% numpy=%NUMPY_VERSION% scipy=%SCIPY_VERSION% ta-lib=%TALIB_VERSION% bcolz=%BCOLZ_VERSION% numexpr=%NUMEXPR_VERSION% -c quantopian -c https://conda.anaconda.org/quantopian/label/ci
+  - conda create -n testenv --yes -q --use-local pip cython python=%PYTHON_VERSION% numpy=%NUMPY_VERSION% scipy=%SCIPY_VERSION% ta-lib=%TALIB_VERSION% bcolz=%BCOLZ_VERSION% numexpr=%NUMEXPR_VERSION% -c quantopian -c https://conda.anaconda.org/quantopian/label/ci
   - activate testenv
   - SET CACHE_DIR=%LOCALAPPDATA%\pip\Cache\pip_np%CONDA_NPY%py%CONDA_PY%
   - pip install -r etc/requirements.txt --cache-dir=%CACHE_DIR%

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -17,7 +17,7 @@ requests-file==1.4.1
 # scipy and pandas are required for statsmodels,
 # statsmodels in turn is required for some pandas packages
 scipy>=0.17.1
-pandas>=0.18.1
+pandas>=0.18.1,<0.23
 pandas-datareader>=0.2.1
 # Needed for parts of pandas.stats
 patsy==0.4.0

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -9,19 +9,19 @@ Logbook==0.12.5
 # Scientific Libraries
 
 pytz==2016.4
-numpy==1.11.1
+numpy>=1.11.1
 
 # for pandas-datareader
 requests-file==1.4.1
 
 # scipy and pandas are required for statsmodels,
 # statsmodels in turn is required for some pandas packages
-scipy==0.17.1
-pandas==0.18.1
-pandas-datareader==0.2.1
+scipy>=0.17.1
+pandas>=0.18.1
+pandas-datareader>=0.2.1
 # Needed for parts of pandas.stats
 patsy==0.4.0
-statsmodels==0.6.1
+statsmodels>=0.6.1
 
 python-dateutil==2.4.2
 six==1.10.0

--- a/etc/requirements_blaze.txt
+++ b/etc/requirements_blaze.txt
@@ -5,7 +5,7 @@
 cytoolz==0.8.2
 
 # Transitive dependencies of blaze:
-dask[dataframe]==0.13.0
+dask[dataframe]>=0.13.0
 partd==0.3.7
 locket==0.2.0
 cloudpickle==0.2.1
@@ -17,4 +17,4 @@ MarkupSafe==0.23
 Werkzeug==0.10.4
 psutil==4.3.0
 
--e git://github.com/quantopian/blaze.git@310605323449e375e81a0cf04011c507cd126ef6#egg=blaze-dev
+blaze

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -43,7 +43,7 @@ mistune==0.7
 
 # Required by tornado
 backports.ssl-match-hostname==3.4.0.2;python_version<'3.0'
-certifi==2015.4.28
+certifi>=2015.4.28
 
 # matplotlib dependencies:
 tornado==4.2.1

--- a/setup.py
+++ b/setup.py
@@ -171,8 +171,6 @@ def _filter_requirements(lines_iter, filter_names=None,
 
 REQ_UPPER_BOUNDS = {
     'bcolz': '<1',
-    'pandas': '<0.19',
-    'pandas-datareader': '<0.6',  # 0.6.0 requires pandas >=0.19.2
     'networkx': '<2.0',
 }
 

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,7 @@ def _filter_requirements(lines_iter, filter_names=None,
 
 REQ_UPPER_BOUNDS = {
     'bcolz': '<1',
+    'pandas': '<0.23',
     'networkx': '<2.0',
 }
 

--- a/tests/calendars/test_trading_calendar.py
+++ b/tests/calendars/test_trading_calendar.py
@@ -24,7 +24,6 @@ import numpy as np
 import pandas as pd
 from nose_parameterized import parameterized
 from pandas import read_csv
-from pandas.tslib import Timedelta
 from pandas.util.testing import assert_index_equal
 from pytz import timezone
 from toolz import concat
@@ -35,6 +34,7 @@ from zipline.errors import (
 )
 
 from zipline.testing.predicates import assert_equal
+from zipline.lib.tslib import Timedelta
 from zipline.utils.calendars import (
     deregister_calendar,
     get_calendar,

--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -21,7 +21,6 @@ import datetime
 from math import sqrt
 
 from nose_parameterized import parameterized
-from pandas.tslib import normalize_date
 import numpy as np
 import pandas as pd
 import pytz
@@ -51,6 +50,7 @@ from zipline.testing.fixtures import (
     WithTradingEnvironment,
     ZiplineTestCase,
 )
+from zipline.lib.tslib import normalize_date
 from zipline.utils.classproperty import classproperty
 
 

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -27,7 +27,6 @@ from pandas import (
     Series,
     Timestamp,
 )
-from pandas.tseries.tools import normalize_date
 from six import iteritems, itervalues
 
 from zipline.algorithm import TradingAlgorithm
@@ -63,6 +62,7 @@ from zipline.testing.fixtures import (
     WithDataPortal,
     ZiplineTestCase,
 )
+from zipline.lib.tslib import normalize_date
 from zipline.utils.calendars import get_calendar
 
 TEST_RESOURCE_PATH = join(

--- a/tests/test_data_portal.py
+++ b/tests/test_data_portal.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 from numpy import array, append, nan, full
 from numpy.testing import assert_almost_equal
 import pandas as pd
-from pandas.tslib import Timedelta
 from six import iteritems
 
 from zipline.assets import Equity, Future
@@ -34,6 +33,7 @@ from zipline.testing.fixtures import (
     alias,
 )
 from zipline.testing.predicates import assert_equal
+from zipline.lib.tslib import Timedelta
 from zipline.utils.numpy_utils import float64_dtype
 
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -395,8 +395,8 @@ def handle_data(context, data):
 
             algocode = """
 from pandas import Timestamp
-from pandas.tseries.tools import normalize_date
 from zipline.api import fetch_csv, record, sid, get_datetime
+from zipline.lib.tslib import normalize_date
 
 def initialize(context):
     fetch_csv(

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -228,6 +228,8 @@ def run(ctx,
     if end is None:
         ctx.fail("must specify an end date with '-e' / '--end'")
 
+    if algotext == '':
+        algotext = None
     if (algotext is not None) == (algofile is not None):
         ctx.fail(
             "must specify exactly one of '-f' / '--algofile' or"

--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -16,7 +16,6 @@ import warnings
 from contextlib import contextmanager
 from functools import wraps
 
-from pandas.tslib import normalize_date
 import pandas as pd
 import numpy as np
 
@@ -31,6 +30,7 @@ from zipline.assets import (
 from zipline.assets._assets cimport Asset, Future
 from zipline.assets.continuous_futures import ContinuousFuture
 from zipline.zipline_warnings import ZiplineDeprecationWarning
+from zipline.lib.tslib import normalize_date
 
 
 cdef bool _is_iterable(obj):

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -21,7 +21,6 @@ import logbook
 import pytz
 import pandas as pd
 from contextlib2 import ExitStack
-from pandas.tseries.tools import normalize_date
 import numpy as np
 
 from itertools import chain, repeat
@@ -94,6 +93,7 @@ from zipline.pipeline.engine import (
     ExplodingPipelineEngine,
     SimplePipelineEngine,
 )
+from zipline.lib.tslib import normalize_date
 from zipline.utils.api_support import (
     api_method,
     require_initialized,

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -20,7 +20,6 @@ import numpy as np
 from numpy import float64, int64, nan
 import pandas as pd
 from pandas import isnull
-from pandas.tslib import normalize_date
 from six import iteritems
 from six.moves import reduce
 
@@ -59,6 +58,7 @@ from zipline.utils.math_utils import (
     nanmean,
     nanstd
 )
+from zipline.lib.tslib import normalize_date
 from zipline.utils.memoize import remember_last, weak_lru_cache
 from zipline.utils.pandas_utils import timedelta_to_integral_minutes
 from zipline.errors import HistoryWindowStartsBeforeData

--- a/zipline/data/history_loader.py
+++ b/zipline/data/history_loader.py
@@ -21,13 +21,13 @@ from abc import (
 from numpy import concatenate
 from lru import LRU
 from pandas import isnull
-from pandas.tslib import normalize_date
 from toolz import sliding_window
 
 from six import with_metaclass
 
 from zipline.assets import Equity, Future
 from zipline.assets.continuous_futures import ContinuousFuture
+from zipline.lib.tslib import normalize_date
 from zipline.lib._int64window import AdjustedArrayWindow as Int64Window
 from zipline.lib._float64window import AdjustedArrayWindow as Float64Window
 from zipline.lib.adjustment import Float64Multiply, Float64Add

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -295,9 +295,10 @@ def ensure_treasury_data(symbol, first_date, last_date, now, environ=None):
 def _load_cached_data(filename, first_date, last_date, now, resource_name,
                       environ=None):
     if resource_name == 'benchmark':
-        from_csv = pd.Series.from_csv
+        from_csv = lambda path: pd.read_csv(path, index_col=0, header=None, parse_dates=True,
+                                            squeeze=True)
     else:
-        from_csv = pd.DataFrame.from_csv
+        from_csv = lambda path: pd.read_csv(path, index_col=0, parse_dates=True)
 
     # Path for the cache.
     path = get_data_filepath(filename, environ)

--- a/zipline/data/us_equity_pricing.py
+++ b/zipline/data/us_equity_pricing.py
@@ -45,7 +45,6 @@ from pandas import (
     to_datetime,
     Timestamp,
 )
-from pandas.tslib import iNaT
 from six import (
     iteritems,
     string_types,
@@ -59,6 +58,7 @@ from zipline.data.bar_reader import (
     NoDataBeforeDate,
     NoDataOnDate,
 )
+from zipline.lib.tslib import iNaT
 from zipline.utils.calendars import get_calendar
 from zipline.utils.functional import apply
 from zipline.utils.preprocess import call

--- a/zipline/finance/trading.py
+++ b/zipline/finance/trading.py
@@ -16,13 +16,13 @@ from functools import partial
 
 import logbook
 import pandas as pd
-from pandas.tslib import normalize_date
 from six import string_types
 from sqlalchemy import create_engine
 
 from zipline.assets import AssetDBWriter, AssetFinder
 from zipline.assets.continuous_futures import CHAIN_PREDICATES
 from zipline.data.loader import load_market_data
+from zipline.lib.tslib import normalize_date
 from zipline.utils.calendars import get_calendar
 from zipline.utils.memoize import remember_last
 

--- a/zipline/lib/tslib.py
+++ b/zipline/lib/tslib.py
@@ -1,4 +1,6 @@
-try:
-    from pandas.tslib import iNaT, normalize_date, Timedelta, Timestamp
-except ImportError:
+import pandas
+
+if pandas.__version__ >= '0.20.0':
     from pandas._libs.tslib import iNaT, normalize_date, Timedelta, Timestamp
+else:
+    from pandas.tslib import iNaT, normalize_date, Timedelta, Timestamp

--- a/zipline/lib/tslib.py
+++ b/zipline/lib/tslib.py
@@ -1,4 +1,4 @@
 try:
-    from pandas.tslib import iNaT, normalize_date, Timedelta
+    from pandas.tslib import iNaT, normalize_date, Timedelta, Timestamp
 except ImportError:
-    from pandas._libs.tslib import iNaT, normalize_date, Timedelta
+    from pandas._libs.tslib import iNaT, normalize_date, Timedelta, Timestamp

--- a/zipline/lib/tslib.py
+++ b/zipline/lib/tslib.py
@@ -1,0 +1,4 @@
+try:
+    from pandas.tslib import iNaT, normalize_date, Timedelta
+except ImportError:
+    from pandas._libs.tslib import iNaT, normalize_date, Timedelta

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -511,12 +511,13 @@ class WithTradingEnvironment(WithAssetFinder,
             filename = get_benchmark_filename(symbol)
             source_path = os.path.join(cls.MARKET_DATA_DIR, filename)
             benchmark_returns = \
-                pd.Series.from_csv(source_path).tz_localize('UTC')
+                pd.read_csv(source_path, index_col=0, header=None, parse_dates=True,
+                            squeeze=True).tz_localize('UTC')
 
             filename = INDEX_MAPPING[symbol][1]
             source_path = os.path.join(cls.MARKET_DATA_DIR, filename)
             treasury_curves = \
-                pd.DataFrame.from_csv(source_path).tz_localize('UTC')
+                pd.read_csv(source_path, index_col=0, parse_dates=True).tz_localize('UTC')
 
             # The TradingEnvironment ordinarily uses cached benchmark returns
             # and treasury curves data, but when running the zipline tests this

--- a/zipline/utils/calendars/exchange_calendar_ice.py
+++ b/zipline/utils/calendars/exchange_calendar_ice.py
@@ -7,9 +7,9 @@ from pandas.tseries.holiday import (
     USLaborDay,
     USThanksgivingDay
 )
-from pandas.tslib import Timestamp
 from pytz import timezone
 
+from zipline.lib.tslib import Timestamp
 from zipline.utils.calendars import TradingCalendar
 from zipline.utils.calendars.trading_calendar import HolidayCalendar
 from zipline.utils.calendars.us_holidays import (

--- a/zipline/utils/factory.py
+++ b/zipline/utils/factory.py
@@ -27,6 +27,7 @@ from zipline.protocol import Event, DATASOURCE_TYPE
 from zipline.sources import SpecificEquityTrades
 from zipline.finance.trading import SimulationParameters
 from zipline.sources.test_source import create_trade
+from zipline.lib.tslib import normalize_date
 from zipline.utils.input_validation import expect_types
 from zipline.utils.calendars import get_calendar
 
@@ -113,9 +114,9 @@ def create_dividend(sid, payment, declared_date, ex_date, pay_date):
         'net_amount': payment,
         'payment_sid': None,
         'ratio': None,
-        'declared_date': pd.tslib.normalize_date(declared_date),
-        'ex_date': pd.tslib.normalize_date(ex_date),
-        'pay_date': pd.tslib.normalize_date(pay_date),
+        'declared_date': normalize_date(declared_date),
+        'ex_date': normalize_date(ex_date),
+        'pay_date': normalize_date(pay_date),
         'type': DATASOURCE_TYPE.DIVIDEND,
         'source_id': 'MockDividendSource'
     })
@@ -130,9 +131,9 @@ def create_stock_dividend(sid, payment_sid, ratio, declared_date,
         'ratio': ratio,
         'net_amount': None,
         'gross_amount': None,
-        'dt': pd.tslib.normalize_date(declared_date),
-        'ex_date': pd.tslib.normalize_date(ex_date),
-        'pay_date': pd.tslib.normalize_date(pay_date),
+        'dt': normalize_date(declared_date),
+        'ex_date': normalize_date(ex_date),
+        'pay_date': normalize_date(pay_date),
         'type': DATASOURCE_TYPE.DIVIDEND,
         'source_id': 'MockDividendSource'
     })


### PR DESCRIPTION
This pull request does three things:

+ Support for pandas 0.20, 0.21, 0.22
+ Replace from_csv by read_csv, which is deprecated in newer version of pandas
+ Support for using %zipline -f algo.py ... in notebook. The current behavior will throw an error because both algotext and algoscript are not None.