### PR TITLE
BUG: Prevent negative lookup in history.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -642,6 +642,20 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
         with self.assertRaises(HistoryInInitialize):
             test_algo.initialize()
 
+    def test_negative_bar_count(self):
+        """
+        Negative bar counts leak future information.
+        """
+        with self.assertRaises(ValueError):
+            self.data_portal.get_history_window(
+                [self.ASSET1],
+                pd.Timestamp('2015-01-07 14:35', tz='UTC'),
+                -1,
+                '1d',
+                'close',
+                'minute',
+            )
+
     def test_daily_splits_and_mergers(self):
         # self.SPLIT_ASSET and self.MERGER_ASSET had splits/mergers
         # on 1/6 and 1/7

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -646,7 +646,10 @@ class MinuteEquityHistoryTestCase(WithHistory, ZiplineTestCase):
         """
         Negative bar counts leak future information.
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(
+                ValueError,
+                "bar_count must be >= 1, but got -1"
+        ):
             self.data_portal.get_history_window(
                 [self.ASSET1],
                 pd.Timestamp('2015-01-07 14:35', tz='UTC'),

--- a/zipline/data/data_portal.py
+++ b/zipline/data/data_portal.py
@@ -951,6 +951,11 @@ class DataPortal(object):
         if field not in OHLCVP_FIELDS and field != 'sid':
             raise ValueError("Invalid field: {0}".format(field))
 
+        if bar_count < 1:
+            raise ValueError(
+                "bar_count must be >= 1, but got {}".format(bar_count)
+            )
+
         if frequency == "1d":
             if field == "price":
                 df = self._get_history_daily_window(assets, end_dt, bar_count,


### PR DESCRIPTION
Raise a value error on negative bar counts to prevent lookups ahead of
simulation time.