### PR TITLE
ENH: Custom command line argument support

### DIFF
--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,11 +1,13 @@
 import zipline.__main__ as main
+import zipline
 from zipline.testing import ZiplineTestCase
 from zipline.testing.predicates import (
     assert_equal,
     assert_raises_str,
+    assert_is,
 )
-from mock import patch
 from click.testing import CliRunner
+from zipline.extensions import ExtensionArgs
 
 
 class CmdLineTestCase(ZiplineTestCase):
@@ -14,25 +16,48 @@ class CmdLineTestCase(ZiplineTestCase):
         super(CmdLineTestCase, self).init_instance_fixtures()
 
         # make sure this starts empty
-        assert_equal(main.extension_args, {})
+        # TODO: decide how this needs to be reset
+        zipline.extension_args = ExtensionArgs([])
 
     def test_parse_args(self):
-        with patch.dict(main.extension_args, {}):
-            main.parse_extension_arg('arg1=test1')
-            main.parse_extension_arg('arg2=test2')
 
-            assert_equal(main.extension_args,
-                         {'arg2': 'test2', 'arg1': 'test1'})
-            msg = 'invalid extension argument 1=test3, ' \
-                  'must be in key=value form'
-            with assert_raises_str(ValueError, msg):
-                main.parse_extension_arg('1=test3')
-            msg = 'invalid extension argument arg4 test4, ' \
-                  'must be in key=value form'
-            with assert_raises_str(ValueError, msg):
-                main.parse_extension_arg('arg4 test4')
+        e = ExtensionArgs(['arg1=test1', 'arg2=test2'])
+        assert_equal(e.extension_args,
+                     {'arg2': 'test2', 'arg1': 'test1'})
+        assert_equal(e.arg1, 'test1')
+        assert_equal(e.arg2, 'test2')
+
+        msg = 'invalid extension argument 1=test3, ' \
+              'must be in key=value form'
+        with assert_raises_str(ValueError, msg):
+            e.parse_extension_arg('1=test3')
+        msg = 'invalid extension argument arg4 test4, ' \
+              'must be in key=value form'
+        with assert_raises_str(ValueError, msg):
+            e.parse_extension_arg('arg4 test4')
+
+    def test_parse_namespaces(self):
+
+        e = ExtensionArgs(["first.second.a=blah1",
+                           "first.second.b=blah2",
+                           "first.third=blah3", ])
+        assert_equal(e.first.second.a, 'blah1')
+        assert_equal(e.first.second.b, 'blah2')
+        assert_equal(e.first.third, 'blah3')
+
+        msg = "Conflicting assignments at namespace level 'second'"
+        with assert_raises_str(ValueError, msg):
+            e = ExtensionArgs(["first.second.a=blah1",
+                               "first.second.b=blah2",
+                               "first.second=blah3", ])
 
     def test_user_input(self):
-        with patch.dict(main.extension_args, {}):
-            runner = CliRunner()
-            result = runner.invoke(main.main, [])
+        runner = CliRunner()
+        result = runner.invoke(main.main, [    '-xfirst.second.a=blah1',
+                                       '-xfirst.second.b=blah2',
+                                       '-xfirst.third=blah3',
+                                  'bundles', ])
+
+        assert_equal(zipline.extension_args.first.second.a, 'blah1')
+        assert_equal(zipline.extension_args.first.second.b, 'blah2')
+        assert_equal(zipline.extension_args.first.third, 'blah3')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -6,7 +6,11 @@ from zipline.testing.predicates import (
     assert_raises_str,
 )
 from click.testing import CliRunner
-from zipline.extensions import ExtensionArgs
+from zipline.extensions import (
+    Namespace,
+    create_args,
+    parse_extension_arg,
+)
 
 
 class CmdLineTestCase(ZiplineTestCase):
@@ -16,47 +20,119 @@ class CmdLineTestCase(ZiplineTestCase):
 
         # make sure this starts empty
         # TODO: decide how this needs to be reset
-        zipline.extension_args = ExtensionArgs([])
+        zipline.extension_args = Namespace()
 
     def test_parse_args(self):
 
-        e = ExtensionArgs(['arg1=test1', 'arg2=test2'])
-        assert_equal(e.extension_args,
-                     {'arg2': 'test2', 'arg1': 'test1'})
-        assert_equal(e.arg1, 'test1')
-        assert_equal(e.arg2, 'test2')
+        arg_dict = {}
 
-        msg = 'invalid extension argument 1=test3, ' \
-              'must be in key=value form'
+        arg_list = [
+            'key=value',
+            'arg1=test1',
+            'arg2=test2',
+            'arg_3=test3',
+            '_arg_4_=test4',
+        ]
+        for arg in arg_list:
+            parse_extension_arg(arg, arg_dict)
+        assert_equal(
+            arg_dict,
+            {
+                '_arg_4_': 'test4',
+                'arg_3': 'test3',
+                'arg2': 'test2',
+                'arg1': 'test1',
+                'key': 'value',
+            }
+        )
+        create_args(arg_list, zipline.extension_args)
+        assert_equal(zipline.extension_args.key, 'value')
+        assert_equal(zipline.extension_args.arg1, 'test1')
+        assert_equal(zipline.extension_args.arg2, 'test2')
+        assert_equal(zipline.extension_args.arg_3, 'test3')
+        assert_equal(zipline.extension_args._arg_4_, 'test4')
+
+        msg = (
+            'invalid extension argument 1=test3, '
+            'must be in key=value form'
+        )
         with assert_raises_str(ValueError, msg):
-            e.parse_extension_arg('1=test3')
-        msg = 'invalid extension argument arg4 test4, ' \
-              'must be in key=value form'
+            parse_extension_arg('1=test3', {})
+        msg = (
+            'invalid extension argument arg4 test4, '
+            'must be in key=value form'
+        )
         with assert_raises_str(ValueError, msg):
-            e.parse_extension_arg('arg4 test4')
+            parse_extension_arg('arg4 test4', {})
+        msg = (
+            'invalid extension argument arg5.1=test5, '
+            'must be in key=value form'
+        )
+        with assert_raises_str(ValueError, msg):
+            parse_extension_arg('arg5.1=test5', {})
+        msg = (
+            'invalid extension argument arg6.6arg=test6, '
+            'must be in key=value form'
+        )
+        with assert_raises_str(ValueError, msg):
+            parse_extension_arg('arg6.6arg=test6', {})
+        msg = (
+            'invalid extension argument arg7.-arg7=test7, '
+            'must be in key=value form'
+        )
+        with assert_raises_str(ValueError, msg):
+            parse_extension_arg('arg7.-arg7=test7', {})
 
     def test_parse_namespaces(self):
 
-        e = ExtensionArgs(["first.second.a=blah1",
-                           "first.second.b=blah2",
-                           "first.third=blah3", ])
-        assert_equal(e.first.second.a, 'blah1')
-        assert_equal(e.first.second.b, 'blah2')
-        assert_equal(e.first.third, 'blah3')
-
-        msg = "Conflicting assignments at namespace level 'second'"
-        with assert_raises_str(ValueError, msg):
-            e = ExtensionArgs(["first.second.a=blah1",
-                               "first.second.b=blah2",
-                               "first.second=blah3", ])
-
-    def test_user_input(self):
-        runner = CliRunner()
-        runner.invoke(main.main, ['-xfirst.second.a=blah1',
-                                  '-xfirst.second.b=blah2',
-                                  '-xfirst.third=blah3',
-                                  'bundles', ])
-
+        create_args(
+            [
+                "first.second.a=blah1",
+                "first.second.b=blah2",
+                "first.third=blah3",
+                "second.a=blah4",
+                "second.b=blah5",
+            ],
+            zipline.extension_args
+        )
         assert_equal(zipline.extension_args.first.second.a, 'blah1')
         assert_equal(zipline.extension_args.first.second.b, 'blah2')
         assert_equal(zipline.extension_args.first.third, 'blah3')
+        assert_equal(zipline.extension_args.second.a, 'blah4')
+        assert_equal(zipline.extension_args.second.b, 'blah5')
+
+        zipline.extension_args = Namespace()
+
+        msg = "Conflicting assignments at namespace level 'second'"
+        with assert_raises_str(ValueError, msg):
+            create_args(
+                [
+                    "first.second.a=blah1",
+                    "first.second.b=blah2",
+                    "first.second=blah3",
+                ],
+                zipline.extension_args
+            )
+
+    def test_user_input(self):
+        runner = CliRunner()
+        result = runner.invoke(main.main, [
+            '-xfirst.second.a=blah1',
+            '-xfirst.second.b=blah2',
+            '-xfirst.third=blah3',
+            '-xsecond.a.b=blah4',
+            '-xsecond.b.a=blah5',
+            '-xa1=value1',
+            '-xb_=value2',
+            'bundles',
+        ])
+
+        print(result.output)
+        assert_equal(result.exit_code, 0)  # assert successful invocation
+        assert_equal(zipline.extension_args.first.second.a, 'blah1')
+        assert_equal(zipline.extension_args.first.second.b, 'blah2')
+        assert_equal(zipline.extension_args.first.third, 'blah3')
+        assert_equal(zipline.extension_args.second.a.b, 'blah4')
+        assert_equal(zipline.extension_args.second.b.a, 'blah5')
+        assert_equal(zipline.extension_args.a1, 'value1')
+        assert_equal(zipline.extension_args.b_, 'value2')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -4,7 +4,6 @@ from zipline.testing import ZiplineTestCase
 from zipline.testing.predicates import (
     assert_equal,
     assert_raises_str,
-    assert_is,
 )
 from click.testing import CliRunner
 from zipline.extensions import ExtensionArgs
@@ -53,9 +52,9 @@ class CmdLineTestCase(ZiplineTestCase):
 
     def test_user_input(self):
         runner = CliRunner()
-        result = runner.invoke(main.main, [    '-xfirst.second.a=blah1',
-                                       '-xfirst.second.b=blah2',
-                                       '-xfirst.third=blah3',
+        runner.invoke(main.main, ['-xfirst.second.a=blah1',
+                                  '-xfirst.second.b=blah2',
+                                  '-xfirst.third=blah3',
                                   'bundles', ])
 
         assert_equal(zipline.extension_args.first.second.a, 'blah1')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,0 +1,31 @@
+import zipline.__main__ as main
+from zipline.testing import ZiplineTestCase
+from zipline.testing.predicates import (
+    assert_equal,
+    assert_raises_str,
+)
+
+
+class CmdLineTestCase(ZiplineTestCase):
+
+    def init_instance_fixtures(self):
+        super(CmdLineTestCase, self).init_instance_fixtures()
+
+        main.extension_args = {}
+
+        # make sure this starts empty
+        assert_equal(main.extension_args, {})
+
+    def test_parse_args(self):
+        main._parse_extension_arg('arg1=test1')
+        main._parse_extension_arg('arg2=test2')
+
+        assert_equal(main.extension_args, {'arg2': 'test2', 'arg1': 'test1'})
+        msg = 'invalid extension argument 1=test3, ' \
+              'must be in key=value form'
+        with assert_raises_str(ValueError, msg):
+            main._parse_extension_arg('1=test3')
+        msg = 'invalid extension argument arg4 test4, ' \
+              'must be in key=value form'
+        with assert_raises_str(ValueError, msg):
+            main._parse_extension_arg('arg4 test4')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -4,6 +4,8 @@ from zipline.testing.predicates import (
     assert_equal,
     assert_raises_str,
 )
+from mock import patch
+from click.testing import CliRunner
 
 
 class CmdLineTestCase(ZiplineTestCase):
@@ -11,21 +13,26 @@ class CmdLineTestCase(ZiplineTestCase):
     def init_instance_fixtures(self):
         super(CmdLineTestCase, self).init_instance_fixtures()
 
-        main.extension_args = {}
-
         # make sure this starts empty
         assert_equal(main.extension_args, {})
 
     def test_parse_args(self):
-        main._parse_extension_arg('arg1=test1')
-        main._parse_extension_arg('arg2=test2')
+        with patch.dict(main.extension_args, {}):
+            main.parse_extension_arg('arg1=test1')
+            main.parse_extension_arg('arg2=test2')
 
-        assert_equal(main.extension_args, {'arg2': 'test2', 'arg1': 'test1'})
-        msg = 'invalid extension argument 1=test3, ' \
-              'must be in key=value form'
-        with assert_raises_str(ValueError, msg):
-            main._parse_extension_arg('1=test3')
-        msg = 'invalid extension argument arg4 test4, ' \
-              'must be in key=value form'
-        with assert_raises_str(ValueError, msg):
-            main._parse_extension_arg('arg4 test4')
+            assert_equal(main.extension_args,
+                         {'arg2': 'test2', 'arg1': 'test1'})
+            msg = 'invalid extension argument 1=test3, ' \
+                  'must be in key=value form'
+            with assert_raises_str(ValueError, msg):
+                main.parse_extension_arg('1=test3')
+            msg = 'invalid extension argument arg4 test4, ' \
+                  'must be in key=value form'
+            with assert_raises_str(ValueError, msg):
+                main.parse_extension_arg('arg4 test4')
+
+    def test_user_input(self):
+        with patch.dict(main.extension_args, {}):
+            runner = CliRunner()
+            result = runner.invoke(main.main, [])

--- a/zipline/__init__.py
+++ b/zipline/__init__.py
@@ -17,6 +17,7 @@ import os
 
 # This is *not* a place to dump arbitrary classes/modules for convenience,
 # it is a place to expose the public interfaces.
+from zipline.extensions import ExtensionArgs
 from . import data
 from . import finance
 from . import gens
@@ -46,6 +47,8 @@ del global_calendar_dispatcher
 
 __version__ = get_versions()['version']
 del get_versions
+
+extension_args = ExtensionArgs([])
 
 
 def load_ipython_extension(ipython):

--- a/zipline/__init__.py
+++ b/zipline/__init__.py
@@ -17,7 +17,6 @@ import os
 
 # This is *not* a place to dump arbitrary classes/modules for convenience,
 # it is a place to expose the public interfaces.
-from zipline.extensions import ExtensionArgs
 from . import data
 from . import finance
 from . import gens
@@ -29,6 +28,7 @@ from ._version import get_versions
 # These need to happen after the other imports.
 from . algorithm import TradingAlgorithm
 from . import api
+from .extensions import Namespace
 
 
 # PERF: Fire a warning if calendars were instantiated during zipline import.
@@ -48,7 +48,7 @@ del global_calendar_dispatcher
 __version__ = get_versions()['version']
 del get_versions
 
-extension_args = ExtensionArgs([])
+extension_args = Namespace()
 
 
 def load_ipython_extension(ipython):

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -60,6 +60,7 @@ def main(extension, strict_extensions, default_extension, x):
         os.environ,
     )
 
+
 def extract_option_object(option):
     """Convert a click.option call into a click.Option object.
 

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -12,25 +12,14 @@ from zipline.utils.calendars.calendar_utils import get_calendar
 from zipline.utils.compat import wraps
 from zipline.utils.cli import Date, Timestamp
 from zipline.utils.run_algo import _run, load_extensions
+from zipline.extensions import ExtensionArgs
 
 try:
     __IPYTHON__
 except NameError:
     __IPYTHON__ = False
 
-extension_args = {}
-
-
-def _parse_extension_arg(arg):
-    match = re.match(r'^(([^\d\W]\w*)(\.[^\d\W]\w*)*)=(.*)$', arg)
-    if match is None:
-        raise ValueError(
-            "invalid extension argument %s, must be in key=value form" % arg
-        )
-
-    name = match.group(1)
-    value = match.group(4)
-    extension_args[name] = value
+extension_args = None
 
 
 @click.group()
@@ -62,8 +51,7 @@ def _parse_extension_arg(arg):
 def main(extension, strict_extensions, default_extension, x):
     """Top level zipline entry point.
     """
-    for arg in x:
-        _parse_extension_arg(arg)
+    extension_args = ExtensionArgs(x)
 
     # install a logbook handler before performing any other operations
     logbook.StderrHandler().push_application()

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -1,12 +1,12 @@
 import errno
 import os
-import re
 
 import click
 import logbook
 import pandas as pd
 from six import text_type
 
+import zipline
 from zipline.data import bundles as bundles_module
 from zipline.utils.calendars.calendar_utils import get_calendar
 from zipline.utils.compat import wraps
@@ -18,8 +18,6 @@ try:
     __IPYTHON__
 except NameError:
     __IPYTHON__ = False
-
-extension_args = None
 
 
 @click.group()
@@ -51,7 +49,7 @@ extension_args = None
 def main(extension, strict_extensions, default_extension, x):
     """Top level zipline entry point.
     """
-    extension_args = ExtensionArgs(x)
+    zipline.extension_args = ExtensionArgs(x)
 
     # install a logbook handler before performing any other operations
     logbook.StderrHandler().push_application()
@@ -61,7 +59,6 @@ def main(extension, strict_extensions, default_extension, x):
         strict_extensions,
         os.environ,
     )
-
 
 def extract_option_object(option):
     """Convert a click.option call into a click.Option object.

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -25,8 +25,7 @@ def _parse_extension_arg(arg):
     match = re.match(r'^(([^\d\W]\w*)(\.[^\d\W]\w*)*)=(.*)$', arg)
     if match is None:
         raise ValueError(
-            "invalid extension argument {arg}, must be in key=value form"
-            % arg
+            "invalid extension argument %s, must be in key=value form" % arg
         )
 
     name = match.group(1)

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -12,7 +12,7 @@ from zipline.utils.calendars.calendar_utils import get_calendar
 from zipline.utils.compat import wraps
 from zipline.utils.cli import Date, Timestamp
 from zipline.utils.run_algo import _run, load_extensions
-from zipline.extensions import ExtensionArgs
+from zipline.extensions import Namespace, create_args
 
 try:
     __IPYTHON__
@@ -49,7 +49,7 @@ except NameError:
 def main(extension, strict_extensions, default_extension, x):
     """Top level zipline entry point.
     """
-    zipline.extension_args = ExtensionArgs(x)
+    create_args(x, zipline.extension_args)
 
     # install a logbook handler before performing any other operations
     logbook.StderrHandler().push_application()

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -12,7 +12,7 @@ from zipline.utils.calendars.calendar_utils import get_calendar
 from zipline.utils.compat import wraps
 from zipline.utils.cli import Date, Timestamp
 from zipline.utils.run_algo import _run, load_extensions
-from zipline.extensions import Namespace, create_args
+from zipline.extensions import create_args
 
 try:
     __IPYTHON__

--- a/zipline/extensions.py
+++ b/zipline/extensions.py
@@ -1,44 +1,45 @@
 import re
 
 
-class ExtensionArgs(object):
+def create_args(args, root):
 
-    def __init__(self, args):
-        self.extension_args = {}
+    extension_args = {}
 
-        for arg in args:
-            self.parse_extension_arg(arg)
+    for arg in args:
+        parse_extension_arg(arg, extension_args)
 
-        for name in sorted(self.extension_args, key=len):
-            path = name.split('.')
-            self.get_namespace(self, path, self.extension_args[name])
+    for name in sorted(extension_args, key=len):
+        path = name.split('.')
+        get_namespace(root, path, extension_args[name])
 
-    def parse_extension_arg(self, arg):
-        match = re.match(r'^(([^\d\W]\w*)(\.[^\d\W]\w*)*)=(.*)$', arg)
-        if match is None:
-            raise ValueError(
-                "invalid extension argument %s, must be in key=value form" %
-                arg)
 
-        name = match.group(1)
-        value = match.group(4)
-        self.extension_args[name] = value
+def parse_extension_arg(arg, arg_dict):
+    match = re.match(r'^(([^\d\W]\w*)(\.[^\d\W]\w*)*)=(.*)$', arg)
+    if match is None:
+        raise ValueError(
+            "invalid extension argument %s, must be in key=value form" %
+            arg)
 
-    def get_namespace(self, obj, path, name):
-        if len(path) == 1:
-            setattr(obj, path[0], name)
+    name = match.group(1)
+    value = match.group(4)
+    arg_dict[name] = value
+
+
+def get_namespace(obj, path, name):
+    if len(path) == 1:
+        setattr(obj, path[0], name)
+    else:
+        if hasattr(obj, path[0]):
+            if type(getattr(obj, path[0])) is str:
+                raise ValueError("Conflicting assignments at namespace"
+                                 " level '%s'" % path[0])
+            get_namespace(getattr(obj, path[0]), path[1:], name)
         else:
-            if hasattr(obj, path[0]):
-                if type(getattr(obj, path[0])) is str:
-                    raise ValueError("Conflicting assignments at namespace"
-                                     " level '%s'" % path[0])
-                self.get_namespace(getattr(obj, path[0]), path[1:], name)
-            else:
-                a = Arg()
-                setattr(obj, path[0], a)
-                self.get_namespace(getattr(obj, path[0]), path[1:], name)
+            a = Namespace()
+            setattr(obj, path[0], a)
+            get_namespace(getattr(obj, path[0]), path[1:], name)
 
 
-class Arg(object):
+class Namespace(object):
 
     pass

--- a/zipline/extensions.py
+++ b/zipline/extensions.py
@@ -1,0 +1,44 @@
+import re
+
+
+class ExtensionArgs(object):
+
+    def __init__(self, args):
+        self.extension_args = {}
+
+        for arg in args:
+            self.parse_extension_arg(arg)
+
+        for name in sorted(self.extension_args, key=len):
+            path = name.split('.')
+            self.get_namespace(self, path, self.extension_args[name])
+
+    def parse_extension_arg(self, arg):
+        match = re.match(r'^(([^\d\W]\w*)(\.[^\d\W]\w*)*)=(.*)$', arg)
+        if match is None:
+            raise ValueError(
+                "invalid extension argument %s, must be in key=value form" %
+                arg)
+
+        name = match.group(1)
+        value = match.group(4)
+        self.extension_args[name] = value
+
+    def get_namespace(self, obj, path, name):
+        if len(path) == 1:
+            setattr(obj, path[0], name)
+        else:
+            if hasattr(obj, path[0]):
+                if type(getattr(obj, path[0])) is str:
+                    raise ValueError("Conflicting assignments at namespace"
+                                     " level '%s'" % path[0])
+                self.get_namespace(getattr(obj, path[0]), path[1:], name)
+            else:
+                a = Arg()
+                setattr(obj, path[0], a)
+                self.get_namespace(getattr(obj, path[0]), path[1:], name)
+
+
+class Arg(object):
+
+    pass


### PR DESCRIPTION
Adds an '-x' option to the top-level entry point, which allows a user to define multiple custom args which would then be under __main__.extension_args. Also adds a function under __main__ that parses these args, making sure that they are entered in key=value form. 