### PR TITLE
Include LICENSE file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ logging-level=INFO
 
 [metadata]
 description-file = README.rst
+license_file = LICENSE
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the


### PR DESCRIPTION
Although not strictly required by the license, having a copy of the license file is preferred by some groups such as Linux distros that repackage the software.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.