### PR TITLE
Correcting market open time

### DIFF
--- a/zipline/utils/calendars/exchange_calendar_nyse.py
+++ b/zipline/utils/calendars/exchange_calendar_nyse.py
@@ -107,7 +107,7 @@ class NYSEExchangeCalendar(TradingCalendar):
 
     @property
     def open_time(self):
-        return time(9, 31)
+        return time(9, 30)
 
     @property
     def close_time(self):


### PR DESCRIPTION
The first minute of the regular trading hours is 9:30, not 9:31. You can confirm that by checking the time of the first candle of stocks like MSFT or AAPL on a 1 minute candlestick chart during regular tading hours on Yahoo Finance or TradingView.com