### PR TITLE
[BUG] Fix invalid data loading in csvdir bundle

### DIFF
--- a/zipline/data/bundles/csvdir.py
+++ b/zipline/data/bundles/csvdir.py
@@ -175,10 +175,13 @@ def _pricing_iter(csvdir, symbols, metadata, divs_splits, show_progress):
         for sid, symbol in enumerate(it):
             logger.debug('%s: sid %s' % (symbol, sid))
 
+            fname = symbol + '.csv'
             try:
-                fname = [fname for fname in files
-                         if '%s.csv' % symbol in fname][0]
-            except IndexError:
+                dfr = read_csv(os.path.join(csvdir, fname),
+                               parse_dates=[0],
+                               infer_datetime_format=False,
+                               index_col=0).sort_index()
+            except OSError:
                 raise ValueError("%s.csv file is not in %s" % (symbol, csvdir))
 
             dfr = read_csv(os.path.join(csvdir, fname),


### PR DESCRIPTION
Calculating the name of CSV file from the symbol name is not done corretly. The current method would match a filename to a symbol if it ended in the symbol concatenated with `.csv`. This means that if there are two stocks Ford (symbol F) and Regions Financial Corporation (symbol RF). Then the calculated filename to load for Ford could be RF.csv which is clearly not the data file for Ford. 

This is clearly a bug. 