### PR TITLE
DOC: Remove instant_fill docstring reference from TradingAlgorithm

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -174,8 +174,6 @@ class TradingAlgorithm(object):
         tracebacks. default: '<string>'.
     data_frequency : {'daily', 'minute'}, optional
         The duration of the bars.
-    instant_fill : bool, optional
-        Whether to fill orders immediately or on next bar. default: False
     equities_metadata : dict or DataFrame or file-like object, optional
         If dict is provided, it must have the following structure:
         * keys are the identifiers


### PR DESCRIPTION
Are there any places where we allow orders to be filled on the same day / work in the same way that `instant_fill` used to work?