### PR TITLE
MAINT: Adding more expressive error message on CustomTermMixin

### DIFF
--- a/zipline/pipeline/mixins.py
+++ b/zipline/pipeline/mixins.py
@@ -144,7 +144,11 @@ class CustomTermMixin(object):
         """
         Override this method with a function that writes a value into `out`.
         """
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "{name} must define a compute method".format(
+                name=type(self).__name__
+            )
+        )
 
     def _allocate_output(self, windows, shape):
         """


### PR DESCRIPTION
Support users have been looking for more detail on the NotImplementedError

__Note:__ New pull request after I accidentally killed the old by squashing the commit it referenced.