### PR TITLE
MAINT: Adding in validation for ComputableTerm input

### DIFF
--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -15,6 +15,7 @@ from zipline.errors import (
     NonWindowSafeInput,
     NotDType,
     TermInputsNotSpecified,
+    NonPipelineInputs,
     TermOutputsEmpty,
     UnsupportedDType,
     WindowLengthNotSpecified,
@@ -544,6 +545,9 @@ class ObjectIdentityTestCase(TestCase):
 
         with self.assertRaises(TermInputsNotSpecified):
             SomeFactorDefaultLength()
+
+        with self.assertRaises(NonPipelineInputs):
+            SomeFactor(window_length=1, inputs=[2])
 
         with self.assertRaises(WindowLengthNotSpecified):
             SomeFactor(inputs=(SomeDataSet.foo,))

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -519,6 +519,26 @@ class TermInputsNotSpecified(ZiplineError):
     msg = "{termname} requires inputs, but no inputs list was passed."
 
 
+class NonPipelineInputs(ZiplineError):
+    """
+    Raised when a non-pipeline object is passed as input to a ComputableTerm
+    """
+    def __init__(self, term, inputs):
+        self.term = term
+        self.inputs = inputs
+
+    def __str__(self):
+        return (
+            "Unexpected inputs types in {}. "
+            "Inputs to Pipeline expressions must be Filters, Factors, "
+            "Classifiers, or BoundColumns.\n"
+            "Got the following type(s) instead: {}".format(
+                type(self.term).__name__,
+                sorted(set(map(type, self.inputs)), key=lambda t: t.__name__),
+            )
+        )
+
+
 class TermOutputsEmpty(ZiplineError):
     """
     Raised if a user attempts to construct a term with an empty outputs list.

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -529,7 +529,7 @@ class NonPipelineInputs(ZiplineError):
 
     def __str__(self):
         return (
-            "Unexpected inputs types in {}. "
+            "Unexpected input types in {}. "
             "Inputs to Pipeline expressions must be Filters, Factors, "
             "Classifiers, or BoundColumns.\n"
             "Got the following type(s) instead: {}".format(

--- a/zipline/pipeline/term.py
+++ b/zipline/pipeline/term.py
@@ -22,6 +22,7 @@ from zipline.errors import (
     NonSliceableTerm,
     NonWindowSafeInput,
     NotDType,
+    NonPipelineInputs,
     TermInputsNotSpecified,
     TermOutputsEmpty,
     UnsupportedDType,
@@ -467,6 +468,13 @@ class ComputableTerm(Term):
             # Allow users to specify lists as class-level defaults, but
             # normalize to a tuple so that inputs is hashable.
             inputs = tuple(inputs)
+
+            # Make sure all our inputs are valid pipeline objects before trying
+            # to infer a domain.
+            for input_ in inputs:
+                non_terms = [t for t in inputs if not isinstance(t, Term)]
+                if non_terms:
+                    raise NonPipelineInputs(cls.__name__, non_terms)
 
         if outputs is NotSpecified:
             outputs = cls.outputs


### PR DESCRIPTION
Make `ComputableTerm` check that the inputs are of type `Term`

1. Adds in a check to the `_validate` method
2. Adds in a new error `TermInputInvalid`
3. Adds a test ensuring the error is raised when an input of incorrect type is passed