### PR TITLE
ENH: Domains, Inference, and Specialization

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -80,3 +80,6 @@ tables==3.3.0
 
 # For trading calendars
 trading-calendars==1.0.1
+
+# Interface definitions
+python-interface==1.4.0

--- a/tests/pipeline/test_dataset.py
+++ b/tests/pipeline/test_dataset.py
@@ -1,6 +1,6 @@
 """Tests for zipline.pipeline.data.DataSet and friends.
 """
-from zipline.pipeline.domain import USEquities
+from zipline.pipeline.domain import USEquities, CanadaEquities
 from zipline.pipeline.data.dataset import Column, DataSet
 import zipline.testing.fixtures as zf
 from zipline.testing.predicates import assert_equal
@@ -45,3 +45,24 @@ class DataSetTestCase(zf.ZiplineTestCase):
             assert_equal(original.name, new.name)
             assert_equal(original.dtype, new.dtype)
             assert_equal(original.missing_value, new.missing_value)
+
+    def test_repr(self):
+        class Data(DataSet):
+            col1 = Column(dtype=float)
+            col2 = Column(dtype=int, missing_value=100)
+            col3 = Column(dtype=object, missing_value="")
+
+        expected = "<DataSet: 'Data'>"
+        self.assertEqual(repr(Data), expected)
+
+        specialized = Data.specialize(USEquities)
+        expected_specialized = "<DataSet: 'Data_US', domain={}>".format(
+            str(USEquities),
+        )
+        self.assertEqual(repr(specialized), expected_specialized)
+
+        specialized_CA = Data.specialize(CanadaEquities)
+        expected_specialized_CA = "<DataSet: 'Data_CA', domain={}>".format(
+            str(CanadaEquities),
+        )
+        self.assertEqual(repr(specialized_CA), expected_specialized_CA)

--- a/tests/pipeline/test_dataset.py
+++ b/tests/pipeline/test_dataset.py
@@ -1,0 +1,47 @@
+"""Tests for zipline.pipeline.data.DataSet and friends.
+"""
+from zipline.pipeline.domain import USEquities
+from zipline.pipeline.data.dataset import Column, DataSet
+import zipline.testing.fixtures as zf
+from zipline.testing.predicates import assert_equal
+
+
+class DataSetTestCase(zf.ZiplineTestCase):
+
+    def test_specialize(self):
+        class MyDataSet(DataSet):
+            col1 = Column(dtype=float)
+            col2 = Column(dtype=int, missing_value=100)
+            col3 = Column(dtype=object, missing_value="")
+
+        specialized = MyDataSet.specialize(USEquities)
+
+        # Specializations should be memoized.
+        self.assertIs(specialized, MyDataSet.specialize(USEquities))
+
+        # Specializations should have the same name, but prefixed with the
+        # country code of the new domain.
+        assert_equal(specialized.__name__, "MyDataSet_US")
+        self.assertIs(specialized.domain, USEquities)
+
+        for attr in ('col1', 'col2', 'col3'):
+            original = getattr(MyDataSet, attr)
+            new = getattr(specialized, attr)
+
+            # We should get a new column from the specialization, which should
+            # be the same object that we would get from specializing the
+            # original column.
+            self.assertIsNot(original, new)
+            self.assertIs(new, original.specialize(USEquities))
+
+            # Columns should be bound to their respective datasets.
+            self.assertIs(original.dataset, MyDataSet)
+            self.assertIs(new.dataset, specialized)
+
+            # The new column should have the domain of the specialization.
+            assert_equal(new.domain, USEquities)
+
+            # Names, dtypes, and missing_values should match.
+            assert_equal(original.name, new.name)
+            assert_equal(original.dtype, new.dtype)
+            assert_equal(original.missing_value, new.missing_value)

--- a/zipline/country.py
+++ b/zipline/country.py
@@ -1,0 +1,14 @@
+"""Canonical definitions of country code constants.
+"""
+from iso3166 import countries_by_name
+
+
+class CountryCode(object):
+    """A simple namespace of iso3166 alpha2 country codes.
+    """
+    CANADA = countries_by_name['CANADA'].alpha2
+    GERMANY = countries_by_name['GERMANY'].alpha2
+    UNITED_KINGDOM = countries_by_name[
+        'UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND'
+    ].alpha2
+    UNITED_STATES = countries_by_name['UNITED STATES OF AMERICA'].alpha2

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -130,7 +130,13 @@ class BoundColumn(LoadableTerm):
     mask = AssetExists()
     window_safe = True
 
-    def __new__(cls, dtype, missing_value, dataset, name, doc, metadata):
+    def __new__(cls,
+                dtype,
+                missing_value,
+                dataset,
+                name,
+                doc,
+                metadata):
         return super(BoundColumn, cls).__new__(
             cls,
             domain=dataset.domain,
@@ -158,6 +164,28 @@ class BoundColumn(LoadableTerm):
             name,
             doc,
             frozenset(sorted(metadata.items(), key=first)),
+        )
+
+    def specialize(self, domain):
+        """Specialize ``self`` to a concrete domain.
+        """
+        if self.domain == domain:
+            return self
+        elif self.domain is not NotSpecified:
+            raise ValueError(
+                "Can't specialize {} to domain {} because it already "
+                "has domain {}.".format(
+                    self, domain, self.domain,
+                )
+            )
+
+        return type(self)(
+            dtype=self.dtype,
+            missing_value=self.missing_value,
+            dataset=self._dataset.specialize(domain),
+            name=self._name,
+            doc=self.__doc__,
+            metadata=self._metadata,
         )
 
     @property
@@ -248,7 +276,57 @@ class DataSetMeta(type):
                 column_names.add(maybe_colname)
 
         newtype._column_names = frozenset(column_names)
+        newtype._domain_specializations = {}
+
         return newtype
+
+    def specialize(self, domain):
+        """
+        Specialize a generic DataSet to a concrete domain.
+
+        Parameters
+        ----------
+        domain : zipline.pipeline.domain.Domain
+            Domain to which we should generate a specialization.
+
+        Returns
+        -------
+        specialized : DataSetMeta
+            A new DataSet subclass with the same columns as ``self``, but
+            specialized to ``domain``.
+        """
+        # TODO_SS: Should this be an error?
+        # We're already the specialization to this domain, so just return self.
+        if domain == self.domain:
+            return self
+        elif self.domain is not NotSpecified:
+            raise ValueError(
+                "Can't specialize {dataset} with domain "
+                "{current} to new domain {new}.".format(
+                    dataset=self.__name__,
+                    current=self.domain,
+                    new=domain,
+                )
+            )
+
+        # Memoize new specializations.
+        try:
+            return self._domain_specializations[domain]
+        except KeyError:
+            new_type = self._create_specialization(domain)
+            self._domain_specializations[domain] = new_type
+            return new_type
+
+    def _create_specialization(self, domain):
+        assert self.domain is NotSpecified, \
+            "Can't specialize non-generic dataset!"
+
+        # Create a new subclass of ``self`` with the given domain whose name is
+        # our name prefixed with domain.country_code.
+        name = '_'.join((self.__name__, domain.country_code))
+        bases = (self,)
+        dict_ = {'domain': domain}
+        return DataSetMeta(name, bases, dict_)
 
     @property
     def columns(self):
@@ -260,7 +338,7 @@ class DataSetMeta(type):
         return id(self) < id(other)
 
     def __repr__(self):
-        return '<DataSet: %r>' % self.__name__
+        return '<DataSet: %r, domain=%s>' % (self.__name__, self.domain)
 
 
 class DataSet(with_metaclass(DataSetMeta, object)):
@@ -316,5 +394,5 @@ class DataSet(with_metaclass(DataSetMeta, object)):
     numeric. Doing so enables the use of `NaN` as a natural missing value,
     which has useful propagation semantics.
     """
-    domain = None
+    domain = NotSpecified
     ndim = 2

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -338,7 +338,13 @@ class DataSetMeta(type):
         return id(self) < id(other)
 
     def __repr__(self):
-        return '<DataSet: %r, domain=%s>' % (self.__name__, self.domain)
+        if self.domain is NotSpecified:
+            return '<DataSet: {!r}>'.format(self.__name__)
+        else:
+            return '<DataSet: {!r}, domain={}>'.format(
+                self.__name__,
+                self.domain,
+            )
 
 
 class DataSet(with_metaclass(DataSetMeta, object)):

--- a/zipline/pipeline/data/equity_pricing.py
+++ b/zipline/pipeline/data/equity_pricing.py
@@ -3,10 +3,11 @@ Dataset representing OHLCV data.
 """
 from zipline.utils.numpy_utils import float64_dtype
 
+from ..domain import USEquities
 from .dataset import Column, DataSet
 
 
-class USEquityPricing(DataSet):
+class EquityPricing(DataSet):
     """
     Dataset representing daily trading prices and volumes.
     """
@@ -15,3 +16,7 @@ class USEquityPricing(DataSet):
     low = Column(float64_dtype)
     close = Column(float64_dtype)
     volume = Column(float64_dtype)
+
+
+# Backwards compat alias.
+USEquityPricing = EquityPricing.specialize(USEquities)

--- a/zipline/pipeline/domain.py
+++ b/zipline/pipeline/domain.py
@@ -70,9 +70,12 @@ class StandardDomain(Domain):
     def calendar(self):
         return get_calendar(self._calendar_name)
 
+    def __str__(self):
+        return self._name
+
     def __repr__(self):
-        return "{}(country={!r}, calendar={!r})".format(
-            self.name,
+        return "StandardDomain(name={!r}, country={!r}, calendar={!r})".format(
+            self._name,
             self.country_code,
             self._calendar_name,
         )

--- a/zipline/pipeline/domain.py
+++ b/zipline/pipeline/domain.py
@@ -1,0 +1,179 @@
+"""
+Domains
+-------
+
+TODO_SS
+"""
+from interface import implements, Interface
+
+from trading_calendars import get_calendar
+
+from zipline.country import CountryCode
+from zipline.utils.memoize import lazyval
+
+from .sentinels import NotSpecified
+
+
+class IDomain(Interface):
+    """Domain interface.
+    """
+
+    @property
+    def name(self):
+        """User-facing name for this domain.
+        """
+
+    @property
+    def country_code(self):
+        """Country code for assets on this domain.
+        """
+
+    # TODO_SS: The original design for domains was to have them return a
+    # TradingCalendar, but we have a bunch of tests in test_blaze that use very
+    # short session indices that I don't know how to port to using a proper
+    # TradingCalendar.
+    #
+    # Is there a strong reason to prefer just exposing the calendar
+    # vs. exposing the sessions? If so, what do we do about the blaze tests?
+    def get_sessions(self):
+        """Get all trading sessions for the calendar of this domain.
+        """
+
+
+# Create a base class so that we can do type-based validation of user input.
+Domain = implements(IDomain)
+Domain.__name__ = 'Domain'
+
+
+# TODO: Better name for this?
+# TODO: Do we want/need memoization for this?
+class StandardDomain(Domain):
+    """TODO_SS
+    """
+    def __init__(self, name, country_code, calendar_name):
+        self._name = name
+        self._country_code = country_code
+        self._calendar_name = calendar_name
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def country_code(self):
+        return self._country_code
+
+    def get_sessions(self):
+        return self.calendar.all_sessions
+
+    @lazyval
+    def calendar(self):
+        return get_calendar(self._calendar_name)
+
+    def __repr__(self):
+        return "{}(country={!r}, calendar={!r})".format(
+            self.name,
+            self.country_code,
+            self._calendar_name,
+        )
+
+
+# TODO: Is this the casing convention we want for domains?
+USEquities = StandardDomain('USEquities', CountryCode.UNITED_STATES, 'NYSE')
+CanadaEquities = StandardDomain('CanadaEquities', CountryCode.CANADA, 'TSX')
+# XXX: The actual country code for this is GB. Should we use that for the name
+# here?
+UKEquities = StandardDomain('UKEquities', CountryCode.UNITED_KINGDOM, 'LSE')
+
+
+def infer_domain(terms):
+    """
+    Infer the domain from a collection of terms.
+
+    The algorithm for inferring domains is as follows:
+
+    - If all input terms have a domain of NotSpecified, the result is also
+      NotSpecified.
+
+    - If there is exactly one non-NotSpecified domain in the input terms, the
+      result is that domain.
+
+    - Otherwise, an AmbiguousDomain error is raised.
+
+    Parameters
+    ----------
+    terms : iterable[zipline.pipeline.term.Term]
+
+    Returns
+    -------
+    inferred : Domain or NotSpecified
+
+    Raises
+    ------
+    AmbiguousDomain
+        Raised if more than one concrete domain is present in the input terms.
+    """
+    domains = {NotSpecified}
+    for t in terms:
+        domains.update(t.domain)
+
+    if len(domains) == 1:
+        return NotSpecified
+    elif len(domains) == 2:
+        domains.remove(NotSpecified)
+        return domains.pop()
+    else:
+        domains.remove(NotSpecified)
+        raise AmbiguousDomain(sorted(domains, key=lambda d: d.country_code))
+
+
+class AmbiguousDomain(Exception):
+    """
+    Raised when we attempt to infer a domain from a collection of mixed terms.
+    """
+
+
+class SessionDomain(Domain):
+    """TODO_SS
+    """
+
+    def __init__(self, name, sessions, country_code):
+        self._name = name
+        self._country_code = country_code
+        self._sessions = sessions
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def country_code(self):
+        return self._country_code
+
+    def get_sessions(self):
+        return self._sessions
+
+
+class ExplicitCalendarDomain(Domain):
+    """
+    A domain that takes an explicit calendar instance at construction time
+    rather than a name. This allows for greater control of the start/end dates
+    of the calendar, which is sometimes useful for testing.
+
+    TODO_SS:
+    """
+    def __init__(self, name, country_code, calendar):
+        self._name = name
+        self._country_code = country_code
+        self._calendar = calendar
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def country_code(self):
+        return self._country_code
+
+    def get_sessions(self):
+        return self._calendar.sessions


### PR DESCRIPTION
This is the first in a series of PRs that aim to implement support for **domains** in the Pipeline API. See https://github.com/quantopian/zipline/issues/2265 for WIP design document.

In particular, this PR implements initial support for Domain objects, along with the machinery for **specialization** of DataSets and BoundColumns to domains.