### PR TITLE
MAINT/ENH: Un-cythonize and create extension point for clocks

### DIFF
--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -23,12 +23,12 @@ requirements:
     - setuptools
     - six
     - typing >=3.5.2
-    - funcsigs >=1.0.2
+    - funcsigs >=1.0.2    [py<30]
   run:
     - python
     - six
     - typing >=3.5.2
-    - funcsigs >=1.0.2
+    - funcsigs >=1.0.2    [py<30]
 
 test:
   imports:

--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -29,7 +29,6 @@ requirements:
 test:
   imports:
     - interface
-    - interface.tests
 
 about:
   home: https://github.com/ssanderson/interface

--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "python-interface" %}
+{% set version = "1.4.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9516c60d014549238b6c983c598ffba89d93fc8556bdb5dc761915dd92b05b72
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - pip
+    - pip
+    - python
+    - six
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - interface
+    - interface.tests
+
+about:
+  home: https://github.com/ssanderson/interface
+  license: Apache Software
+  license_family: APACHE
+  license_file: 
+  summary: Pythonic Interface definitions
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here

--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -32,11 +32,10 @@ about:
   home: https://github.com/ssanderson/interface
   license: Apache Software
   license_family: APACHE
-  license_file: 
+  license_file: ''
   summary: Pythonic Interface definitions
-  doc_url: 
-  dev_url: 
+  doc_url: ''
+  dev_url: ''
 
 extra:
-  recipe-maintainers:
-    - your-github-id-here
+  recipe-maintainers: ''

--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -1,23 +1,26 @@
 {% set name = "python-interface" %}
 {% set version = "1.4.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "9516c60d014549238b6c983c598ffba89d93fc8556bdb5dc761915dd92b05b72" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9516c60d014549238b6c983c598ffba89d93fc8556bdb5dc761915dd92b05b72
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
-  host:
-    - pip
-    - pip
+  build:
     - python
+    - setuptools
     - six
   run:
     - python
@@ -30,10 +33,25 @@ test:
 
 about:
   home: https://github.com/ssanderson/interface
-  license: Apache Software
+  license: Apache Software License
   license_family: APACHE
   license_file: ''
   summary: Pythonic Interface definitions
+  description: "``interface``\n=============\n\n|build status|\n\n``interface`` provides facilities for declaring interfaces and for statically\nasserting that classes implement those interfaces. It supports\
+    \ Python 2.7 and\nPython 3.4+.\n\n``interface`` improves on Python's ``abc`` module in two ways:\n\n1. Interface requirements are checked at class creation time, rather than at\n   instance creation\
+    \ time.  This means that ``interface`` can tell you if a\n   class fails to meet the requirements of an interface even if you never\n   create any instances of that class.\n\n2. ``interface`` requires\
+    \ that method signatures of interface implementations\n   are compatible with the signatures declared in the interface.  For example,\n   the following code using ``abc`` does not produce an error:\n\
+    \n   .. code-block:: python\n\n      >>> from abc import ABCMeta, abstractmethod\n      >>> class Base(metaclass=ABCMeta):\n      ...     @abstractmethod\n      ...     def method(self, a, b):\n   \
+    \   ...         pass\n      ...\n      >>> class Implementation(MyABC):\n      ...     def method(self):\n      ...         return \"This shouldn't work.\"\n      ...\n      >>> impl = Implementation()\n\
+    \      >>>\n\n   The equivalent code using ``interface`` produces an error indicating that\n   the signature of our implementation method is incompatible with the\n   signature of our interface declaration:\n\
+    \n   .. code-block:: python\n\n      >>> from interface import implements, Interface\n      >>> class I(Interface):\n      ...     def method(self, a, b):\n      ...         pass\n      ...\n      >>>\
+    \ class C(implements(I)):\n      ...     def method(self):\n      ...         return \"This shouldn't work\"\n      ...\n      TypeError:\n      class C failed to implement interface I:\n\n      The\
+    \ following methods were implemented but had invalid signatures:\n        - method(self) != method(self, a, b)\n\nDefining an Interface\n~~~~~~~~~~~~~~~~~~~~~\n\nTo define an interface, simply subclass\
+    \ from ``interface.Interface`` and define\nmethod stubs in your class body.\n\n.. code-block:: python\n\n   from interface import Interface\n\n   class MyInterface(Interface):\n\n       def method1(self):\n\
+    \           pass\n\n       def method2(self, arg1, arg2):\n           pass\n\nImplementing an Interface\n~~~~~~~~~~~~~~~~~~~~~~~~~\n\nTo declare that a particular class implements an interface ``I``,\
+    \ pass\n``implements(I)`` as a base class for your class.\n\n.. code-block:: python\n\n   from interface import implements\n\n   class MyClass(implements(MyInterface)):\n\n       def method1(self):\n\
+    \           return \"method1\"\n\n       def method2(self, arg1, arg2):\n           return \"method2\"\n\nInstallation\n~~~~~~~~~~~~\n\n.. code-block:: shell\n\n   $ pip install python-interface\n\n\
+    .. |build status| image:: https://travis-ci.org/ssanderson/interface.svg?branch=master\n   :target: https://travis-ci.org/ssanderson/interface\n"
   doc_url: ''
   dev_url: ''
 

--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -22,13 +22,18 @@ requirements:
     - python
     - setuptools
     - six
+    - typing >=3.5.2
+    - funcsigs >=1.0.2
   run:
     - python
     - six
+    - typing >=3.5.2
+    - funcsigs >=1.0.2
 
 test:
   imports:
     - interface
+    - interface.tests
 
 about:
   home: https://github.com/ssanderson/interface

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -25,6 +25,7 @@ statsmodels==0.6.1
 
 python-dateutil==2.4.2
 six==1.10.0
+python-interface==1.4.0
 
 # For fetching remote data
 requests==2.9.1

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ ext_modules = [
         'zipline.finance._finance_ext',
         ['zipline/finance/_finance_ext.pyx'],
     ),
-    Extension('zipline.gens.sim_engine', ['zipline/gens/sim_engine.pyx']),
     Extension(
         'zipline.data._minute_bar_internal',
         ['zipline/data/_minute_bar_internal.pyx']

--- a/tests/finance/test_cancel_policy.py
+++ b/tests/finance/test_cancel_policy.py
@@ -15,7 +15,7 @@
 from unittest import TestCase
 
 from zipline.finance.cancel_policy import NeverCancel, EODCancel
-from zipline.gens.sim_engine import (
+from zipline.gens.clock import (
     BAR,
     SESSION_END
 )

--- a/tests/finance/test_cancel_policy.py
+++ b/tests/finance/test_cancel_policy.py
@@ -15,20 +15,17 @@
 from unittest import TestCase
 
 from zipline.finance.cancel_policy import NeverCancel, EODCancel
-from zipline.gens.clock import (
-    BAR,
-    SESSION_END
-)
+from zipline.gens.clock import SessionEvent
 
 
 class CancelPolicyTestCase(TestCase):
 
     def test_eod_cancel(self):
         cancel_policy = EODCancel()
-        self.assertTrue(cancel_policy.should_cancel(SESSION_END))
-        self.assertFalse(cancel_policy.should_cancel(BAR))
+        self.assertTrue(cancel_policy.should_cancel(SessionEvent.SESSION_END))
+        self.assertFalse(cancel_policy.should_cancel(SessionEvent.BAR))
 
     def test_never_cancel(self):
         cancel_policy = NeverCancel()
-        self.assertFalse(cancel_policy.should_cancel(SESSION_END))
-        self.assertFalse(cancel_policy.should_cancel(BAR))
+        self.assertFalse(cancel_policy.should_cancel(SessionEvent.SESSION_END))
+        self.assertFalse(cancel_policy.should_cancel(SessionEvent.BAR))

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -34,7 +34,6 @@ from pandas.core.common import PerformanceWarning
 from trading_calendars import get_calendar, register_calendar
 
 import zipline.api
-from zipline import Blotter
 from zipline.api import FixedSlippage
 from zipline.assets import Equity, Future, Asset
 from zipline.assets.continuous_futures import ContinuousFuture
@@ -55,7 +54,6 @@ from zipline.errors import (
     UnsupportedDatetimeFormat,
     ZeroCapitalError
 )
-from zipline.extensions import load
 
 from zipline.finance.commission import PerShare, PerTrade
 from zipline.finance.execution import LimitOrder
@@ -79,6 +77,7 @@ from zipline.testing import (
     str_to_seconds,
     to_utc,
 )
+from zipline.testing import RecordBatchBlotter
 import zipline.testing.fixtures as zf
 from zipline.test_algorithms import (
     access_account_in_init,
@@ -1653,6 +1652,7 @@ def handle_data(context, data):
     def test_batch_market_order_matches_multiple_manual_orders(self):
         share_counts = pd.Series([50, 100])
 
+        multi_blotter = RecordBatchBlotter()
         multi_test_algo = self.make_algo(
             script=dedent("""\
                 from collections import OrderedDict
@@ -1674,11 +1674,12 @@ def handle_data(context, data):
                         context.placed = True
 
             """).format(share_counts=list(share_counts)),
-            blotter=load(Blotter, 'record_batch'),
+            blotter=multi_blotter,
         )
         multi_stats = multi_test_algo.run()
-        self.assertFalse(multi_test_algo.blotter.order_batch_called)
+        self.assertFalse(multi_blotter.order_batch_called)
 
+        batch_blotter = RecordBatchBlotter()
         batch_test_algo = self.make_algo(
             script=dedent("""\
                 import pandas as pd
@@ -1703,10 +1704,10 @@ def handle_data(context, data):
                         context.placed = True
 
             """).format(share_counts=list(share_counts)),
-            blotter=load(Blotter, 'record_batch'),
+            blotter=batch_blotter,
         )
         batch_stats = batch_test_algo.run()
-        self.assertTrue(batch_test_algo.blotter.order_batch_called)
+        self.assertTrue(batch_blotter.order_batch_called)
 
         for stats in (multi_stats, batch_stats):
             stats.orders = stats.orders.apply(
@@ -1720,6 +1721,7 @@ def handle_data(context, data):
     def test_batch_market_order_filters_null_orders(self):
         share_counts = [50, 0]
 
+        batch_blotter = RecordBatchBlotter()
         batch_test_algo = self.make_algo(
             script=dedent("""\
                 import pandas as pd
@@ -1743,10 +1745,10 @@ def handle_data(context, data):
                         context.placed = True
 
             """).format(share_counts=share_counts),
-            blotter=load(Blotter, 'record_batch'),
+            blotter=batch_blotter,
         )
         batch_test_algo.run()
-        self.assertTrue(batch_test_algo.blotter.order_batch_called)
+        self.assertTrue(batch_blotter.order_batch_called)
 
     def test_order_dead_asset(self):
         # after asset 0 is dead

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -32,7 +32,7 @@ from zipline.finance.slippage import (
     FixedSlippage,
     VolumeShareSlippage,
 )
-from zipline.gens.sim_engine import BAR, SESSION_END
+from zipline.gens.clock import BAR, SESSION_END
 from zipline.testing.fixtures import (
     WithCreateBarData,
     WithDataPortal,

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -32,7 +32,7 @@ from zipline.finance.slippage import (
     FixedSlippage,
     VolumeShareSlippage,
 )
-from zipline.gens.clock import BAR, SESSION_END
+from zipline.gens.clock import SessionEvent
 from zipline.testing.fixtures import (
     WithCreateBarData,
     WithDataPortal,
@@ -166,11 +166,11 @@ class BlotterTestCase(WithCreateBarData,
         self.assertEqual(blotter.new_orders[0].status, ORDER_STATUS.OPEN)
         self.assertEqual(blotter.new_orders[1].status, ORDER_STATUS.OPEN)
 
-        blotter.execute_cancel_policy(BAR)
+        blotter.execute_cancel_policy(SessionEvent.BAR)
         self.assertEqual(blotter.new_orders[0].status, ORDER_STATUS.OPEN)
         self.assertEqual(blotter.new_orders[1].status, ORDER_STATUS.OPEN)
 
-        blotter.execute_cancel_policy(SESSION_END)
+        blotter.execute_cancel_policy(SessionEvent.SESSION_END)
         for order_id in order_ids:
             order = blotter.orders[order_id]
             self.assertEqual(order.status, ORDER_STATUS.CANCELLED)
@@ -183,10 +183,10 @@ class BlotterTestCase(WithCreateBarData,
         self.assertEqual(len(blotter.new_orders), 1)
         self.assertEqual(blotter.new_orders[0].status, ORDER_STATUS.OPEN)
 
-        blotter.execute_cancel_policy(BAR)
+        blotter.execute_cancel_policy(SessionEvent.BAR)
         self.assertEqual(blotter.new_orders[0].status, ORDER_STATUS.OPEN)
 
-        blotter.execute_cancel_policy(SESSION_END)
+        blotter.execute_cancel_policy(SessionEvent.SESSION_END)
         self.assertEqual(blotter.new_orders[0].status, ORDER_STATUS.OPEN)
 
     def test_order_rejection(self):

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -4,7 +4,7 @@ import pandas as pd
 from trading_calendars import get_calendar
 from trading_calendars.utils.pandas_utils import days_at_time
 
-from zipline.gens.sim_engine import (
+from zipline.gens.clock import (
     MinuteSimulationClock,
     SESSION_START,
     BEFORE_TRADING_START_BAR,

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -6,10 +6,7 @@ from trading_calendars.utils.pandas_utils import days_at_time
 
 from zipline.gens.clock import (
     MinuteSimulationClock,
-    SESSION_START,
-    BEFORE_TRADING_START_BAR,
-    BAR,
-    SESSION_END
+    SessionEvent,
 )
 
 
@@ -44,11 +41,19 @@ class TestClock(TestCase):
 
             self.assertEqual(393, len(events))
 
-            self.assertEqual(events[0], (session_label, SESSION_START))
-            self.assertEqual(events[1], (bts_dt, BEFORE_TRADING_START_BAR))
+            self.assertEqual(
+                events[0], (session_label, SessionEvent.SESSION_START)
+            )
+            self.assertEqual(
+                events[1], (bts_dt, SessionEvent.BEFORE_TRADING_START_BAR)
+            )
             for i in range(2, 392):
-                self.assertEqual(events[i], (minutes[i - 2], BAR))
-            self.assertEqual(events[392], (minutes[-1], SESSION_END))
+                self.assertEqual(
+                    events[i], (minutes[i - 2], SessionEvent.BAR)
+                )
+            self.assertEqual(
+                events[392], (minutes[-1], SessionEvent.SESSION_END)
+            )
 
         _check_session_bts_first(
             self.sessions[0],
@@ -104,20 +109,28 @@ class TestClock(TestCase):
 
             self.assertEqual(393, len(events))
 
-            self.assertEqual(events[0], (session_label, SESSION_START))
+            self.assertEqual(
+                events[0], (session_label, SessionEvent.SESSION_START)
+            )
 
             for i in range(1, bts_idx):
-                self.assertEqual(events[i], (minutes[i - 1], BAR))
+                self.assertEqual(
+                    events[i], (minutes[i - 1], SessionEvent.BAR)
+                )
 
             self.assertEqual(
                 events[bts_idx],
-                (bts_dt, BEFORE_TRADING_START_BAR)
+                (bts_dt, SessionEvent.BEFORE_TRADING_START_BAR)
             )
 
             for i in range(bts_idx + 1, 391):
-                self.assertEqual(events[i], (minutes[i - 2], BAR))
+                self.assertEqual(
+                    events[i], (minutes[i - 2], SessionEvent.BAR)
+                )
 
-            self.assertEqual(events[392], (minutes[-1], SESSION_END))
+            self.assertEqual(
+                events[392], (minutes[-1], SessionEvent.SESSION_END)
+            )
 
         clock = MinuteSimulationClock(
             self.sessions,
@@ -166,12 +179,18 @@ class TestClock(TestCase):
             minutes = self.nyse_calendar.minutes_for_session(session_label)
 
             self.assertEqual(392, len(events))
-            self.assertEqual(events[0], (session_label, SESSION_START))
+            self.assertEqual(
+                events[0], (session_label, SessionEvent.SESSION_START)
+            )
 
             for i in range(1, 391):
-                self.assertEqual(events[i], (minutes[i - 1], BAR))
+                self.assertEqual(
+                    events[i], (minutes[i - 1], SessionEvent.BAR)
+                )
 
-            self.assertEqual(events[-1], (minutes[389], SESSION_END))
+            self.assertEqual(
+                events[-1], (minutes[389], SessionEvent.SESSION_END)
+            )
 
         for i in range(0, 2):
             _check_session_bts_after(

--- a/tests/test_registration_manager.py
+++ b/tests/test_registration_manager.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from zipline.extensions import Registry
 from zipline.testing.fixtures import ZiplineTestCase
 from zipline.testing.predicates import assert_raises_str, assert_true
@@ -44,7 +46,8 @@ class RegistrationManagerTestCase(ZiplineTestCase):
                 "Class ProperDummyInterface wasn't properly registered under"
                 "name 'ayy-lmao'"
             )
-            self.assertIsInstance(rm.load('ayy-lmao'), ProperDummyInterface)
+            self.assertIsInstance(rm.load('ayy-lmao'), partial)
+            self.assertIsInstance(rm.load('ayy-lmao')(), ProperDummyInterface)
 
         # Check that we successfully registered.
         check_registered()
@@ -88,7 +91,8 @@ class RegistrationManagerTestCase(ZiplineTestCase):
                 "Class ProperDummyInterface wasn't properly registered under"
                 "name 'ayy-lmao'"
             )
-            self.assertIsInstance(rm.load('ayy-lmao'), ProperDummyInterface)
+            self.assertIsInstance(rm.load('ayy-lmao'), partial)
+            self.assertIsInstance(rm.load('ayy-lmao')(), ProperDummyInterface)
 
         # Check that we successfully registered.
         check_registered()

--- a/tests/test_registration_manager.py
+++ b/tests/test_registration_manager.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from zipline.extensions import Registry
 from zipline.testing.fixtures import ZiplineTestCase
 from zipline.testing.predicates import assert_raises_str, assert_true
@@ -46,8 +44,7 @@ class RegistrationManagerTestCase(ZiplineTestCase):
                 "Class ProperDummyInterface wasn't properly registered under"
                 "name 'ayy-lmao'"
             )
-            self.assertIsInstance(rm.load('ayy-lmao'), partial)
-            self.assertIsInstance(rm.load('ayy-lmao')(), ProperDummyInterface)
+            self.assertEqual(rm.load('ayy-lmao'), ProperDummyInterface)
 
         # Check that we successfully registered.
         check_registered()
@@ -91,8 +88,7 @@ class RegistrationManagerTestCase(ZiplineTestCase):
                 "Class ProperDummyInterface wasn't properly registered under"
                 "name 'ayy-lmao'"
             )
-            self.assertIsInstance(rm.load('ayy-lmao'), partial)
-            self.assertIsInstance(rm.load('ayy-lmao')(), ProperDummyInterface)
+            self.assertEqual(rm.load('ayy-lmao'), ProperDummyInterface)
 
         # Check that we successfully registered.
         check_registered()

--- a/tests/test_tradesimulation.py
+++ b/tests/test_tradesimulation.py
@@ -15,7 +15,7 @@
 
 import pandas as pd
 
-from zipline.gens.clock import BEFORE_TRADING_START_BAR
+from zipline.gens.clock import SessionEvent
 
 from zipline.finance.asset_restrictions import NoRestrictions
 from zipline.finance import metrics
@@ -89,7 +89,7 @@ class BeforeTradingStartsOnlyClock(object):
         self.bts_minute = bts_minute
 
     def __iter__(self):
-        yield self.bts_minute, BEFORE_TRADING_START_BAR
+        yield self.bts_minute, SessionEvent.BEFORE_TRADING_START_BAR
 
 
 class TestBeforeTradingStartSimulationDt(zf.WithMakeAlgo, zf.ZiplineTestCase):

--- a/tests/test_tradesimulation.py
+++ b/tests/test_tradesimulation.py
@@ -15,7 +15,7 @@
 
 import pandas as pd
 
-from zipline.gens.sim_engine import BEFORE_TRADING_START_BAR
+from zipline.gens.clock import BEFORE_TRADING_START_BAR
 
 from zipline.finance.asset_restrictions import NoRestrictions
 from zipline.finance import metrics

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -206,6 +206,12 @@ def ipython_only(option):
     help="The blotter to use.",
     show_default=True,
 )
+@click.option(
+    '--clock',
+    default='default',
+    help="The clock to use.",
+    show_default=True,
+)
 @ipython_only(click.option(
     '--local-namespace/--no-local-namespace',
     is_flag=True,
@@ -228,7 +234,8 @@ def run(ctx,
         print_algo,
         metrics_set,
         local_namespace,
-        blotter):
+        blotter,
+        clock):
     """Run a backtest for the given algorithm.
     """
     # check that the start and end dates are passed correctly
@@ -273,6 +280,7 @@ def run(ctx,
         local_namespace=local_namespace,
         environ=os.environ,
         blotter=blotter,
+        clock=clock,
         benchmark_returns=None,
     )
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -223,8 +223,7 @@ class TradingAlgorithm(object):
                  trading_calendar=None,
                  metrics_set=None,
                  blotter=None,
-                 blotter_class=None,
-                 clock_class=None,
+                 clock=None,
                  cancel_policy=None,
                  benchmark_sid=None,
                  benchmark_returns=None,
@@ -308,14 +307,12 @@ class TradingAlgorithm(object):
             cleanup=clear_dataframe_indexer_caches
         )
 
-        if blotter is not None:
-            self.blotter = blotter
-        else:
-            cancel_policy = cancel_policy or NeverCancel()
-            blotter_class = blotter_class or SimulationBlotter
-            self.blotter = blotter_class(cancel_policy=cancel_policy)
+        cancel_policy = cancel_policy or NeverCancel()
+        self.blotter = (blotter or SimulationBlotter)(
+            cancel_policy=cancel_policy
+        )
 
-        self._clock_class = clock_class or MinuteSimulationClock
+        self._clock_class = clock or MinuteSimulationClock
 
         # The symbol lookup date specifies the date to use when resolving
         # symbols to sids, and can be set using set_symbol_lookup_date()

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -308,9 +308,9 @@ class TradingAlgorithm(object):
         )
 
         cancel_policy = cancel_policy or NeverCancel()
-        self.blotter = (blotter or SimulationBlotter)(
+        self.blotter = SimulationBlotter(
             cancel_policy=cancel_policy
-        )
+        ) if blotter is None else blotter()
 
         self._clock_class = clock or MinuteSimulationClock
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -308,10 +308,12 @@ class TradingAlgorithm(object):
         )
 
         cancel_policy = cancel_policy or NeverCancel()
+        # We're expecting a blotter instance here
         self.blotter = SimulationBlotter(
             cancel_policy=cancel_policy
-        ) if blotter is None else blotter()
+        ) if blotter is None else blotter
 
+        # We're expecting a clock type here
         self._clock_class = clock or MinuteSimulationClock
 
         # The symbol lookup date specifies the date to use when resolving

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -128,7 +128,7 @@ from zipline.utils.security_list import SecurityList
 import zipline.protocol
 from zipline.sources.requests_csv import PandasRequestsCSV
 
-from zipline.gens.sim_engine import MinuteSimulationClock
+from zipline.gens.clock import MinuteSimulationClock
 from zipline.sources.benchmark_source import BenchmarkSource
 from zipline.zipline_warnings import ZiplineDeprecationWarning
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -224,6 +224,7 @@ class TradingAlgorithm(object):
                  metrics_set=None,
                  blotter=None,
                  blotter_class=None,
+                 clock_class=None,
                  cancel_policy=None,
                  benchmark_sid=None,
                  benchmark_returns=None,
@@ -313,6 +314,8 @@ class TradingAlgorithm(object):
             cancel_policy = cancel_policy or NeverCancel()
             blotter_class = blotter_class or SimulationBlotter
             self.blotter = blotter_class(cancel_policy=cancel_policy)
+
+        self._clock_class = clock_class or MinuteSimulationClock
 
         # The symbol lookup date specifies the date to use when resolving
         # symbols to sids, and can be set using set_symbol_lookup_date()
@@ -481,6 +484,9 @@ class TradingAlgorithm(object):
     def _create_clock(self):
         """
         If the clock property is not set, then create one based on frequency.
+
+        If using a custom clock extension, users must account for the
+        arguments passed to the Clock subclass here (see comment below).
         """
         trading_o_and_c = self.trading_calendar.schedule.ix[
             self.sim_params.sessions]
@@ -516,7 +522,9 @@ class TradingAlgorithm(object):
             "US/Eastern"
         )
 
-        return MinuteSimulationClock(
+        # Users intending to use custom clocks must account for the arguments
+        # specified here.
+        return self._clock_class(
             self.sim_params.sessions,
             execution_opens,
             execution_closes,

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -37,7 +37,7 @@ from zipline.data._minute_bar_internal import (
     find_last_traded_position_internal
 )
 
-from zipline.gens.sim_engine import NANOS_IN_MINUTE
+from zipline.gens.clock import NANOS_IN_MINUTE
 from zipline.data.bar_reader import BarReader, NoDataForSid, NoDataOnDate
 from zipline.data.us_equity_pricing import check_uint32_safe
 from zipline.utils.cli import maybe_show_progress

--- a/zipline/extensions.py
+++ b/zipline/extensions.py
@@ -1,3 +1,4 @@
+from functools import partial
 import re
 import six
 from toolz import curry
@@ -107,7 +108,7 @@ class Registry(object):
         self.interface = interface
         self._factories = {}
 
-    def load(self, name):
+    def load(self, name, *args, **kwargs):
         """Construct an object from a registered factory.
 
         Parameters
@@ -116,7 +117,7 @@ class Registry(object):
             Name with which the factory was registered.
         """
         try:
-            return self._factories[name]()
+            return partial(self._factories[name], *args, **kwargs)
         except KeyError:
             raise ValueError(
                 "no %s factory registered under name %r, options are: %r" %
@@ -176,7 +177,7 @@ def get_registry(interface):
         raise ValueError("class specified is not an extendable type")
 
 
-def load(interface, name):
+def load(interface, name, *args, **kwargs):
     """
     Retrieves a custom class whose name is given.
 
@@ -192,7 +193,7 @@ def load(interface, name):
     obj : object
         An instance of the desired class.
     """
-    return get_registry(interface).load(name)
+    return get_registry(interface).load(name, *args, **kwargs)
 
 
 @curry
@@ -207,8 +208,7 @@ def register(interface, name, factory):
     name : str
         The name of the subclass
     factory : type
-        The class to register, which must be a subclass of the
-        abstract base class in self.interface
+        The class to register, which is typically a subclass of the interface
     """
 
     return get_registry(interface).register(name, factory)

--- a/zipline/extensions.py
+++ b/zipline/extensions.py
@@ -196,9 +196,9 @@ def load(interface, name):
 
 
 @curry
-def register(interface, name, custom_class):
+def register(interface, name, factory):
     """
-    Registers a class for retrieval by the load method
+    Registers a class factory for retrieval by the load method
 
     Parameters
     ----------
@@ -206,12 +206,12 @@ def register(interface, name, custom_class):
         The base class for which to perform this operation
     name : str
         The name of the subclass
-    custom_class : type
+    factory : type
         The class to register, which must be a subclass of the
-        abstract base class in self.dtype
+        abstract base class in self.interface
     """
 
-    return get_registry(interface).register(name, custom_class)
+    return get_registry(interface).register(name, factory)
 
 
 def unregister(interface, name):

--- a/zipline/extensions.py
+++ b/zipline/extensions.py
@@ -1,4 +1,3 @@
-from functools import partial
 import re
 import six
 from toolz import curry
@@ -108,7 +107,7 @@ class Registry(object):
         self.interface = interface
         self._factories = {}
 
-    def load(self, name, *args, **kwargs):
+    def load(self, name):
         """Construct an object from a registered factory.
 
         Parameters
@@ -117,7 +116,7 @@ class Registry(object):
             Name with which the factory was registered.
         """
         try:
-            return partial(self._factories[name], *args, **kwargs)
+            return self._factories[name]
         except KeyError:
             raise ValueError(
                 "no %s factory registered under name %r, options are: %r" %
@@ -177,7 +176,7 @@ def get_registry(interface):
         raise ValueError("class specified is not an extendable type")
 
 
-def load(interface, name, *args, **kwargs):
+def load(interface, name):
     """
     Retrieves a custom class whose name is given.
 
@@ -193,7 +192,7 @@ def load(interface, name, *args, **kwargs):
     obj : object
         An instance of the desired class.
     """
-    return get_registry(interface).load(name, *args, **kwargs)
+    return get_registry(interface).load(name)
 
 
 @curry

--- a/zipline/finance/cancel_policy.py
+++ b/zipline/finance/cancel_policy.py
@@ -17,7 +17,7 @@ import abc
 from abc import abstractmethod
 from six import with_metaclass
 
-from zipline.gens.clock import SESSION_END
+from zipline.gens.clock import SessionEvent
 
 
 class CancelPolicy(with_metaclass(abc.ABCMeta)):
@@ -58,7 +58,7 @@ class EODCancel(CancelPolicy):
         self.warn_on_cancel = warn_on_cancel
 
     def should_cancel(self, event):
-        return event == SESSION_END
+        return event == SessionEvent.SESSION_END
 
 
 class NeverCancel(CancelPolicy):

--- a/zipline/finance/cancel_policy.py
+++ b/zipline/finance/cancel_policy.py
@@ -17,7 +17,7 @@ import abc
 from abc import abstractmethod
 from six import with_metaclass
 
-from zipline.gens.sim_engine import SESSION_END
+from zipline.gens.clock import SESSION_END
 
 
 class CancelPolicy(with_metaclass(abc.ABCMeta)):
@@ -32,10 +32,10 @@ class CancelPolicy(with_metaclass(abc.ABCMeta)):
         ----------
         event : enum-value
             An event type, one of:
-              - :data:`zipline.gens.sim_engine.BAR`
-              - :data:`zipline.gens.sim_engine.DAY_START`
-              - :data:`zipline.gens.sim_engine.DAY_END`
-              - :data:`zipline.gens.sim_engine.MINUTE_END`
+              - :data:`zipline.gens.clock.BAR`
+              - :data:`zipline.gens.clock.DAY_START`
+              - :data:`zipline.gens.clock.DAY_END`
+              - :data:`zipline.gens.clock.MINUTE_END`
 
         Returns
         -------

--- a/zipline/gens/clock.py
+++ b/zipline/gens/clock.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import IntEnum
 import numpy as np
 import pandas as pd
 from interface import Interface, implements
@@ -32,7 +32,7 @@ _nanos_in_minute = np.int64(60000000000)
 NANOS_IN_MINUTE = _nanos_in_minute
 
 
-class SessionEvt(Enum):
+class SessionEvt(IntEnum):
     BAR = 0
     SESSION_START = 1
     SESSION_END = 2

--- a/zipline/gens/clock.py
+++ b/zipline/gens/clock.py
@@ -46,13 +46,6 @@ class SessionEvent(IntEnum):
     BEFORE_TRADING_START_BAR = 4
 
 
-BAR = SessionEvent.BAR
-SESSION_START = SessionEvent.SESSION_START
-SESSION_END = SessionEvent.SESSION_END
-MINUTE_END = SessionEvent.MINUTE_END
-BEFORE_TRADING_START_BAR = SessionEvent.BEFORE_TRADING_START_BAR
-
-
 @register(Clock, 'default')
 class MinuteSimulationClock(implements(Clock)):
 
@@ -81,18 +74,19 @@ class MinuteSimulationClock(implements(Clock)):
             market_close = pd.Timestamp(market_close, tz='UTC')
             bts_minute = pd.Timestamp(bts_minute, tz='UTC')
 
-            yield pd.Timestamp(session_nano, tz='UTC'), SESSION_START
+            yield pd.Timestamp(session_nano, tz='UTC'), \
+                SessionEvent.SESSION_START
 
             if bts_minute < counter:
-                yield bts_minute, BEFORE_TRADING_START_BAR
+                yield bts_minute, SessionEvent.BEFORE_TRADING_START_BAR
 
             while counter <= market_close:
                 if counter == bts_minute:
-                    yield counter, BEFORE_TRADING_START_BAR
-                yield counter, BAR
+                    yield counter, SessionEvent.BEFORE_TRADING_START_BAR
+                yield counter, SessionEvent.BAR
                 if self.minute_emission:
-                    yield counter, MINUTE_END
+                    yield counter, SessionEvent.MINUTE_END
 
                 counter += pd.Timedelta(_nanos_in_minute)
 
-            yield market_close, SESSION_END
+            yield market_close, SessionEvent.SESSION_END

--- a/zipline/gens/clock.py
+++ b/zipline/gens/clock.py
@@ -16,7 +16,6 @@
 from enum import Enum
 import numpy as np
 import pandas as pd
-import itertools
 from interface import Interface, implements
 
 from zipline.extensions import extensible, register

--- a/zipline/gens/clock.py
+++ b/zipline/gens/clock.py
@@ -63,21 +63,6 @@ class MinuteSimulationClock(implements(Clock)):
         self.sessions_nanos = sessions.values.astype(np.int64)
         self.bts_nanos = before_trading_start_minutes.values.astype(np.int64)
 
-    #     self.minutes_by_session = self.calc_minutes_by_session()
-    #
-    # def calc_minutes_by_session(self):
-    #     minutes_by_session = {}
-    #     for session_idx, session_nano in enumerate(self.sessions_nanos):
-    #         minutes_nanos = np.arange(
-    #             self.market_opens_nanos[session_idx],
-    #             self.market_closes_nanos[session_idx] + _nanos_in_minute,
-    #             _nanos_in_minute
-    #         )
-    #         minutes_by_session[session_nano] = pd.to_datetime(
-    #             minutes_nanos, utc=True, box=True
-    #         )
-    #     return minutes_by_session
-
     def __iter__(self):
         for session_nano, market_open, market_close, bts_minute in zip(
             self.sessions_nanos,

--- a/zipline/gens/clock.py
+++ b/zipline/gens/clock.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Quantopian, Inc.
+# Copyright 2018 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ from zipline.extensions import extensible, register
 class Clock(Interface):
 
     def __iter__(self):
+        """
+        A clock's __iter__ method must yield tuples of length 2, where the
+        first element is a pandas Timestamp, and the second element is an
+        integer (typically part of an IntEnum) representing an event. This
+        requirement will be checked at runtime.
+        """
         raise NotImplementedError('__iter__ must be implemented')
 
 
@@ -32,7 +38,7 @@ _nanos_in_minute = np.int64(60000000000)
 NANOS_IN_MINUTE = _nanos_in_minute
 
 
-class SessionEvt(IntEnum):
+class SessionEvent(IntEnum):
     BAR = 0
     SESSION_START = 1
     SESSION_END = 2
@@ -40,13 +46,14 @@ class SessionEvt(IntEnum):
     BEFORE_TRADING_START_BAR = 4
 
 
-BAR = SessionEvt.BAR
-SESSION_START = SessionEvt.SESSION_START
-SESSION_END = SessionEvt.SESSION_END
-MINUTE_END = SessionEvt.MINUTE_END
-BEFORE_TRADING_START_BAR = SessionEvt.BEFORE_TRADING_START_BAR
+BAR = SessionEvent.BAR
+SESSION_START = SessionEvent.SESSION_START
+SESSION_END = SessionEvent.SESSION_END
+MINUTE_END = SessionEvent.MINUTE_END
+BEFORE_TRADING_START_BAR = SessionEvent.BEFORE_TRADING_START_BAR
 
 
+@register(Clock, 'default')
 class MinuteSimulationClock(implements(Clock)):
 
     def __init__(self,
@@ -89,8 +96,3 @@ class MinuteSimulationClock(implements(Clock)):
                 counter += pd.Timedelta(_nanos_in_minute)
 
             yield market_close, SESSION_END
-
-
-@register(Clock, 'default')
-def func():
-    return MinuteSimulationClock

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -21,14 +21,7 @@ from zipline.finance.order import ORDER_STATUS
 from zipline.protocol import BarData
 from zipline.utils.api_support import ZiplineAPI
 
-from zipline.gens.clock import (
-    BAR,
-    SESSION_START,
-    SESSION_END,
-    MINUTE_END,
-    BEFORE_TRADING_START_BAR,
-    SessionEvent,
-)
+from zipline.gens.clock import SessionEvent
 
 log = Logger('Trade Simulation')
 
@@ -188,7 +181,7 @@ class AlgorithmSimulator(object):
 
             if algo.data_frequency == 'minute':
                 def execute_order_cancellation_policy():
-                    algo.blotter.execute_cancel_policy(SESSION_END)
+                    algo.blotter.execute_cancel_policy(SessionEvent.SESSION_END)
 
                 def calculate_minute_capital_changes(dt):
                     # process any capital changes that came between the last
@@ -210,13 +203,13 @@ class AlgorithmSimulator(object):
                        and isinstance(event[1], SessionEvent))
 
                 dt, action = event
-                if action == BAR:
+                if action == SessionEvent.BAR:
                     for capital_change_packet in every_bar(dt):
                         yield capital_change_packet
-                elif action == SESSION_START:
+                elif action == SessionEvent.SESSION_START:
                     for capital_change_packet in once_a_day(dt):
                         yield capital_change_packet
-                elif action == SESSION_END:
+                elif action == SessionEvent.SESSION_END:
                     # End of the session.
                     positions = metrics_tracker.positions
                     position_assets = algo.asset_finder.retrieve_all(positions)
@@ -226,11 +219,11 @@ class AlgorithmSimulator(object):
                     algo.validate_account_controls()
 
                     yield self._get_daily_message(dt, algo, metrics_tracker)
-                elif action == BEFORE_TRADING_START_BAR:
+                elif action == SessionEvent.BEFORE_TRADING_START_BAR:
                     self.simulation_dt = dt
                     algo.on_dt_changed(dt)
                     algo.before_trading_start(self.current_data)
-                elif action == MINUTE_END:
+                elif action == SessionEvent.MINUTE_END:
                     minute_msg = self._get_minute_message(
                         dt,
                         algo,

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -20,7 +20,7 @@ from zipline.protocol import BarData
 from zipline.utils.api_support import ZiplineAPI
 from six import viewkeys
 
-from zipline.gens.sim_engine import (
+from zipline.gens.clock import (
     BAR,
     SESSION_START,
     SESSION_END,

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -181,7 +181,9 @@ class AlgorithmSimulator(object):
 
             if algo.data_frequency == 'minute':
                 def execute_order_cancellation_policy():
-                    algo.blotter.execute_cancel_policy(SessionEvent.SESSION_END)
+                    algo.blotter.execute_cancel_policy(
+                        SessionEvent.SESSION_END
+                    )
 
                 def calculate_minute_capital_changes(dt):
                     # process any capital changes that came between the last

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -26,9 +26,11 @@ from sqlalchemy import create_engine
 from testfixtures import TempDirectory
 from toolz import concat, curry
 from trading_calendars import get_calendar
+from zipline import Blotter
 
 from zipline.assets import AssetFinder, AssetDBWriter
 from zipline.assets.synthetic import make_simple_equity_info
+from zipline.extensions import register
 from zipline.utils.compat import wraps
 from zipline.data.data_portal import DataPortal
 from zipline.data.loader import get_benchmark_filename, INDEX_MAPPING
@@ -1524,6 +1526,7 @@ def ensure_doctest(f, name=None):
     return f
 
 
+@register(Blotter, 'record_batch')
 class RecordBatchBlotter(SimulationBlotter):
     """Blotter that tracks how its batch_order method was called.
     """

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -26,11 +26,9 @@ from sqlalchemy import create_engine
 from testfixtures import TempDirectory
 from toolz import concat, curry
 from trading_calendars import get_calendar
-from zipline import Blotter
 
 from zipline.assets import AssetFinder, AssetDBWriter
 from zipline.assets.synthetic import make_simple_equity_info
-from zipline.extensions import register
 from zipline.utils.compat import wraps
 from zipline.data.data_portal import DataPortal
 from zipline.data.loader import get_benchmark_filename, INDEX_MAPPING
@@ -1526,7 +1524,6 @@ def ensure_doctest(f, name=None):
     return f
 
 
-@register(Blotter, 'record_batch')
 class RecordBatchBlotter(SimulationBlotter):
     """Blotter that tracks how its batch_order method was called.
     """

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -202,7 +202,7 @@ def _run(handle_data,
         ),
         metrics_set=metrics_set,
         blotter=blotter,
-        clock_class=clock,
+        clock=clock,
         benchmark_returns=benchmark_returns,
         **{
             'initialize': initialize,
@@ -295,7 +295,8 @@ def run_algorithm(start,
                   extensions=(),
                   strict_extensions=True,
                   environ=os.environ,
-                  blotter='default'):
+                  blotter='default',
+                  clock='default'):
     """
     Run a trading algorithm.
 
@@ -354,6 +355,12 @@ def run_algorithm(start,
         ``zipline.extensions.register`` and call it with no parameters.
         Default is a :class:`zipline.finance.blotter.SimulationBlotter` that
         never cancels orders.
+    clock : str or type (subtype of zipline.gens.clock.Clock), optional
+        Clock to use with this algorithm. If passed as a string, we look for
+        a blotter construction function registered with
+        ``zipline.extensions.register`` and call it with our default
+        parameters. The default resolves to our
+        :class:`zipline.gens.clock.MinuteSimulationClock`.
 
     Returns
     -------
@@ -387,5 +394,6 @@ def run_algorithm(start,
         local_namespace=False,
         environ=environ,
         blotter=blotter,
+        clock=clock,
         benchmark_returns=benchmark_returns,
     )

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -3,6 +3,8 @@ import os
 import sys
 import warnings
 
+from zipline.gens.clock import Clock
+
 try:
     from pygments import highlight
     from pygments.lexers import PythonLexer
@@ -73,6 +75,7 @@ def _run(handle_data,
          local_namespace,
          environ,
          blotter,
+         clock,
          benchmark_returns):
     """Run a backtest for the given algorithm.
 
@@ -179,6 +182,12 @@ def _run(handle_data,
         except ValueError as e:
             raise _RunAlgoError(str(e))
 
+    if isinstance(clock, six.string_types):
+        try:
+            clock = load(Clock, clock)
+        except ValueError as e:
+            raise _RunAlgoError(str(e))
+
     perf = TradingAlgorithm(
         namespace=namespace,
         data_portal=data,
@@ -193,6 +202,7 @@ def _run(handle_data,
         ),
         metrics_set=metrics_set,
         blotter=blotter,
+        clock_class=clock,
         benchmark_returns=benchmark_returns,
         **{
             'initialize': initialize,

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -3,6 +3,7 @@ import os
 import sys
 import warnings
 
+from zipline.finance.cancel_policy import NeverCancel
 from zipline.gens.clock import Clock
 
 try:
@@ -76,6 +77,7 @@ def _run(handle_data,
          environ,
          blotter,
          clock,
+         cancel_policy,
          benchmark_returns):
     """Run a backtest for the given algorithm.
 
@@ -178,7 +180,9 @@ def _run(handle_data,
 
     if isinstance(blotter, six.string_types):
         try:
-            blotter = load(Blotter, blotter)
+            blotter = load(Blotter, blotter)(
+                cancel_policy=(cancel_policy or NeverCancel())
+            )
         except ValueError as e:
             raise _RunAlgoError(str(e))
 
@@ -203,6 +207,7 @@ def _run(handle_data,
         metrics_set=metrics_set,
         blotter=blotter,
         clock=clock,
+        cancel_policy=cancel_policy,
         benchmark_returns=benchmark_returns,
         **{
             'initialize': initialize,
@@ -296,7 +301,8 @@ def run_algorithm(start,
                   strict_extensions=True,
                   environ=os.environ,
                   blotter='default',
-                  clock='default'):
+                  clock='default',
+                  cancel_policy=NeverCancel()):
     """
     Run a trading algorithm.
 
@@ -361,6 +367,8 @@ def run_algorithm(start,
         ``zipline.extensions.register`` and call it with our default
         parameters. The default resolves to our
         :class:`zipline.gens.clock.MinuteSimulationClock`.
+    cancel_policy : CancelPolicy
+        The cancellation policy to use.
 
     Returns
     -------
@@ -395,5 +403,6 @@ def run_algorithm(start,
         environ=environ,
         blotter=blotter,
         clock=clock,
+        cancel_policy=cancel_policy,
         benchmark_returns=benchmark_returns,
     )


### PR DESCRIPTION
Moves the `MinuteSimulationClock` from cython to python, and simplifies some of its logic. Also makes the class implement a new `Clock` interface (created with @ssanderson's `interface` module), which will allow us to create extension points for clocks in the near future. @llllllllll hinted that there may be a point at which we want to take into account the scheduling of a user's functions to make the yielding of values even more efficient, but that we're not quite ready to do that yet. 