### PR TITLE
AssetDBWriter.write_direct

### DIFF
--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -43,7 +43,7 @@ mistune==0.7
 
 # Required by tornado
 backports.ssl-match-hostname==3.4.0.2;python_version<'3.0'
-certifi==2018.4.16
+certifi==2018.8.24
 
 # matplotlib dependencies:
 tornado==4.2.1

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -43,6 +43,7 @@ from zipline.assets import (
     AssetDBWriter,
     AssetFinder,
 )
+from zipline.assets.assets import OwnershipPeriod
 from zipline.assets.synthetic import (
     make_commodity_future_info,
     make_rotating_equity_info,
@@ -2309,7 +2310,7 @@ class TestWriteDirect(WithTmpDir, ZiplineTestCase):
         equity_supplementary_mappings = pd.DataFrame({
             'sid': [0, 1],
             'field': ['QSIP', 'QSIP'],
-            'value': [hash('AYY'), hash('LMAO')],
+            'value': [str(hash(s)) for s in ['AYY', 'LMAO']],
         })
         exchanges = pd.DataFrame({
             'exchange': ['NYSE', 'TSE'],
@@ -2360,3 +2361,24 @@ class TestWriteDirect(WithTmpDir, ZiplineTestCase):
             'TSE': ExchangeInfo('TSE', 'TSE', 'JP'),
         }
         assert_equal(exchange_info, expected_exchange_info)
+
+        supplementary_map = reader.equity_supplementary_map
+        expected_supplementary_map = {
+            ('QSIP', str(hash('AYY'))): (
+                OwnershipPeriod(
+                    start=pd.Timestamp(0, tz='UTC'),
+                    end=pd.Timestamp.max.tz_localize('UTC'),
+                    sid=0,
+                    value=str(hash('AYY')),
+                ),
+            ),
+            ('QSIP', str(hash('LMAO'))): (
+                OwnershipPeriod(
+                    start=pd.Timestamp(0, tz='UTC'),
+                    end=pd.Timestamp.max.tz_localize('UTC'),
+                    sid=1,
+                    value=str(hash('LMAO')),
+                ),
+            ),
+        }
+        assert_equal(supplementary_map, expected_supplementary_map)

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -270,6 +270,23 @@ def _format_range(r):
 
 
 def _check_symbol_mappings(df, exchanges, asset_exchange):
+    """Check that there are no cases where multiple symbols resolve to the same
+    asset at the same time in the same country.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The equity symbol mappings table.
+    exchanges : pd.DataFrame
+        The exchanges table.
+    asset_exchange : pd.Series
+        A series that maps sids to the exchange the asset is in.
+
+    Raises
+    ------
+    ValueError
+        Raised when there are ambiguous symbol mappings.
+    """
     mappings = df.set_index('sid')[list(mapping_columns)].copy()
     mappings['country_code'] = exchanges['country_code'][
         asset_exchange[df['sid']]
@@ -322,6 +339,8 @@ def _split_symbol_mappings(df, exchanges):
     ----------
     df : pd.DataFrame
         The dataframe with multiple rows for each symbol: sid pair.
+    exchanges : pd.DataFrame
+        The exchanges table.
 
     Returns
     -------

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -354,7 +354,13 @@ def _split_symbol_mappings(df, exchanges):
     mappings = df[list(mapping_columns)]
     mappings['sid'] = mappings.index
     mappings.reset_index(drop=True, inplace=True)
-    _check_symbol_mappings(mappings, exchanges, df['exchange'])
+
+    asset_exchange = df[['exchange']]
+    asset_exchange['sid'] = df.index
+    asset_exchange.drop_duplicates(inplace=True)
+    asset_exchange = asset_exchange['exchange']
+
+    _check_symbol_mappings(mappings, exchanges, asset_exchange)
     return (
         df.groupby(level=0).apply(_check_asset_group),
         mappings,

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -770,15 +770,7 @@ class AssetDBWriter(object):
             chunk_size=chunk_size,
         )
 
-    def _write_df_to_table(
-        self,
-        tbl,
-        df,
-        txn,
-        chunk_size,
-        idx=True,
-        idx_label=None,
-    ):
+    def _write_df_to_table(self, tbl, df, txn, chunk_size):
         df = df.copy()
         for column, dtype in df.dtypes.iteritems():
             if dtype.kind == 'M':
@@ -787,12 +779,8 @@ class AssetDBWriter(object):
         df.to_sql(
             tbl.name,
             txn.connection,
-            index=idx,
-            index_label=(
-                idx_label
-                if idx_label is not None else
-                first(tbl.primary_key.columns).name
-            ),
+            index=True,
+            index_label=first(tbl.primary_key.columns).name,
             if_exists='append',
             chunksize=chunk_size,
         )

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -681,6 +681,8 @@ class AssetFinder(object):
                        symbols=self._lookup_most_recent_symbols(sids)):
                 d = dict(row)
                 d['exchange_info'] = exchanges[d.pop('exchange')]
+                # we are not required to have a symbol for every asset, if
+                # we don't have any symbols we will just use the empty string
                 return merge(d, symbols.get(row['sid'], {}))
         else:
             def mkdict(row, exchanges=self.exchange_info):

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -723,7 +723,7 @@ def assert_slice_equal(result, expected, path=(), msg=''):
 def assert_asset_equal(result, expected, path=(), msg='', **kwargs):
     if type(result) is not type(expected):
         raise AssertionError(
-            '%sresult type differs from expected type: %s is not %s\n%2',
+            '%sresult type differs from expected type: %s is not %s\n%s',
             _fmt_msg(msg),
             type(result).__name__,
             type(expected).__name__,

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -45,6 +45,7 @@ from six.moves import zip_longest
 from toolz import dissoc, keyfilter
 import toolz.curried.operator as op
 
+from zipline.assets import Asset
 from zipline.dispatch import dispatch
 from zipline.lib.adjustment import Adjustment
 from zipline.lib.labelarray import LabelArray
@@ -670,6 +671,15 @@ def assert_timestamp_and_datetime_equal(result,
         )
     )
 
+    if isinstance(result, pd.Timestamp) and isinstance(expected, pd.Timestamp):
+        assert_equal(
+            result.tz,
+            expected.tz,
+            path=path + ('.tz',),
+            msg=msg,
+            **kwargs
+        )
+
     result = pd.Timestamp(result)
     expected = pd.Timestamp(expected)
     if compare_nat_equal and pd.isnull(result) and pd.isnull(expected):
@@ -706,6 +716,26 @@ def assert_slice_equal(result, expected, path=(), msg=''):
         _fmt_msg(msg),
         '\n'.join(filter(None, diffs)),
         _fmt_path(path),
+    )
+
+
+@assert_equal.register(Asset, Asset)
+def assert_asset_equal(result, expected, path=(), msg='', **kwargs):
+    if type(result) is not type(expected):
+        raise AssertionError(
+            '%sresult type differs from expected type: %s is not %s\n%2',
+            _fmt_msg(msg),
+            type(result).__name__,
+            type(expected).__name__,
+            _fmt_path(path),
+        )
+
+    assert_equal(
+        result.to_dict(),
+        expected.to_dict(),
+        path=path + ('.to_dict()',),
+        msg=msg,
+        **kwargs
     )
 
 


### PR DESCRIPTION
This PR also adds two improvements to `assert_equal`:

1. On master, `assert_equal(Timestamp, Timestamp)` where the `tz` field is different raises a `TypeError` and doesn't show the `path` nor message. This now checks for this explicitly to fail with a better error.
2. `assert_equal(Asset, Asset)` is added to compare assets through `to_dict()`.

Regarding the dataframe index stuff in the asset db writer: as a consumer, I found it hard to know if I needed to set the index, and if so to what. `write_direct` supports both cases by normalizing a particular column per table to the index. If the given column is not present, it assumes it is already the index. 