### PR TITLE
MAINT: Silence warning about setting with copy.

### DIFF
--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -352,7 +352,8 @@ def _split_symbol_mappings(df, exchanges):
         end_date.
     """
     mappings = df[list(mapping_columns)]
-    mappings['sid'] = mappings.index
+    with pd.option_context('mode.chained_assignment', None):
+        mappings['sid'] = mappings.index
     mappings.reset_index(drop=True, inplace=True)
 
     # take the most recent sid->exchange mapping based on end date


### PR DESCRIPTION
Pandas raises a warning here because we're assigning to a column of a
subset of a dataframe. This warning is intended to prevent people from
doing things like::

    `df[df.col1 > 10]['col1'] = <value>`

which has no effect because the first [] creates a copy, which then gets
mutated, so the original frame remains unchanged.

In this case, however, we've bound the copy to a name that we're going to
continue to use, so we don't care about the warning.