### PR TITLE
BLD: Fetch tags when unshallowing for conda.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ script:
   - source deactivate
 
   # unshallow the clone so the conda build can clone it.
-  - git fetch --unshallow
+  - git fetch --unshallow --tags
   - exec 3>&1; ZP_OUT=$(conda build conda/zipline --python=$CONDA_PY --numpy=$CONDA_NPY -c quantopian -c quantopian/label/ci | tee >(cat - >&3))
   - ZP_OUTPUT=$(echo "$ZP_OUT" | grep "anaconda upload " | awk '{print $NF}')
   - if [ -z "$ZP_OUTPUT" ]; then exit 1; fi


### PR DESCRIPTION
The OSX builds are currently failing, and they appear to be failing to fetch
tags, which causes ``git describe`` to fail when invoked internally by
conda. The tentative culprit for this is that the OSX builds are using a newer
git version, which may have stopped fetching tags by default on --unshallow
clones.