### PR TITLE
BUG: Drop orphaned records from asset db in v6 downgrade.

### DIFF
--- a/zipline/assets/asset_db_migrations.py
+++ b/zipline/assets/asset_db_migrations.py
@@ -526,3 +526,28 @@ def _downgrade_v7(op):
         sa.Column('multiplier', sa.Float),
         sa.Column('tick_size', sa.Float),
     )
+
+    # Delete equity_symbol_mappings records that no longer refer to valid sids.
+    op.execute(
+        """
+        DELETE FROM
+            equity_symbol_mappings
+        WHERE
+            sid NOT IN (SELECT sid FROM equities);
+        """
+    )
+
+    # Delete asset_router records that no longer refer to valid sids.
+    op.execute(
+        """
+        DELETE FROM
+            asset_router
+        WHERE
+            sid
+            NOT IN (
+                SELECT sid FROM equities
+                UNION
+                SELECT sid FROM futures_contracts
+            );
+        """
+    )


### PR DESCRIPTION
Remove records that no longer refer to equities from equity_symbol_mappings and
asset_router.