### PR TITLE
checkpoint issue

### DIFF
--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -1041,7 +1041,7 @@ def get_materialized_checkpoints(checkpoints, colnames, lower_dt, odo_kwargs):
     if checkpoints is not None:
         ts = checkpoints[TS_FIELD_NAME]
         checkpoints_ts = odo(
-            ts[ts <= lower_dt].max(),
+            ts[ts < lower_dt].max(),
             pd.Timestamp,
             **odo_kwargs
         )


### PR DESCRIPTION
When resolving data points to an output row index, we do not include records with a timestamp of _exactly_ the data query cutoff time:

https://github.com/quantopian/zipline/blob/5cda2ad542cb1eab02a84a6685dfb3d2adabd44e/zipline/pipeline/loaders/blaze/_core.pyx#L566-L572

however, when deciding which checkpoint to retrieve we would select anything less than **or equal to** the query start timestamp, after it had been adjusted to the data query cutoff time:

https://github.com/quantopian/zipline/blob/5cda2ad542cb1eab02a84a6685dfb3d2adabd44e/zipline/pipeline/loaders/blaze/core.py#L1043-L1047

If we had a checkpoint at exactly the data query time, we would have selected it meaning all of the data would have a timestamp of exactly the data query time. We only select base rows between the checkpoint timestamp and the upper dt, so we would not have any base rows between the checkpoint and the first output index. When we go to slot these checkpoint rows into the output rows, we would shift them all forward one day leaving us with a leading missing row instead of the checkpoint data.

This change makes us select the most recent checkpoint strictly less than the `lower_dt` which correctly gives us the checkpoint data on the first row of the output when the query begins on a checkpoint boundary.