### PR TITLE
BUG: Use NullHandler to scope user algorithm code logging

### DIFF
--- a/docs/source/whatsnew/1.3.1.txt
+++ b/docs/source/whatsnew/1.3.1.txt
@@ -31,7 +31,8 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+Now uses `NullHandler` to block logs from the user's algorithm from
+being sent to stdout or stderr unless otherwise specified.
 
 Performance
 ~~~~~~~~~~~

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -336,6 +336,15 @@ class TradingAlgorithm(object):
         def noop(*args, **kwargs):
             pass
 
+        def unlog_method(fn):
+            def unlogged_method(*args, **kwargs):
+                with logbook.NullHandler().applicationbound():
+                    fn(*args, **kwargs)
+            if fn is None:
+                return fn
+            else:
+                return unlogged_method
+
         if self.algoscript is not None:
             unexpected_api_methods = set()
             if initialize is not None:
@@ -358,15 +367,15 @@ class TradingAlgorithm(object):
             if algo_filename is None:
                 algo_filename = '<string>'
             code = compile(self.algoscript, algo_filename, 'exec')
-            exec_(code, self.namespace)
+            unlog_method(exec_)(code, self.namespace)
 
-            self._initialize = self.namespace.get('initialize', noop)
-            self._handle_data = self.namespace.get('handle_data', noop)
-            self._before_trading_start = self.namespace.get(
+            self._initialize = unlog_method(self.namespace.get('initialize', noop))
+            self._handle_data = unlog_method(self.namespace.get('handle_data', noop))
+            self._before_trading_start = unlog_method(self.namespace.get(
                 'before_trading_start',
-            )
+            ))
             # Optional analyze function, gets called after run
-            self._analyze = self.namespace.get('analyze')
+            self._analyze = unlog_method(self.namespace.get('analyze'))
 
         else:
             self._initialize = initialize or (lambda self: None)

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -2,6 +2,7 @@ import click
 import os
 import sys
 import warnings
+from logbook import NullHandler
 
 try:
     from pygments import highlight
@@ -237,6 +238,7 @@ def load_extensions(default, extensions, strict, environ, reload=False):
     reload : bool, optional
         Reload any extensions that have already been loaded.
     """
+
     if default:
         default_extension_path = pth.default_extension(environ=environ)
         pth.ensure_file(default_extension_path)
@@ -252,7 +254,8 @@ def load_extensions(default, extensions, strict, environ, reload=False):
             if ext.endswith('.py'):
                 with open(ext) as f:
                     ns = {}
-                    six.exec_(compile(f.read(), ext, 'exec'), ns, ns)
+                    with NullHandler.applicationbound():
+                        six.exec_(compile(f.read(), ext, 'exec'), ns, ns)
             else:
                 __import__(ext)
         except Exception as e:


### PR DESCRIPTION
As I mentioned in my comment on the issue, I have used `NullHandler` to block logs from the algorithm from being sent to stdout or stderr by pushing the `NullHandler` a context handler just outside the places where the algorithm and its methods (i.e. `initialize`) are invoked.  Because the `NullHandler` lies in a higher position on the stack than any other handler called internally to zipline, it handles logs that are not handled by the algorithm.  The `unlog_method` scopes a passed method by a context handler containing `NullHandler`.  Resolves issue #2296.