### PR TITLE
MAINT: Removed tornado, backports.ssl-match-hostname, and certifi

### DIFF
--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -41,12 +41,7 @@ mistune==0.7
 
 # Example scripts that are run during unit tests use the following:
 
-# Required by tornado
-backports.ssl-match-hostname==3.4.0.2;python_version<'3.0'
-certifi==2018.8.24
-
 # matplotlib dependencies:
-tornado==4.2.1
 pyparsing==2.0.3
 cycler==0.10.0
 matplotlib==1.5.3


### PR DESCRIPTION
@richafrank As per discussion earlier

These are no longer required by the version of matplotlib we're installing.