### PR TITLE
Made changes to RSI based on member feedback

### DIFF
--- a/zipline/pipeline/factors/technical.py
+++ b/zipline/pipeline/factors/technical.py
@@ -48,14 +48,14 @@ class RSI(CustomFactor, SingleInputMixin):
 
     **Default Window Length**: 15
     """
-    window_length = 15
-    inputs = (EquityPricing.close,)
+    window_length = 14
+    inputs = [EquityPricing.close]
     window_safe = True
 
     def compute(self, today, assets, out, closes):
         diffs = diff(closes, axis=0)
-        ups = nanmean(clip(diffs, 0, inf), axis=0)
-        downs = abs(nanmean(clip(diffs, -inf, 0), axis=0))
+        ups = nanmean(diffs[diffs > 0])
+        downs = abs(nanmean(diffs[diffs < 0]))
         return evaluate(
             "100 - (100 / (1 + (ups / downs)))",
             local_dict={'ups': ups, 'downs': downs},


### PR DESCRIPTION
The way we calculate RSI seems to differ from the consensus way of doing it. [Investopedia](https://www.investopedia.com/terms/r/rsi.asp). [Wikipedia](https://en.wikipedia.org/wiki/Relative_strength_index).

Changes made: 

1. Changed window length to 14.
2. Made syntax change to inputs variable to match the syntax I've seen in the past for custom factors.
3. Dropped zeros from ups and downs, because they will change the value of the mean of the array.