### PR TITLE
MAINT: Make load_raw_arrays for daily bar readers handle unknown sids

### DIFF
--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -199,7 +199,7 @@ class BundleCoreTestCase(WithInstanceTmpDir,
         for actual_column, colname in zip(actual, columns):
             assert_equal(
                 actual_column,
-                expected_bar_values_2d(minutes, equities, colname),
+                expected_bar_values_2d(minutes, sids, equities, colname),
                 msg=colname,
             )
 
@@ -212,7 +212,7 @@ class BundleCoreTestCase(WithInstanceTmpDir,
         for actual_column, colname in zip(actual, columns):
             assert_equal(
                 actual_column,
-                expected_bar_values_2d(sessions, equities, colname),
+                expected_bar_values_2d(sessions, sids, equities, colname),
                 msg=colname,
             )
         adjustments_for_cols = bundle.adjustment_reader.load_adjustments(

--- a/tests/data/test_daily_bars.py
+++ b/tests/data/test_daily_bars.py
@@ -334,21 +334,21 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
             end_date=TEST_QUERY_STOP,
         )
 
-    def test_read_only_unknown_sids(self):
-        """
-        Test a query where all sids are unknown.
-        """
-
+    @parameterized.expand([
         # Query for only even sids, only odd ids are valid.
-        query_assets = [2, 4, 800]
-
-        columns = ['close', 'volume']
-        self._check_read_results(
-            columns,
-            query_assets,
-            start_date=TEST_QUERY_START,
-            end_date=TEST_QUERY_STOP,
-        )
+        ([],),
+        ([2],),
+        ([2, 4, 800],),
+    ])
+    def test_read_only_unknown_sids(self, query_assets):
+        columns = [CLOSE, VOLUME]
+        with self.assertRaises(ValueError):
+            self.daily_bar_reader.load_raw_arrays(
+                columns,
+                TEST_QUERY_START,
+                TEST_QUERY_STOP,
+                query_assets,
+            )
 
     def test_unadjusted_get_value(self):
         """Test get_value() on both a price field (CLOSE) and VOLUME."""

--- a/tests/data/test_daily_bars.py
+++ b/tests/data/test_daily_bars.py
@@ -30,13 +30,13 @@ from pandas import (
     Timestamp,
 )
 from six import iteritems
+from six.moves import range
 from toolz import merge
 from trading_calendars import get_calendar
 
 from zipline.data.bar_reader import (
     NoDataAfterDate,
     NoDataBeforeDate,
-    NoDataForSid,
     NoDataOnDate,
 )
 from zipline.data.bcolz_daily_bars import BcolzDailyBarWriter
@@ -77,60 +77,62 @@ TEST_CALENDAR_STOP = Timestamp('2015-06-30', tz='UTC')
 TEST_QUERY_START = Timestamp('2015-06-10', tz='UTC')
 TEST_QUERY_STOP = Timestamp('2015-06-19', tz='UTC')
 
-# One asset for each of the cases enumerated in load_raw_arrays_from_bcolz.
+# NOTE: All sids here are odd, so we can test querying for unknown sids
+#       with evens.
 us_info = DataFrame(
     [
         # 1) The equity's trades start and end before query.
         {'start_date': '2015-06-01', 'end_date': '2015-06-05'},
-        # 2) The equity's trades start and end after query.
+        # 3) The equity's trades start and end after query.
         {'start_date': '2015-06-22', 'end_date': '2015-06-30'},
-        # 3) The equity's data covers all dates in range (but we define
+        # 5) The equity's data covers all dates in range (but we define
         #    a hole for it on 2015-06-17).
         {'start_date': '2015-06-02', 'end_date': '2015-06-30'},
-        # 4) The equity's trades start before the query start, but stop
+        # 7) The equity's trades start before the query start, but stop
         #    before the query end.
         {'start_date': '2015-06-01', 'end_date': '2015-06-15'},
-        # 5) The equity's trades start and end during the query.
+        # 9) The equity's trades start and end during the query.
         {'start_date': '2015-06-12', 'end_date': '2015-06-18'},
-        # 6) The equity's trades start during the query, but extend through
+        # 11) The equity's trades start during the query, but extend through
         #    the whole query.
         {'start_date': '2015-06-15', 'end_date': '2015-06-25'},
     ],
-    index=arange(1, 7),
+    index=arange(1, 12, step=2),
     columns=['start_date', 'end_date'],
 ).astype('datetime64[ns]')
 us_info['exchange'] = 'NYSE'
 
 ca_info = DataFrame(
     [
-        # 7) The equity's trades start and end before query.
+        # 13) The equity's trades start and end before query.
         {'start_date': '2015-06-01', 'end_date': '2015-06-05'},
-        # 8) The equity's trades start and end after query.
+        # 15) The equity's trades start and end after query.
         {'start_date': '2015-06-22', 'end_date': '2015-06-30'},
-        # 9) The equity's data covers all dates in range.
+        # 17) The equity's data covers all dates in range.
         {'start_date': '2015-06-02', 'end_date': '2015-06-30'},
-        # 10) The equity's trades start before the query start, but stop
+        # 19) The equity's trades start before the query start, but stop
         #    before the query end.
         {'start_date': '2015-06-01', 'end_date': '2015-06-15'},
-        # 11) The equity's trades start and end during the query.
+        # 21) The equity's trades start and end during the query.
         {'start_date': '2015-06-12', 'end_date': '2015-06-18'},
-        # 12) The equity's trades start during the query, but extend through
+        # 23) The equity's trades start during the query, but extend through
         #    the whole query.
         {'start_date': '2015-06-15', 'end_date': '2015-06-25'},
     ],
-    index=arange(7, 13),
+    index=arange(13, 24, step=2),
     columns=['start_date', 'end_date'],
 ).astype('datetime64[ns]')
 ca_info['exchange'] = 'TSX'
 
 EQUITY_INFO = concat([us_info, ca_info])
-EQUITY_INFO['symbol'] = [chr(ord('A') + n) for n in range(len(EQUITY_INFO))]
+EQUITY_INFO['symbol'] = [chr(ord('A') + x) for x in range(len(EQUITY_INFO))]
 
 TEST_QUERY_ASSETS = EQUITY_INFO.index
+assert (TEST_QUERY_ASSETS % 2 == 1).all(), 'All sids should be odd.'
 
 HOLES = {
-    'US': {3: (Timestamp('2015-06-17', tz='UTC'),)},
-    'CA': {9: (Timestamp('2015-06-17', tz='UTC'),)},
+    'US': {5: (Timestamp('2015-06-17', tz='UTC'),)},
+    'CA': {17: (Timestamp('2015-06-17', tz='UTC'),)},
 }
 
 
@@ -219,7 +221,8 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
                 result,
                 expected_bar_values_2d(
                     dates,
-                    EQUITY_INFO.loc[assets],
+                    assets,
+                    EQUITY_INFO.loc[self.assets],
                     column,
                     holes=self.holes,
                 )
@@ -298,7 +301,7 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
         Test loading with queries that end on the last day of each asset's
         lifetime.
         """
-        columns = ['close', 'volume']
+        columns = [CLOSE, VOLUME]
         for asset in self.assets:
             self._check_read_results(
                 columns,
@@ -306,6 +309,46 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
                 start_date=self.sessions[0],
                 end_date=self.asset_end(asset),
             )
+
+    def test_read_known_and_unknown_sids(self):
+        """
+        Test a query with some known sids mixed in with unknown sids.
+        """
+
+        # Construct a list of alternating valid and invalid query sids,
+        # bookended by invalid sids.
+        #
+        # E.g.
+        #   INVALID VALID INVALID VALID ... VALID INVALID
+        query_assets = (
+            [self.assets[-1] + 1] +
+            list(range(self.assets[0], self.assets[-1] + 1)) +
+            [self.assets[-1] + 3]
+        )
+
+        columns = [CLOSE, VOLUME]
+        self._check_read_results(
+            columns,
+            query_assets,
+            start_date=TEST_QUERY_START,
+            end_date=TEST_QUERY_STOP,
+        )
+
+    def test_read_only_unknown_sids(self):
+        """
+        Test a query where all sids are unknown.
+        """
+
+        # Query for only even sids, only odd ids are valid.
+        query_assets = [2, 4, 800]
+
+        columns = ['close', 'volume']
+        self._check_read_results(
+            columns,
+            query_assets,
+            start_date=TEST_QUERY_START,
+            end_date=TEST_QUERY_STOP,
+        )
 
     def test_unadjusted_get_value(self):
         """Test get_value() on both a price field (CLOSE) and VOLUME."""
@@ -509,27 +552,27 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, _DailyBarsTestCase):
         result = self.bcolz_daily_bar_ctable
         expected_first_row = {
             '1': 0,
-            '2': 5,   # Asset 1 has 5 trading days.
-            '3': 12,  # Asset 2 has 7 trading days.
-            '4': 33,  # Asset 3 has 21 trading days.
-            '5': 44,  # Asset 4 has 11 trading days.
-            '6': 49,  # Asset 5 has 5 trading days.
+            '3': 5,    # Asset 1 has 5 trading days.
+            '5': 12,   # Asset 3 has 7 trading days.
+            '7': 33,   # Asset 5 has 21 trading days.
+            '9': 44,   # Asset 7 has 11 trading days.
+            '11': 49,  # Asset 9 has 5 trading days.
         }
         expected_last_row = {
             '1': 4,
-            '2': 11,
-            '3': 32,
-            '4': 43,
-            '5': 48,
-            '6': 57,    # Asset 6 has 9 trading days.
+            '3': 11,
+            '5': 32,
+            '7': 43,
+            '9': 48,
+            '11': 57,    # Asset 11 has 9 trading days.
         }
         expected_calendar_offset = {
-            '1': 0,   # Starts on 6-01, 1st trading day of month.
-            '2': 15,  # Starts on 6-22, 16th trading day of month.
-            '3': 1,   # Starts on 6-02, 2nd trading day of month.
-            '4': 0,   # Starts on 6-01, 1st trading day of month.
-            '5': 9,   # Starts on 6-12, 10th trading day of month.
-            '6': 10,  # Starts on 6-15, 11th trading day of month.
+            '1': 0,    # Starts on 6-01, 1st trading day of month.
+            '3': 15,   # Starts on 6-22, 16th trading day of month.
+            '5': 1,    # Starts on 6-02, 2nd trading day of month.
+            '7': 0,    # Starts on 6-01, 1st trading day of month.
+            '9': 9,    # Starts on 6-12, 10th trading day of month.
+            '11': 10,  # Starts on 6-15, 11th trading day of month.
         }
         self.assertEqual(result.attrs['first_row'], expected_first_row)
         self.assertEqual(result.attrs['last_row'], expected_last_row)
@@ -570,8 +613,8 @@ class BcolzDailyBarWriterMissingDataTestCase(WithAssetFinder,
                                              WithTmpDir,
                                              WithTradingCalendars,
                                              ZiplineTestCase):
-    # Sid 3 is active from 2015-06-02 to 2015-06-30.
-    MISSING_DATA_SID = 3
+    # Sid 5 is active from 2015-06-02 to 2015-06-30.
+    MISSING_DATA_SID = 5
     # Leave out data for a day in the middle of the query range.
     MISSING_DATA_DAY = Timestamp('2015-06-15', tz='UTC')
 
@@ -646,42 +689,6 @@ class _HDF5DailyBarTestCase(WithHDF5EquityMultiCountryDailyBarReader,
                 msg=(
                     'asset_start_dates value for sid={} differs from expected'
                 ).format(sid)
-            )
-
-    def test_invalid_sid(self):
-        INVALID_SID = 100
-
-        with self.assertRaises(NoDataForSid):
-            self.daily_bar_reader.load_raw_arrays(
-                OHLCV,
-                TEST_QUERY_START,
-                TEST_QUERY_STOP,
-                [INVALID_SID],
-            )
-
-        with self.assertRaises(NoDataForSid):
-            self.daily_bar_reader.get_value(
-                INVALID_SID,
-                TEST_QUERY_START,
-                'close',
-            )
-
-    def test_invalid_sid_single_country(self):
-        INVALID_SID = 100
-
-        with self.assertRaises(NoDataForSid):
-            self.single_country_reader.load_raw_arrays(
-                OHLCV,
-                TEST_QUERY_START,
-                TEST_QUERY_STOP,
-                [INVALID_SID],
-            )
-
-        with self.assertRaises(NoDataForSid):
-            self.single_country_reader.get_value(
-                INVALID_SID,
-                TEST_QUERY_START,
-                'close',
             )
 
     def test_invalid_date(self):

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -1005,6 +1005,7 @@ class SyntheticBcolzTestCase(zf.WithAdjustmentReader,
         expected_raw = DataFrame(
             expected_bar_values_2d(
                 dates - self.trading_calendar.day,
+                asset_ids,
                 self.equity_info,
                 'close',
             ),

--- a/tests/pipeline/test_us_equity_pricing_loader.py
+++ b/tests/pipeline/test_us_equity_pricing_loader.py
@@ -491,11 +491,13 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
 
         expected_baseline_closes = expected_bar_values_2d(
             shifted_query_days,
+            self.sids,
             self.asset_info,
             'close',
         )
         expected_baseline_volumes = expected_bar_values_2d(
             shifted_query_days,
+            self.sids,
             self.asset_info,
             'volume',
         )
@@ -569,11 +571,13 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
 
         expected_baseline_highs = expected_bar_values_2d(
             shifted_query_days,
+            self.sids,
             self.asset_info,
             'high',
         )
         expected_baseline_volumes = expected_bar_values_2d(
             shifted_query_days,
+            self.sids,
             self.asset_info,
             'volume',
         )

--- a/zipline/data/_equities.pyx
+++ b/zipline/data/_equities.pyx
@@ -213,6 +213,10 @@ cpdef _read_bcolz_data(ctable_t table,
 
             for asset in range(nassets):
                 first_row = first_rows[asset]
+                if first_row == -1:
+                    # This is an unknown asset, leave its slot empty.
+                    continue
+
                 last_row = last_rows[asset]
                 offset = offsets[asset]
                 out_start = offset

--- a/zipline/data/_equities.pyx
+++ b/zipline/data/_equities.pyx
@@ -100,11 +100,11 @@ cpdef _compute_row_slices(dict asset_starts_absolute,
         intp_t asset_end_calendar
 
     for i, asset in enumerate(requested_assets):
-        try:
-            asset_start_data = asset_starts_absolute[asset]
-        except KeyError:
+        if asset not in asset_starts_absolute:
             # This is an unknown asset, leave its slot empty.
             continue
+        else:
+            asset_start_data = asset_starts_absolute[asset]
 
         asset_end_data = asset_ends_absolute[asset]
         asset_start_calendar = asset_starts_calendar[asset]

--- a/zipline/data/_equities.pyx
+++ b/zipline/data/_equities.pyx
@@ -99,13 +99,18 @@ cpdef _compute_row_slices(dict asset_starts_absolute,
         intp_t asset_start_calendar
         intp_t asset_end_calendar
 
+        # Flag to check whether we should raise an error because we don't know
+        # about any of the requested sids.
+        uint8_t any_hits = 0
+
     for i, asset in enumerate(requested_assets):
         if asset not in asset_starts_absolute:
             # This is an unknown asset, leave its slot empty.
             continue
-        else:
-            asset_start_data = asset_starts_absolute[asset]
 
+        any_hits = 1
+
+        asset_start_data = asset_starts_absolute[asset]
         asset_end_data = asset_ends_absolute[asset]
         asset_start_calendar = asset_starts_calendar[asset]
         asset_end_calendar = (
@@ -130,6 +135,9 @@ cpdef _compute_row_slices(dict asset_starts_absolute,
         # Otherwise, offset by the number of rows in the query in which the
         # asset did not yet exist.
         offset_a[i] = max(0, asset_start_calendar - query_start)
+
+    if not any_hits:
+        raise ValueError('At least one valid asset id is required.')
 
     return first_row_a, last_row_a, offset_a
 

--- a/zipline/data/_equities.pyx
+++ b/zipline/data/_equities.pyx
@@ -19,6 +19,7 @@ from cpython cimport bool
 from numpy import (
     array,
     float64,
+    full,
     intp,
     uint32,
     zeros,
@@ -50,34 +51,33 @@ cpdef _compute_row_slices(dict asset_starts_absolute,
     """
     Core indexing functionality for loading raw data from bcolz.
 
-    Parameters
-    ----------
-    asset_starts_absolute : dict
-        Dictionary containing the index of the first row of each asset in the
-        bcolz file from which we will query.
-
-    asset_ends_absolute : dict
-        Dictionary containing the index of the last row of each asset in the
-        bcolz file from which we will query.
-
-    asset_starts_calendar : dict
-        Dictionary containing the index of in our calendar corresponding to the
-        start date of each asset
-
-    query_start : intp
-    query_end : intp
-        Start and end indices in our calendar of the dates for which we're
-        querying.
-
-    requested_assets : pandas.Int64Index
-        The assets for which we want to load data.
-
     For each asset in requested assets, computes three values:
+
     1.) The index in the raw bcolz data of first row to load.
     2.) The index in the raw bcolz data of the last row to load.
     3.) The index in the dates of our query corresponding to the first row for
         each asset. This is non-zero iff the asset's lifetime begins partway
         through the requested query dates.
+
+    Values for unknown sids will be populated with a value of -1.
+
+    Parameters
+    ----------
+    asset_starts_absolute : dict
+        Dictionary containing the index of the first row of each asset in the
+        bcolz file from which we will query.
+    asset_ends_absolute : dict
+        Dictionary containing the index of the last row of each asset in the
+        bcolz file from which we will query.
+    asset_starts_calendar : dict
+        Dictionary containing the index of in our calendar corresponding to the
+        start date of each asset
+    query_start : intp
+        Start index in our calendar of the dates for which we're querying.
+    query_end : intp
+        End index in our calendar of the dates for which we're querying.
+    requested_assets : pandas.Int64Index
+        The assets for which we want to load data.
 
     Returns
     -------
@@ -87,9 +87,9 @@ cpdef _compute_row_slices(dict asset_starts_absolute,
         intp_t nassets = len(requested_assets)
 
         # For each sid, we need to compute the following:
-        ndarray[dtype=intp_t, ndim=1] first_row_a = zeros(nassets, dtype=intp)
-        ndarray[dtype=intp_t, ndim=1] last_row_a = zeros(nassets, dtype=intp)
-        ndarray[dtype=intp_t, ndim=1] offset_a = zeros(nassets, dtype=intp)
+        ndarray[dtype=intp_t, ndim=1] first_row_a = full(nassets, -1, dtype=intp)
+        ndarray[dtype=intp_t, ndim=1] last_row_a = full(nassets, -1, dtype=intp)
+        ndarray[dtype=intp_t, ndim=1] offset_a = full(nassets, -1, dtype=intp)
 
         # Loop variables.
         intp_t i
@@ -100,7 +100,12 @@ cpdef _compute_row_slices(dict asset_starts_absolute,
         intp_t asset_end_calendar
 
     for i, asset in enumerate(requested_assets):
-        asset_start_data = asset_starts_absolute[asset]
+        try:
+            asset_start_data = asset_starts_absolute[asset]
+        except KeyError:
+            # This is an unknown asset, leave its slot empty.
+            continue
+
         asset_end_data = asset_ends_absolute[asset]
         asset_start_calendar = asset_starts_calendar[asset]
         asset_end_calendar = (
@@ -191,8 +196,13 @@ cpdef _read_bcolz_data(ctable_t table,
 
             for asset in range(nassets):
                 first_row = first_rows[asset]
+                if first_row == -1:
+                    # This is an unknown asset, leave its slot empty.
+                    continue
+
                 last_row = last_rows[asset]
                 offset = offsets[asset]
+
                 if first_row <= last_row:
                     outbuf[offset:offset + (last_row + 1 - first_row), asset] =\
                         raw_data[first_row:last_row + 1]

--- a/zipline/data/bcolz_daily_bars.py
+++ b/zipline/data/bcolz_daily_bars.py
@@ -570,9 +570,6 @@ class BcolzDailyBarReader(SessionBarReader):
         )
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
-        if not any(asset in self._calendar_offsets for asset in assets):
-            raise ValueError('At least one valid asset id is required.')
-
         start_idx = self._load_raw_arrays_date_to_index(start_date)
         end_idx = self._load_raw_arrays_date_to_index(end_date)
 

--- a/zipline/data/bcolz_daily_bars.py
+++ b/zipline/data/bcolz_daily_bars.py
@@ -570,6 +570,9 @@ class BcolzDailyBarReader(SessionBarReader):
         )
 
     def load_raw_arrays(self, columns, start_date, end_date, assets):
+        if not any(asset in self._calendar_offsets for asset in assets):
+            raise ValueError('At least one valid asset id is required.')
+
         start_idx = self._load_raw_arrays_date_to_index(start_date)
         end_idx = self._load_raw_arrays_date_to_index(end_date)
 

--- a/zipline/data/hdf5_daily_bars.py
+++ b/zipline/data/hdf5_daily_bars.py
@@ -75,7 +75,7 @@ import h5py
 import logbook
 import numpy as np
 import pandas as pd
-from six import iteritems, viewkeys
+from six import iteritems, raise_from, viewkeys
 from six.moves import reduce
 
 from zipline.data.bar_reader import (
@@ -878,8 +878,18 @@ class MultiCountryDailyBarReader(SessionBarReader):
         NoDataOnDate
             If the given dt is not a valid market minute (in minute mode) or
             session (in daily mode) according to this reader's tradingcalendar.
+        NoDataForSid
+            If the given sid is not valid.
         """
-        country_code = self._country_code_for_assets([sid])
+        try:
+            country_code = self._country_code_for_assets([sid])
+        except ValueError as exc:
+            raise_from(
+                NoDataForSid(
+                    'Asset not contained in daily pricing file: {}'.format(sid)
+                ),
+                exc
+            )
         return self._readers[country_code].get_value(sid, dt, field)
 
     def get_last_traded_dt(self, asset, dt):

--- a/zipline/data/hdf5_daily_bars.py
+++ b/zipline/data/hdf5_daily_bars.py
@@ -512,9 +512,20 @@ class HDF5DailyBarReader(SessionBarReader):
 
     def _make_sid_selector(self, assets):
         """
-        Retursn an indexer that converts an array aligned to self.sids
-        (which is what we pull from the h5 file) into an array aligned
-        to ``assets``.
+        Build an indexer mapping ``self.sids`` to ``assets``.
+
+        Parameters
+        ----------
+        assets : list[int]
+            List of assets requested by a caller of ``load_raw_arrays``.
+
+        Returns
+        -------
+        index : np.array[int64]
+            Index array containing the index in ``self.sids`` for each location
+            in ``assets``. Entries in ``assets`` for which we don't have a sid
+            will contain -1. It is caller's responsibility to handle these
+            values correctly.
         """
         assets = np.array(assets)
         sid_selector = self.sids.searchsorted(assets)

--- a/zipline/data/hdf5_daily_bars.py
+++ b/zipline/data/hdf5_daily_bars.py
@@ -75,7 +75,7 @@ import h5py
 import logbook
 import numpy as np
 import pandas as pd
-from six import iteritems, raise_from, viewkeys
+from six import iteritems, viewkeys
 from six.moves import reduce
 
 from zipline.data.bar_reader import (
@@ -466,40 +466,61 @@ class HDF5DailyBarReader(SessionBarReader):
             (minutes in range, sids) with a dtype of float64, containing the
             values for the respective field over start and end dt range.
         """
-        self._validate_assets(assets)
         self._validate_timestamp(start_date)
         self._validate_timestamp(end_date)
 
         start = start_date.asm8
         end = end_date.asm8
 
-        sid_selector = self.sids.searchsorted(assets)
+        sid_selector, out_buf_indexer = self._make_sid_indexers(assets)
+
         date_slice = self._compute_date_range_slice(start, end)
 
-        nrows = date_slice.stop - date_slice.start
-        ncols = len(self.sids)
+        n_dates = date_slice.stop - date_slice.start
+        n_valid_sids = len(self.sids)
+        n_query_sids = len(assets)
 
-        buf = np.zeros((ncols, nrows), dtype=np.uint32)
+        read_buf = np.zeros((n_valid_sids, n_dates), dtype=np.uint32)
 
         out = []
         for column in columns:
             # Zero the buffer to prepare it to receive new data.
-            buf.fill(0)
+            read_buf.fill(0)
 
             dataset = self._country_group[DATA][column]
 
             dataset.read_direct(
-                buf,
-                np.s_[:, date_slice.start:date_slice.stop],
+                read_buf,
+                np.s_[:, date_slice],
             )
+
+            out_buf = np.zeros((n_query_sids, n_dates), dtype=np.uint32)
+            out_buf[out_buf_indexer] = read_buf[sid_selector]
 
             out.append(
                 self._postprocessors[column](
-                    buf[sid_selector].T
+                    out_buf.T
                 )
             )
 
         return out
+
+    def _make_sid_indexers(self, assets):
+        """
+        Given the assets that have been queried, returns two indexers:
+
+          (1) Indexer to select the requested sids from the data read
+              out of the h5 file.
+          (2) Indexer to slot the data for those sids into the output
+              array, which may contain gaps (for invalid sids).
+        """
+
+        assets = np.array(assets)
+
+        valid_assets_mask = np.in1d(assets, self.sids)
+        sid_selector = self.sids.searchsorted(assets[valid_assets_mask])
+
+        return sid_selector, valid_assets_mask
 
     def _compute_date_range_slice(self, start_date, end_date):
         # Get the index of the start of dates for ``start_date``.
@@ -726,21 +747,17 @@ class MultiCountryDailyBarReader(SessionBarReader):
         return viewkeys(self._readers)
 
     def _country_code_for_assets(self, assets):
-        try:
-            country_codes = self._country_map.loc[assets]
-        except KeyError as exc:
-            raise_from(
-                NoDataForSid(
-                    'Assets not contained in daily pricing file: {}'.format(
-                        set(assets) - set(self._country_map)
-                    )
-                ),
-                exc
-            )
+        country_codes = self._country_map.get(assets)
 
-        unique_country_codes = country_codes.unique()
+        if country_codes is not None:
+            unique_country_codes = country_codes.dropna().unique()
+            num_countries = len(unique_country_codes)
+        else:
+            num_countries = 0
 
-        if len(unique_country_codes) > 1:
+        if num_countries == 0:
+            return self._country_map.iloc[0]
+        elif num_countries > 1:
             raise NotImplementedError(
                 (
                     'Assets were requested from multiple countries ({}),'

--- a/zipline/data/hdf5_daily_bars.py
+++ b/zipline/data/hdf5_daily_bars.py
@@ -758,7 +758,7 @@ class MultiCountryDailyBarReader(SessionBarReader):
             num_countries = 0
 
         if num_countries == 0:
-            return self._country_map.iloc[0]
+            raise ValueError('At least one valid asset id is required.')
         elif num_countries > 1:
             raise NotImplementedError(
                 (

--- a/zipline/pipeline/loaders/synthetic.py
+++ b/zipline/pipeline/loaders/synthetic.py
@@ -341,13 +341,20 @@ def expected_bar_value_with_holes(asset_id,
     return expected_bar_value(asset_id, date, colname)
 
 
-def expected_bar_values_2d(dates, asset_info, colname, holes=None):
+def expected_bar_values_2d(dates,
+                           assets,
+                           asset_info,
+                           colname,
+                           holes=None):
     """
     Return an 2D array containing cls.expected_value(asset_id, date,
     colname) for each date/asset pair in the inputs.
 
-    Values before/after an assets lifetime, as well as the locs defined,
-    in `holes` are filled with 0 for volume and NaN for price columns.
+    Missing locs are filled with 0 for volume and NaN for price columns:
+
+        - Values before/after an asset's lifetime.
+        - Values for asset_ids not contained in asset_info.
+        - Locs defined in `holes`.
     """
     if colname == 'volume':
         dtype = uint32
@@ -356,10 +363,12 @@ def expected_bar_values_2d(dates, asset_info, colname, holes=None):
         dtype = float64
         missing = float('nan')
 
-    assets = asset_info.index
-
     data = full((len(dates), len(assets)), missing, dtype=dtype)
     for j, asset in enumerate(assets):
+        # Use missing values when asset_id is not contained in asset_info.
+        if asset not in asset_info.index:
+            continue
+
         start = asset_start(asset_info, asset)
         end = asset_end(asset_info, asset)
         for i, date in enumerate(dates):


### PR DESCRIPTION
The readers would previously error, they'll now return `nan`/`0` for these sids.