### PR TITLE
MAINT: Upgrade sqlalchemy to 1.1.18

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -71,7 +71,7 @@ multipledispatch==0.6.0
 MarkupSafe==0.23
 Mako==1.0.1
 # Asset writer and finder
-sqlalchemy==1.0.8
+sqlalchemy==1.1.18
 # For asset db management
 alembic==0.7.7
 


### PR DESCRIPTION
Includes a bunch of bug fixes and more support for enums.