### PR TITLE
MAINT: Use a param name that is not the type builtin.

### DIFF
--- a/tests/events/test_events_nyse.py
+++ b/tests/events/test_events_nyse.py
@@ -144,8 +144,8 @@ class TestStatelessRulesNYSE(StatelessRulesTests, TestCase):
         self.assertEquals(expected, results)
 
     @parameterized.expand([('week_start',), ('week_end',)])
-    def test_week_and_time_composed_rule(self, type):
-        week_rule = NthTradingDayOfWeek(0) if type == 'week_start' else \
+    def test_week_and_time_composed_rule(self, rule_type):
+        week_rule = NthTradingDayOfWeek(0) if rule_type == 'week_start' else \
             NDaysBeforeLastTradingDayOfWeek(4)
         time_rule = AfterOpen(minutes=60)
 


### PR DESCRIPTION
# Notes

Follows up on https://github.com/quantopian/zipline/pull/2394#discussion_r244758588