### PR TITLE
BUG: fix for newer pandas

### DIFF
--- a/tests/pipeline/test_domain.py
+++ b/tests/pipeline/test_domain.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import datetime
 from textwrap import dedent
 
+import numpy as np
 import pandas as pd
 import pytz
 
@@ -380,7 +381,7 @@ class DataQueryCutoffForSessionTestCase(zf.ZiplineTestCase):
             EquityCalendarDomain(
                 CountryCode.UNITED_STATES,
                 'XNYS',
-                data_query_offset=-datetime.timedelta(hours=2, minutes=30),
+                data_query_offset=-np.timedelta64(2 * 60 + 30, 'm'),
             ),
             datetime.time(7, 0),
         )
@@ -390,7 +391,7 @@ class DataQueryCutoffForSessionTestCase(zf.ZiplineTestCase):
             EquityCalendarDomain(
                 CountryCode.UNITED_STATES,
                 'XNYS',
-                data_query_offset=-datetime.timedelta(hours=10),
+                data_query_offset=-np.timedelta64(10, 'h'),
             ),
             datetime.time(23, 30),
             expected_cutoff_date_offset=-1,
@@ -401,7 +402,7 @@ class DataQueryCutoffForSessionTestCase(zf.ZiplineTestCase):
             EquityCalendarDomain(
                 CountryCode.UNITED_STATES,
                 'XNYS',
-                data_query_offset=-datetime.timedelta(hours=24 * 6 + 10),
+                data_query_offset=-np.timedelta64(24 * 6 + 10, 'h'),
             ),
             datetime.time(23, 30),
             expected_cutoff_date_offset=-7,

--- a/zipline/pipeline/domain.py
+++ b/zipline/pipeline/domain.py
@@ -156,7 +156,7 @@ class EquityCalendarDomain(Domain):
     data_query_offset : np.timedelta64
          The offset from market open when data should no longer be considered
          available for a session. For example, a ``data_query_offset`` of
-         ``-datetime.timedelta(minutes=45)`` means that the data must have
+         ``-np.timedelta64(45, 'm')`` means that the data must have
          been available at least 45 minutes prior to market open for it to
          appear in the pipeline input for the given session.
     """


### PR DESCRIPTION
The object timedelta arithmetic here fails in newer numpy. This should also be slightly more efficient for large date ranges.