### PR TITLE
MultiDimensionalDataSet

### DIFF
--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -1,0 +1,287 @@
+from collections import OrderedDict
+import itertools
+from textwrap import dedent
+
+from nose_parameterized import parameterized
+import numpy as np
+
+from zipline.pipeline.data import (
+    Column,
+    MultiDimensionalDataSet,
+    MultiDimensionalDataSetSlice,
+)
+from zipline.testing import ZiplineTestCase
+from zipline.testing.predicates import (
+    assert_equal,
+    assert_is,
+    assert_is_not,
+    assert_is_not_subclass,
+    assert_is_subclass,
+    assert_raises_str,
+)
+
+
+class TestMultiDimensionalDataSet(ZiplineTestCase):
+    def test_cache(self):
+        class MD1(MultiDimensionalDataSet):
+            extra_dims = [('dim_0', ['a', 'b', 'c'])]
+
+        class MD2(MultiDimensionalDataSet):
+            extra_dims = [('dim_0', ['a', 'b', 'c'])]
+
+        MD1Slice = MD1.slice(dim_0='a')
+        MD2Slice = MD2.slice(dim_0='a')
+
+        assert_equal(MD1Slice.extra_coords, MD2Slice.extra_coords)
+        assert_is_not(MD1Slice, MD2Slice)
+
+    def test_empty_extra_dims(self):
+        expected_msg = (
+            'MultiDimensionalDataSet must be defined with non-empty extra_dims'
+        )
+        with assert_raises_str(ValueError, expected_msg):
+            class MD(MultiDimensionalDataSet):
+                extra_dims = []
+
+    def spec(*cs):
+        return (cs,)
+
+    @parameterized.expand([
+        spec(
+            ('dim_0', range(10))
+        ),
+        spec(
+            ('dim_0', range(10)),
+            ('dim_1', range(10, 15)),
+        ),
+        spec(
+            ('dim_0', range(10)),
+            ('dim_1', range(10, 15)),
+            ('dim_2', range(5, 15)),
+        ),
+        spec(
+            ('dim_0', range(6)),
+            ('dim_1', {'a', 'b', 'c'}),
+            ('dim_2', range(5, 15)),
+            ('dim_3', {'b', 'c', 'e'}),
+        ),
+    ])
+    def test_valid_slice(self, dims_spec):
+        class MD(MultiDimensionalDataSet):
+            extra_dims = dims_spec
+
+            f8 = Column('f8')
+            i8 = Column('i8', missing_value=0)
+            ob = Column('O')
+            M8 = Column('M8[ns]')
+            boolean = Column('?')
+
+        expected_dims = OrderedDict([(k, frozenset(v)) for k, v in dims_spec])
+        assert_equal(MD.extra_dims, expected_dims)
+
+        for valid_combination in itertools.product(*expected_dims.values()):
+            Slice = MD.slice(*valid_combination)
+            alternate_constructions = [
+                # all positional
+                MD.slice(*valid_combination),
+                # all keyword
+                MD.slice(**dict(zip(expected_dims.keys(), valid_combination))),
+                # mix keyword/positional
+                MD.slice(
+                    *valid_combination[:len(valid_combination) // 2],
+                    **dict(
+                        list(zip(expected_dims.keys(), valid_combination))[
+                            len(valid_combination) // 2:
+                        ],
+                    )
+                ),
+            ]
+            for alt in alternate_constructions:
+                assert_is(Slice, alt, msg='Slices are not properly memoized')
+
+            expected_coords = OrderedDict(
+                zip(expected_dims, valid_combination),
+            )
+            assert_equal(Slice.extra_coords, expected_coords)
+
+            assert_is(Slice.parent_multidimensional_dataset, MD)
+
+            assert_is_subclass(Slice, MultiDimensionalDataSetSlice)
+
+            expected_columns = {
+                ('f8', np.dtype('f8'), Slice),
+                ('i8', np.dtype('i8'), Slice),
+                ('ob', np.dtype('O'), Slice),
+                ('M8', np.dtype('M8[ns]'), Slice),
+                ('boolean', np.dtype('?'), Slice),
+            }
+            actual_columns = {
+                (c.name, c.dtype, c.dataset) for c in Slice.columns
+            }
+            assert_equal(actual_columns, expected_columns)
+
+    del spec
+
+    def test_slice_unknown_dims(self):
+        class MD(MultiDimensionalDataSet):
+            extra_dims = [
+                ('dim_0', {'a', 'b', 'c'}),
+                ('dim_1', {'c', 'd', 'e'}),
+            ]
+
+        def expect_slice_fails(*args, **kwargs):
+            expected_msg = kwargs.pop('expected_msg')
+
+            with assert_raises_str(TypeError, expected_msg):
+                MD.slice(*args, **kwargs)
+
+        # insufficient positional
+        expect_slice_fails(
+            expected_msg=(
+                'no coordinate provided for the following dimensions:'
+                ' dim_0, dim_1'
+            ),
+        )
+        expect_slice_fails(
+            'a',
+            expected_msg=(
+                'no coordinate provided for the following dimension: dim_1'
+            ),
+        )
+
+        # too many positional
+        expect_slice_fails(
+            'a', 'b', 'c',
+            expected_msg='MD has 2 extra dimensions but 3 were given',
+        )
+
+        # mismatched keys
+        expect_slice_fails(
+            dim_2='??',
+            expected_msg='MD does not have the following dimension: dim_2',
+        )
+        expect_slice_fails(
+            dim_1='??', dim_2='??',
+            expected_msg='MD does not have the following dimension: dim_2',
+        )
+        expect_slice_fails(
+            dim_0='??', dim_1='??', dim_2='??',
+            expected_msg='MD does not have the following dimension: dim_2',
+        )
+
+        # the extra keyword dims should be sorted
+        expect_slice_fails(
+            dim_3='??', dim_2='??',
+            expected_msg=(
+                'MD does not have the following dimensions: dim_2, dim_3'
+            ),
+        )
+
+    def test_slice_unknown_dim_label(self):
+        class MD(MultiDimensionalDataSet):
+            extra_dims = [
+                ('dim_0', {'a', 'b', 'c'}),
+                ('dim_1', {'c', 'd', 'e'}),
+            ]
+
+        def expect_slice_fails(*args, **kwargs):
+            expected_msg = kwargs.pop('expected_msg')
+
+            with assert_raises_str(ValueError, expected_msg):
+                MD.slice(*args, **kwargs)
+
+        expect_slice_fails(
+            'not-in-0', 'c',
+            expected_msg="'not-in-0' is not a value along the dim_0 dimension",
+        )
+        expect_slice_fails(
+            dim_0='not-in-0', dim_1='c',
+            expected_msg="'not-in-0' is not a value along the dim_0 dimension",
+        )
+
+        expect_slice_fails(
+            'a', 'not-in-1',
+            expected_msg="'not-in-1' is not a value along the dim_1 dimension",
+        )
+        expect_slice_fails(
+            dim_0='a', dim_1='not-in-1',
+            expected_msg="'not-in-1' is not a value along the dim_1 dimension",
+        )
+
+    def test_inheritence(self):
+        class Parent(MultiDimensionalDataSet):
+            extra_dims = [
+                ('dim_0', {'a', 'b', 'c'}),
+                ('dim_1', {'d', 'e', 'f'}),
+            ]
+
+            column_0 = Column('f8')
+            column_1 = Column('?')
+
+        class Child(Parent):
+            column_2 = Column('O')
+            column_3 = Column('i8', -1)
+
+        assert_is_subclass(Child, Parent)
+        assert_equal(Child.extra_dims, Parent.extra_dims)
+
+        ParentSlice = Parent.slice(dim_0='a', dim_1='d')
+        ChildSlice = Child.slice(dim_0='a', dim_1='d')
+
+        assert_is_not_subclass(ChildSlice, ParentSlice)
+
+        expected_child_slice_columns = frozenset({
+            ChildSlice.column_0,
+            ChildSlice.column_1,
+            ChildSlice.column_2,
+            ChildSlice.column_3,
+        })
+        assert_equal(ChildSlice.columns, expected_child_slice_columns)
+
+    def test_column_access_without_slice(self):
+        class Parent(MultiDimensionalDataSet):
+            extra_dims = [
+                ('dim_0', {'a', 'b', 'c'}),
+                ('dim_1', {'d', 'e', 'f'}),
+            ]
+
+            column_0 = Column('f8')
+            column_1 = Column('?')
+
+        class Child(Parent):
+            column_2 = Column('O')
+            column_3 = Column('i8', -1)
+
+        def make_expected_msg(ds, attr):
+            return dedent(
+                """\
+                Attempted to access column from a MultiDimensionalDataSet.
+                You must first slice the dataset along the extra dimensions like:
+
+                    %s.slice(...).%s
+                """,  # noqa
+            ) % (ds, attr)
+
+        expected_msg = make_expected_msg('Parent', 'column_0')
+        with assert_raises_str(AttributeError, expected_msg):
+            Parent.column_0
+
+        expected_msg = make_expected_msg('Parent', 'column_1')
+        with assert_raises_str(AttributeError, expected_msg):
+            Parent.column_1
+
+        expected_msg = make_expected_msg('Child', 'column_0')
+        with assert_raises_str(AttributeError, expected_msg):
+            Child.column_0
+
+        expected_msg = make_expected_msg('Child', 'column_1')
+        with assert_raises_str(AttributeError, expected_msg):
+            Child.column_1
+
+        expected_msg = make_expected_msg('Child', 'column_2')
+        with assert_raises_str(AttributeError, expected_msg):
+            Child.column_2
+
+        expected_msg = make_expected_msg('Child', 'column_3')
+        with assert_raises_str(AttributeError, expected_msg):
+            Child.column_3

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -21,6 +21,31 @@ from zipline.testing.predicates import (
 
 
 class TestMultiDimensionalDataSet(ZiplineTestCase):
+    def test_repr(self):
+        class MD1(MultiDimensionalDataSet):
+            extra_dims = [('dim_0', [])]
+
+        expected_repr = (
+            "<MultiDimensionalDataSet: 'MD1', extra_dims=['dim_0']>"
+        )
+        assert_equal(repr(MD1), expected_repr)
+
+        class MD2(MultiDimensionalDataSet):
+            extra_dims = [('dim_0', []), ('dim_1', [])]
+
+        expected_repr = (
+            "<MultiDimensionalDataSet: 'MD2', extra_dims=['dim_0', 'dim_1']>"
+        )
+        assert_equal(repr(MD2), expected_repr)
+
+        class MD3(MultiDimensionalDataSet):
+            extra_dims = [('dim_1', []), ('dim_0', [])]
+
+        expected_repr = (
+            "<MultiDimensionalDataSet: 'MD3', extra_dims=['dim_1', 'dim_0']>"
+        )
+        assert_equal(repr(MD3), expected_repr)
+
     def test_cache(self):
         class MD1(MultiDimensionalDataSet):
             extra_dims = [('dim_0', ['a', 'b', 'c'])]
@@ -270,12 +295,14 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         def make_expected_msg(ds, attr):
             return dedent(
                 """\
-                Attempted to access column from a MultiDimensionalDataSet.
-                You must first slice the dataset along the extra dimensions like:
+                Attempted to access column {c} from multi-dimensional dataset {d}:
 
-                    %s.slice(...).%s
-                """,  # noqa
-            ) % (ds, attr)
+                To work with multi-dimensional datasets, you must first choose a
+                slice using the ``slice`` method:
+
+                    {d}.slice(...).{c}
+                """.format(c=attr, d=ds),  # noqa
+            )
 
         expected_msg = make_expected_msg('Parent', 'column_0')
         with assert_raises_str(AttributeError, expected_msg):

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -138,14 +138,15 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         # insufficient positional
         expect_slice_fails(
             expected_msg=(
-                'no coordinate provided for the following dimensions:'
+                'no coordinate provided to MD for the following dimensions:'
                 ' dim_0, dim_1'
             ),
         )
         expect_slice_fails(
             'a',
             expected_msg=(
-                'no coordinate provided for the following dimension: dim_1'
+                'no coordinate provided to MD for the following dimension:'
+                ' dim_1'
             ),
         )
 
@@ -158,22 +159,32 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         # mismatched keys
         expect_slice_fails(
             dim_2='??',
-            expected_msg='MD does not have the following dimension: dim_2',
+            expected_msg=(
+                'MD does not have the following dimension: dim_2\n'
+                'Valid dimensions are: dim_0, dim_1'
+            ),
         )
         expect_slice_fails(
             dim_1='??', dim_2='??',
-            expected_msg='MD does not have the following dimension: dim_2',
+            expected_msg=(
+                'MD does not have the following dimension: dim_2\n'
+                'Valid dimensions are: dim_0, dim_1'
+            ),
         )
         expect_slice_fails(
             dim_0='??', dim_1='??', dim_2='??',
-            expected_msg='MD does not have the following dimension: dim_2',
+            expected_msg=(
+                'MD does not have the following dimension: dim_2\n'
+                'Valid dimensions are: dim_0, dim_1'
+            ),
         )
 
         # the extra keyword dims should be sorted
         expect_slice_fails(
             dim_3='??', dim_2='??',
             expected_msg=(
-                'MD does not have the following dimensions: dim_2, dim_3'
+                'MD does not have the following dimensions: dim_2, dim_3\n'
+                'Valid dimensions are: dim_0, dim_1'
             ),
         )
 
@@ -192,20 +203,28 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
 
         expect_slice_fails(
             'not-in-0', 'c',
-            expected_msg="'not-in-0' is not a value along the dim_0 dimension",
+            expected_msg=(
+                "'not-in-0' is not a value along the dim_0 dimension of MD"
+            ),
         )
         expect_slice_fails(
             dim_0='not-in-0', dim_1='c',
-            expected_msg="'not-in-0' is not a value along the dim_0 dimension",
+            expected_msg=(
+                "'not-in-0' is not a value along the dim_0 dimension of MD"
+            ),
         )
 
         expect_slice_fails(
             'a', 'not-in-1',
-            expected_msg="'not-in-1' is not a value along the dim_1 dimension",
+            expected_msg=(
+                "'not-in-1' is not a value along the dim_1 dimension of MD"
+            ),
         )
         expect_slice_fails(
             dim_0='a', dim_1='not-in-1',
-            expected_msg="'not-in-1' is not a value along the dim_1 dimension",
+            expected_msg=(
+                "'not-in-1' is not a value along the dim_1 dimension of MD"
+            ),
         )
 
     def test_inheritence(self):

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -244,10 +244,7 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         assert_is_subclass(Child, Parent)
         assert_equal(Child.extra_dims, Parent.extra_dims)
 
-        ParentSlice = Parent.slice(dim_0='a', dim_1='d')
         ChildSlice = Child.slice(dim_0='a', dim_1='d')
-
-        assert_is_not_subclass(ChildSlice, ParentSlice)
 
         expected_child_slice_columns = frozenset({
             ChildSlice.column_0,

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -15,7 +15,6 @@ from zipline.testing.predicates import (
     assert_equal,
     assert_is,
     assert_is_not,
-    assert_is_not_subclass,
     assert_is_subclass,
     assert_raises_str,
 )

--- a/zipline/pipeline/data/__init__.py
+++ b/zipline/pipeline/data/__init__.py
@@ -1,10 +1,18 @@
 from .equity_pricing import EquityPricing, USEquityPricing
-from .dataset import DataSet, Column, BoundColumn
+from .dataset import (
+    BoundColumn,
+    Column,
+    DataSet,
+    MultiDimensionalDataSet,
+    MultiDimensionalDataSetSlice,
+)
 
 __all__ = [
     'BoundColumn',
     'Column',
     'DataSet',
     'EquityPricing',
+    'MultiDimensionalDataSet',
+    'MultiDimensionalDataSetSlice',
     'USEquityPricing',
 ]

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -559,6 +559,10 @@ class MultiDimensionalDataSetMeta(abc.ABCMeta):
         columns = {}
         for k, v in dict_.items():
             if isinstance(v, Column):
+                # capture all the columns off the MultiDimensionalDataSet class
+                # and replace them with a descriptor that will raise a helpful
+                # error message. The columns will get added to the BaseSlice
+                # for this type.
                 columns[k] = v
                 dict_[k] = _MultiDimensionalDataSetColumn(k)
 
@@ -650,7 +654,7 @@ class MultiDimensionalDataSet(_base):
            column_0 = Column('f8')
            column_1 = Column('?')
 
-    This represents a table with the following columns:
+    This dataset might represent a table with the following columns:
 
     ::
 

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -1,10 +1,14 @@
+import abc
+from collections import OrderedDict
 from functools import total_ordering
+from itertools import repeat
+from textwrap import dedent
+from weakref import WeakKeyDictionary
+
 from six import (
     iteritems,
     with_metaclass,
 )
-from weakref import WeakKeyDictionary
-
 from toolz import first
 
 from zipline.pipeline.classifiers import Classifier, Latest as LatestClassifier
@@ -497,3 +501,277 @@ class DataSet(with_metaclass(DataSetMeta, object)):
 # base DataSet class, and we also don't want to accidentally use a shared
 # version of this attribute if we fail to set this in a subclass somewhere.
 del DataSet._domain_specializations
+
+
+class AccessedOnMultiDimensionalDataSet(AttributeError):
+    """Exception thrown when a column is accessed on a MultiDimensionalDataSet
+    instead of on the result of a slice.
+
+    Parameters
+    ----------
+    dataset_name : str
+        The name of the MultiDimensionalDataSet.
+    column_names : str
+        The name of the column accessed.
+    """
+    def __init__(self, dataset_name, column_name):
+        self.dataset_name = dataset_name
+        self.column_name = column_name
+
+    def __str__(self):
+        return dedent(
+            """\
+            Attempted to access column from a MultiDimensionalDataSet.
+            You must first slice the dataset along the extra dimensions like:
+
+                %s.slice(...).%s
+            """
+        ) % (self.dataset_name, self.column_name)
+
+
+class _MultiDimensionalDataSetColumn(object):
+    """Descriptor used to raise a helpful error when a column is accessed on a
+    MultiDimensionalDataSet instead of on the result of a slice.
+
+    Parameters
+    ----------
+    column_names : str
+        The name of the column.
+    """
+    def __init__(self, column_name):
+        self.column_name = column_name
+
+    def __get__(self, instance, owner):
+        raise AccessedOnMultiDimensionalDataSet(
+            owner.__name__,
+            self.column_name,
+        )
+
+
+class MultiDimensionalDataSetMeta(abc.ABCMeta):
+    _base_marker = object()
+
+    def __new__(cls, name, bases, dict_):
+        columns = {}
+        for k, v in dict_.items():
+            if isinstance(v, Column):
+                columns[k] = v
+                dict_[k] = _MultiDimensionalDataSetColumn(k)
+
+        is_base_class = bases == (cls._base_marker,)
+        if is_base_class:
+            bases = (object,)
+        self = super(MultiDimensionalDataSetMeta, cls).__new__(
+            cls,
+            name,
+            bases,
+            dict_,
+        )
+
+        if not is_base_class:
+            self.extra_dims = extra_dims = OrderedDict([
+                (k, frozenset(v))
+                for k, v in OrderedDict(self.extra_dims).items()
+            ])
+            if not extra_dims:
+                raise ValueError(
+                    'MultiDimensionalDataSet must be defined with non-empty'
+                    ' extra_dims',
+                )
+
+            class BaseSlice(self._SliceType):
+                parent_multidimensional_dataset = self
+
+                ndim = self.slice_ndim
+                domain = self.domain
+
+                locals().update(columns)
+
+            BaseSlice.__name__ = '%sBaseSlice' % self.__name__
+            self._SliceType = BaseSlice
+
+        # each type gets a unique cache
+        self._slice_cache = {}
+        return self
+
+
+_base = with_metaclass(
+    MultiDimensionalDataSetMeta,
+    MultiDimensionalDataSetMeta._base_marker,
+)
+
+
+class MultiDimensionalDataSetSlice(DataSet):
+    """Marker type for slices of a
+    :class:`zipline.pipeline.data.dataset.MultiDimensionalDataSet` objects
+    """
+
+
+class MultiDimensionalDataSet(_base):
+    """
+    Base class for Pipeline multi-dimensional datasets.
+
+    A multi-dimensional dataset represents data where the unique identifier for
+    a particular value requires more than asset and date coordinates. A
+    multi-dimensional dataset may be thought of as a collection of
+    :class:`~zipline.pipeline.data.DataSet` objects with the same columns,
+    domain, and ndim.
+
+    ``MultiDimensionalDataSet`` objects have an extra field called the
+    ``extra_dims``. The ``extra_dims`` field describes the coords that are not
+    asset or date. The ``extra_dims`` are represented as an ordered dictionary
+    where the keys are the dimension name, and the values are a set of unique
+    values along that dimension.
+
+    To use a ``MultiDimensionalDataSet``, one must "fix" all of the extra
+    dimensions. The
+    :meth:`~zipline.pipeline.data.dataset.MultiDimensionalDataSet.slice` method
+    is used to create a dataset where all rows have the same values in the
+    extra dimensions. For example, given a ``MultiDimensionalDataSet``:
+
+    .. code-block:: python
+
+       class SomeDataSet(MultiDimensionalDataSet):
+           extra_dims = [
+               ('dimension_0', {'a', 'b', 'c'}),
+               ('dimension_1', {'d', 'e', 'f'}),
+           ]
+
+           column_0 = Column('f8')
+           column_1 = Column('?')
+
+    This represents a table with the following columns:
+
+    ::
+
+      sid :: int64
+      asof_date :: datetime64[ns]
+      timestamp :: datetime64[ns]
+      dimension_0 :: {'a', 'b', 'c'}
+      dimension_1 :: {'d', 'e', 'f'}
+      column_0 :: float64
+      column_1 :: bool
+
+    Here we see the implicit ``sid``, ``asof_date`` and ``timestamp`` columns
+    as well as the extra dimensions columns.
+
+    This ``MultiDimensionalDataSet`` can be converted to a regular ``DataSet``
+    with:
+
+    .. code-block:: python
+
+       DataSetSlice = SomeDataSet.slice(dimension_0='a', dimension_1='e')
+
+    This sliced dataset represents the rows from the higher dimensional dataset
+    where ``(dimension_0 == 'a') & (dimension_1 == 'e')``.
+    """
+    domain = GENERIC
+    slice_ndim = 2
+
+    _SliceType = MultiDimensionalDataSetSlice
+
+    @abc.abstractproperty
+    def extra_dims(self):
+        raise NotImplementedError(
+            'extra_dims must be specified as a sequence of tuples of dimension'
+            ' name and the set of values on the given dimension',
+        )
+
+    @classmethod
+    def _canonical_key(cls, args, kwargs):
+        extra_dims = cls.extra_dims
+        dimensions_set = set(extra_dims)
+        if not set(kwargs) <= dimensions_set:
+            extra = sorted(set(kwargs) - dimensions_set)
+            raise TypeError(
+                '%s does not have the following dimension%s: %s' % (
+                    cls.__name__,
+                    's' if len(extra) > 1 else '',
+                    ', '.join(extra),
+                ),
+            )
+
+        if len(args) > len(extra_dims):
+            raise TypeError(
+                '%s has %d extra dimension%s but %d %s given' % (
+                    cls.__name__,
+                    len(extra_dims),
+                    's' if len(extra_dims) > 1 else '',
+                    len(args),
+                    'were' if len(args) != 1 else 'was',
+                ),
+            )
+
+        missing = object()
+        coords = OrderedDict(zip(extra_dims, repeat(missing)))
+        to_add = dict(zip(extra_dims, args))
+        coords.update(to_add)
+        added = set(to_add)
+
+        for key, value in kwargs.items():
+            if key in added:
+                raise TypeError(
+                    '%s got multiple values for dimension %r' % (
+                        cls.__name__,
+                        coords,
+                    ),
+                )
+            coords[key] = value
+            added.add(key)
+
+        missing = {k for k, v in coords.items() if v is missing}
+        if missing:
+            missing = sorted(missing)
+            raise TypeError(
+                'no coordinate provided for the following dimension%s: %s' % (
+                    's' if len(missing) > 1 else '',
+                    ', '.join(missing),
+                ),
+            )
+
+        # validate that all of the provided values exist along their given
+        # dimensions
+        for key, value in coords.items():
+            if value not in cls.extra_dims[key]:
+                raise ValueError(
+                    '%r is not a value along the %s dimension' % (value, key),
+                )
+
+        return coords, tuple(coords.items())
+
+    @classmethod
+    def slice(cls, *args, **kwargs):
+        """Take a slice of a multi-dimensional dataset to produce a dataset
+        indexed by asset and date.
+
+        Parameters
+        ----------
+        *args
+        **kwargs
+            The coordinates to fix along each extra dimension.
+
+        Returns
+        -------
+        dataset : DataSet
+            A regular pipeline dataset indexed by asset and date.
+
+        Notes
+        -----
+        The extra dimensions coords used to produce the result are available
+        under the ``extra_coords`` attribute.
+        """
+        coords, hash_key = cls._canonical_key(args, kwargs)
+        try:
+            return cls._slice_cache[hash_key]
+        except KeyError:
+            pass
+
+        class Slice(cls._SliceType):
+            extra_coords = coords
+
+        Slice.__name__ = '%s.slice(%s)' % (
+            cls.__name__,
+            ', '.join('%s=%r' % item for item in coords.items()),
+        )
+        cls._slice_cache[hash_key] = Slice
+        return Slice

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -21,6 +21,7 @@ from zipline.pipeline.term import (
     LoadableTerm,
     validate_dtype,
 )
+from zipline.utils.formatting import s, plural
 from zipline.utils.input_validation import ensure_dtype, expect_types
 from zipline.utils.numpy_utils import NoDefaultMissingValue
 from zipline.utils.preprocess import preprocess
@@ -647,8 +648,8 @@ class MultiDimensionalDataSet(_base):
       sid :: int64
       asof_date :: datetime64[ns]
       timestamp :: datetime64[ns]
-      dimension_0 :: {'a', 'b', 'c'}
-      dimension_1 :: {'d', 'e', 'f'}
+      dimension_0 :: str
+      dimension_1 :: str
       column_0 :: float64
       column_1 :: bool
 
@@ -684,21 +685,23 @@ class MultiDimensionalDataSet(_base):
         if not set(kwargs) <= dimensions_set:
             extra = sorted(set(kwargs) - dimensions_set)
             raise TypeError(
-                '%s does not have the following dimension%s: %s' % (
+                '%s does not have the following %s: %s\n'
+                'Valid dimensions are: %s' % (
                     cls.__name__,
-                    's' if len(extra) > 1 else '',
+                    s('dimension', extra),
                     ', '.join(extra),
+                    ', '.join(extra_dims),
                 ),
             )
 
         if len(args) > len(extra_dims):
             raise TypeError(
-                '%s has %d extra dimension%s but %d %s given' % (
+                '%s has %d extra %s but %d %s given' % (
                     cls.__name__,
                     len(extra_dims),
-                    's' if len(extra_dims) > 1 else '',
+                    s('dimension', extra_dims),
                     len(args),
-                    'were' if len(args) != 1 else 'was',
+                    plural('was', 'were', args),
                 ),
             )
 
@@ -723,8 +726,9 @@ class MultiDimensionalDataSet(_base):
         if missing:
             missing = sorted(missing)
             raise TypeError(
-                'no coordinate provided for the following dimension%s: %s' % (
-                    's' if len(missing) > 1 else '',
+                'no coordinate provided to %s for the following %s: %s' % (
+                    cls.__name__,
+                    s('dimension', missing),
                     ', '.join(missing),
                 ),
             )
@@ -734,7 +738,11 @@ class MultiDimensionalDataSet(_base):
         for key, value in coords.items():
             if value not in cls.extra_dims[key]:
                 raise ValueError(
-                    '%r is not a value along the %s dimension' % (value, key),
+                    '%r is not a value along the %s dimension of %s' % (
+                        value,
+                        key,
+                        cls.__name__,
+                    ),
                 )
 
         return coords, tuple(coords.items())

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -520,14 +520,17 @@ class AccessedOnMultiDimensionalDataSet(AttributeError):
         self.column_name = column_name
 
     def __str__(self):
+        # NOTE: when ``aggregate`` is added, remember to update this message
         return dedent(
             """\
-            Attempted to access column from a MultiDimensionalDataSet.
-            You must first slice the dataset along the extra dimensions like:
+            Attempted to access column {c} from multi-dimensional dataset {d}:
 
-                %s.slice(...).%s
-            """
-        ) % (self.dataset_name, self.column_name)
+            To work with multi-dimensional datasets, you must first choose a
+            slice using the ``slice`` method:
+
+                {d}.slice(...).{c}
+            """.format(c=self.column_name, d=self.dataset_name)
+        )
 
 
 class _MultiDimensionalDataSetColumn(object):
@@ -594,6 +597,12 @@ class MultiDimensionalDataSetMeta(abc.ABCMeta):
         # each type gets a unique cache
         self._slice_cache = {}
         return self
+
+    def __repr__(self):
+        return '<MultiDimensionalDataSet: %r, extra_dims=%r>' % (
+            self.__name__,
+            list(self.extra_dims),
+        )
 
 
 _base = with_metaclass(
@@ -671,12 +680,12 @@ class MultiDimensionalDataSet(_base):
 
     _SliceType = MultiDimensionalDataSetSlice
 
-    @abc.abstractproperty
-    def extra_dims(self):
-        raise NotImplementedError(
-            'extra_dims must be specified as a sequence of tuples of dimension'
-            ' name and the set of values on the given dimension',
-        )
+    @type.__call__
+    class extra_dims(object):
+        __isabstractmethod__ = True
+
+        def __get__(self, instance, owner):
+            return []
 
     @classmethod
     def _canonical_key(cls, args, kwargs):

--- a/zipline/pipeline/domain.py
+++ b/zipline/pipeline/domain.py
@@ -24,6 +24,7 @@ import pytz
 from trading_calendars import get_calendar
 
 from zipline.country import CountryCode
+from zipline.utils.formatting import bulleted_list
 from zipline.utils.input_validation import expect_types, optional
 from zipline.utils.memoize import lazyval
 from zipline.utils.pandas_utils import days_at_time
@@ -312,12 +313,6 @@ def infer_domain(terms):
         raise AmbiguousDomain(sorted(domains, key=repr))
 
 
-def bulleted_list(items):
-    """Format a bulleted list of values.
-    """
-    return "\n".join(map("  - {}".format, items))
-
-
 # This would be better if we provided more context for which domains came from
 # which terms.
 class AmbiguousDomain(Exception):
@@ -334,7 +329,9 @@ class AmbiguousDomain(Exception):
         self.domains = domains
 
     def __str__(self):
-        return self._TEMPLATE.format(domains=bulleted_list(self.domains))
+        return self._TEMPLATE.format(
+            domains=bulleted_list(self.domains, indent=2),
+        )
 
 
 class EquitySessionDomain(Domain):

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -258,6 +258,27 @@ def assert_is_subclass(subcls, cls, msg=''):
     )
 
 
+def assert_is_not_subclass(not_subcls, cls, msg=''):
+    """Assert that ``not_subcls`` is not a subclass of ``cls``.
+
+    Parameters
+    ----------
+    not_subcls : type
+        The type to check.
+    cls : type
+        The type to check ``not_subcls`` against.
+    msg : str, optional
+        An extra assertion message to print if this fails.
+    """
+    assert not issubclass(not_subcls, cls), (
+        '%s is a subclass of %s\n%s' % (
+            _safe_cls_name(not_subcls),
+            _safe_cls_name(cls),
+            msg,
+        )
+    )
+
+
 def assert_regex(result, expected, msg=''):
     """Assert that ``expected`` matches the result.
 

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -51,6 +51,7 @@ from zipline.lib.adjustment import Adjustment
 from zipline.lib.labelarray import LabelArray
 from zipline.testing.core import ensure_doctest
 from zipline.utils.compat import getargspec, mappingproxy
+from zipline.utils.formatting import s
 from zipline.utils.functional import dzip_exact, instance
 from zipline.utils.math_utils import tolerant_equals
 
@@ -173,25 +174,6 @@ def filter_kwargs(f, kwargs):
     Taken from odo.utils
     """
     return keyfilter(op.contains(keywords(f)), kwargs)
-
-
-def _s(word, seq, suffix='s'):
-    """Adds a suffix to ``word`` if some sequence has anything other than
-    exactly one element.
-
-    word : str
-        The string to add the suffix to.
-    seq : sequence
-        The sequence to check the length of.
-    suffix : str, optional.
-        The suffix to add to ``word``
-
-    Returns
-    -------
-    maybe_plural : str
-        ``word`` with ``suffix`` added if ``len(seq) != 1``.
-    """
-    return word + (suffix if len(seq) != 1 else '')
 
 
 def _fmt_path(path):
@@ -432,17 +414,17 @@ def _check_sets(result, expected, msg, path, type_):
     if result != expected:
         if result > expected:
             diff = result - expected
-            msg = 'extra %s in result: %r' % (_s(type_, diff), diff)
+            msg = 'extra %s in result: %r' % (s(type_, diff), diff)
         elif result < expected:
             diff = expected - result
-            msg = 'result is missing %s: %r' % (_s(type_, diff), diff)
+            msg = 'result is missing %s: %r' % (s(type_, diff), diff)
         else:
             in_result = result - expected
             in_expected = expected - result
             msg = '%s only in result: %s\n%s only in expected: %s' % (
-                _s(type_, in_result),
+                s(type_, in_result),
                 in_result,
-                _s(type_, in_expected),
+                s(type_, in_expected),
                 in_expected,
             )
         raise AssertionError(

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from contextlib import contextmanager
 import datetime
 from functools import partial
@@ -488,6 +489,16 @@ def asssert_mappingproxy_equal(result, expected, path=(), msg='', **kwargs):
 
     if failures:
         raise AssertionError('\n'.join(failures))
+
+
+@assert_equal.register(OrderedDict, OrderedDict)
+def assert_ordereddict_equal(result, expected, path=(), **kwargs):
+    assert_sequence_equal(
+        result.items(),
+        expected.items(),
+        path=path + ('.items()',),
+        **kwargs
+    )
 
 
 @assert_equal.register(list, list)

--- a/zipline/utils/formatting.py
+++ b/zipline/utils/formatting.py
@@ -43,3 +43,24 @@ def plural(singular, plural, seq):
         return singular
 
     return plural
+
+
+def bulleted_list(items, indent=0, bullet_type='-'):
+    """Format a bulleted list of values.
+
+    Parameters
+    ----------
+    items : sequence
+        The items to make a list.
+    indent : int, optional
+        The number of spaces to add before each bullet.
+    bullet_type : str, optional
+        The bullet type to use.
+
+    Returns
+    -------
+    formatted_list : str
+        The formatted list as a single string.
+    """
+    format_string = ' ' * indent + bullet_type + ' {}'
+    return "\n".join(map(format_string.format, items))

--- a/zipline/utils/formatting.py
+++ b/zipline/utils/formatting.py
@@ -1,0 +1,45 @@
+def s(word, seq, suffix='s'):
+    """Adds a suffix to ``word`` if some sequence has anything other than
+    exactly one element.
+
+    Parameters
+    ----------
+    word : str
+        The string to add the suffix to.
+    seq : sequence
+        The sequence to check the length of.
+    suffix : str, optional.
+        The suffix to add to ``word``
+
+    Returns
+    -------
+    maybe_plural : str
+        ``word`` with ``suffix`` added if ``len(seq) != 1``.
+    """
+    if len(seq) == 1:
+        return word
+
+    return word + suffix
+
+
+def plural(singular, plural, seq):
+    """Selects a singular or plural word based on the length of a sequence.
+
+    Parameters
+    ----------
+    singlular : str
+        The string to use when ``len(seq) == 1``.
+    plural : str
+        The string to use when ``len(seq) != 1``.
+    seq : sequence
+        The sequence to check the length of.
+
+    Returns
+    -------
+    maybe_plural : str
+        Either ``singlular`` or ``plural``.
+    """
+    if len(seq) == 1:
+        return singular
+
+    return plural


### PR DESCRIPTION
Add the mechanism for defining a new `MultiDimensionalDataSet`. This is just shorthand for creating a collection of regular `DataSet`s that share the same columns.

I was going to add a test that executes a pipeline using this, but to do that I was writing a new one-off loader and dispatcher. At the end I realized that the test wasn't actually testing anything about `MultiDimensionalDataset`s, it was just testing the scaffolding I set up.