### PR TITLE
TST: fix parameter_space error handling

### DIFF
--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -1194,7 +1194,7 @@ def parameter_space(__fail_fast=_FAIL_FAST_DEFAULT, **params):
         if unspecified:
             raise AssertionError(
                 "Function arguments %s were not "
-                "supplied to parameter_space()." % extra
+                "supplied to parameter_space()." % unspecified
             )
 
         def make_param_sets():


### PR DESCRIPTION
Fix error message when the function has parameters that are not provided by
parameter_space. I saw this when I removed a parameter from the decorator but
forgot to update the function signature.