### PR TITLE
Add sphinx-sitemap extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
+    'sphinx_sitemap',
 ]
 
 
@@ -63,6 +64,8 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 # The name of the Pygments (syntax highlighting) style to use.
 highlight_language = 'python'
+
+html_baseurl = 'https://www.zipline.io/'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/etc/requirements_docs.txt
+++ b/etc/requirements_docs.txt
@@ -1,3 +1,4 @@
 Sphinx>=1.3.2
 numpydoc>=0.5.0
 sphinx-autobuild==0.6.0
+sphinx-sitemap==1.0.1


### PR DESCRIPTION
This adds a sphinx extension that creates a sitemap.xml at https://www.zipline.io/sitemap.xml to improve SEO etc and help people find the information they need.