### PR TITLE
BUG: group exprdata by the expressions, not identity

### DIFF
--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -2415,6 +2415,38 @@ class MiscTestCase(ZiplineTestCase):
             " checkpoints='checkpoints', odo_kwargs={'a': 'b'})",
         )
 
+    def test_exprdata_eq(self):
+        dshape = 'var * {sid: int64, asof_date: datetime, value: float64}'
+        base_expr = bz.symbol('base', dshape)
+        checkpoints_expr = bz.symbol('checkpoints', dshape)
+
+        odo_kwargs = {'a': 1, 'b': 2}
+
+        actual = ExprData(
+            expr=base_expr,
+            deltas=None,
+            checkpoints=checkpoints_expr,
+            odo_kwargs=odo_kwargs,
+        )
+        same = ExprData(
+            expr=base_expr,
+            deltas=None,
+            checkpoints=checkpoints_expr,
+            odo_kwargs=odo_kwargs,
+        )
+        self.assertEqual(actual, same)
+
+        different_obs = [
+            actual._replace(expr=bz.symbol('not base', dshape)),
+            actual._replace(expr=bz.symbol('not deltas', dshape)),
+            actual._replace(checkpoints=bz.symbol('not checkpoints', dshape)),
+            actual._replace(checkpoints=None),
+            actual._replace(odo_kwargs={k: ~v for k, v in odo_kwargs.items()}),
+        ]
+
+        for different in different_obs:
+            self.assertNotEqual(actual, different)
+
     def test_blaze_loader_lookup_failure(self):
         class D(DataSet):
             c = Column(dtype='float64')


### PR DESCRIPTION
When comparing exprdata, check `isidentical` on the constituent expressions instead of identity on the exprdata tuple itself. There are cases where we don't register the whole underlying table in a single call to `register_dataset` because it is difficult to group the columns this way. The equality of the exprdata object determines how we batch queries to the underlying, so we want to group them up as much as possible or we will be querying for the same `sid`, `asof_date`, and `timestamp` columns and re-aligning them for multiple columns.