### PR TITLE
DOC: Update documentation

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -60,9 +60,7 @@ On `Arch Linux`_, you can acquire the additional dependencies via ``pacman``:
 
    $ pacman -S lapack gcc gcc-fortran pkg-config
 
-There are also AUR packages available for installing `Python 3.4
-<https://aur.archlinux.org/packages/python34/>`_ (Arch's default python is now
-3.5, but Zipline only currently supports 3.4), and `ta-lib
+There are also AUR packages available for installing `ta-lib
 <https://aur.archlinux.org/packages/ta-lib/>`_, an optional Zipline dependency.
 Python 2 is also installable via:
 


### PR DESCRIPTION
The install page was carrying old information about supported Python
version.

Page to be updated: [http://www.zipline.io/install.html#gnu-linux](http://www.zipline.io/install.html#gnu-linux)
I was based on the information provided at: [http://www.zipline.io/releases.html#release-1-2-0](http://www.zipline.io/releases.html#release-1-2-0) [https://www.zipline.io/releases.html#release-1-1-1](https://www.zipline.io/releases.html#release-1-1-1)
The Dockerfile also bases my assumption of outdated documentation: [https://github.com/quantopian/zipline/blob/master/Dockerfile](https://github.com/quantopian/zipline/blob/master/Dockerfile).