### PR TITLE
BUG: Ensure correct dtypes when unpacking empty dataframes.

### DIFF
--- a/zipline/__init__.py
+++ b/zipline/__init__.py
@@ -97,10 +97,9 @@ def setup(self,
           new_pandas=new_pandas):
     """Lives in zipline.__init__ for doctests."""
 
-    legacy_version = '1.13'
-    if numpy_version > StrictVersion(legacy_version):
+    if numpy_version >= StrictVersion('1.14'):
         self.old_opts = np.get_printoptions()
-        np.set_printoptions(legacy=legacy_version)
+        np.set_printoptions(legacy='1.13')
     else:
         self.old_opts = None
 

--- a/zipline/utils/functional.py
+++ b/zipline/utils/functional.py
@@ -1,4 +1,5 @@
 from functools import reduce
+from operator import itemgetter
 from pprint import pformat
 
 from six import viewkeys, iteritems
@@ -406,3 +407,14 @@ def invert(d):
         except KeyError:
             out[v] = {k}
     return out
+
+
+def keysorted(d):
+    """Get the items from a dict, sorted by key.
+
+    Example
+    -------
+    >>> keysorted({'c': 1, 'b': 2, 'a': 3})
+    [('a', 3), ('b', 2), ('c', 1)]
+    """
+    return sorted(iteritems(d), key=itemgetter(0))


### PR DESCRIPTION
Fixes a bug where columns of adjustment db dataframes would come back as object
dtype when the table is empty.