### PR TITLE
ENH: Update assert_equal(ndarray) to handle datetime arrays.

### DIFF
--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -498,7 +498,7 @@ def changed_locations(a, include_first):
 
 def compare_datetime_arrays(x, y):
     """
-    Compare datetime64 ndarrays in a NaT-aware fashion.
+    Compare datetime64 ndarrays, treating NaT values as equal.
     """
 
     return array_equal(x.view('int64'), y.view('int64'))

--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -11,6 +11,7 @@ from warnings import (
 
 import numpy as np
 from numpy import (
+    array_equal,
     broadcast,
     busday_count,
     datetime64,
@@ -493,3 +494,11 @@ def changed_locations(a, include_first):
         return indices
 
     return hstack([[0], indices])
+
+
+def compare_datetime_arrays(x, y):
+    """
+    Compare datetime64 ndarrays in a NaT-aware fashion.
+    """
+
+    return array_equal(x.view('int64'), y.view('int64'))


### PR DESCRIPTION
`numpy.testing.assert_array_equal` (`numpy==1.11.3`) doesn't handle datetime arrays correctly if either of the inputs contain `NaT`s.

To get around that, we can cast the arrays to ints using `view('int64')` and compare them. This is possible because 'NaT' maps to a reserved int.