### PR TITLE
Get column and finalize names

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [nosetests]
 verbosity=2
-detailed-errors=1
 with-ignore-docstrings=1
 with-timer=1
 timer-top-n=15

--- a/tests/pipeline/test_dataset.py
+++ b/tests/pipeline/test_dataset.py
@@ -1,0 +1,75 @@
+"""Tests for the zipline.pipeline.data.DataSet and related functionality.
+"""
+from textwrap import dedent
+
+from zipline.pipeline.data.dataset import Column, DataSet
+from zipline.testing import chrange, ZiplineTestCase
+from zipline.testing.predicates import assert_messages_equal
+
+
+class SomeDataSet(DataSet):
+    a = Column(dtype=float)
+    b = Column(dtype=object)
+    c = Column(dtype=int, missing_value=-1)
+
+
+# A DataSet with lots of columns.
+class LargeDataSet(DataSet):
+    locals().update({
+        name: Column(dtype=float)
+        for name in chrange('a', 'z')
+    })
+
+
+class GetColumnTestCase(ZiplineTestCase):
+
+    def test_get_column_success(self):
+        a = SomeDataSet.a
+        b = SomeDataSet.b
+        c = SomeDataSet.c
+
+        # Run multiple times to validate caching of descriptor return values.
+        for _ in range(3):
+            self.assertIs(SomeDataSet.get_column('a'), a)
+            self.assertIs(SomeDataSet.get_column('b'), b)
+            self.assertIs(SomeDataSet.get_column('c'), c)
+
+    def test_get_column_failure(self):
+        with self.assertRaises(AttributeError) as e:
+            SomeDataSet.get_column('arglebargle')
+
+        result = str(e.exception)
+        expected = dedent(
+            """\
+            SomeDataSet has no column 'arglebargle':
+
+            Possible choices are:
+              - a
+              - b
+              - c"""
+        )
+        assert_messages_equal(result, expected)
+
+    def test_get_column_failure_truncate_error_message(self):
+        with self.assertRaises(AttributeError) as e:
+            LargeDataSet.get_column('arglebargle')
+
+        result = str(e.exception)
+        expected = dedent(
+            """\
+            LargeDataSet has no column 'arglebargle':
+
+            Possible choices are:
+              - a
+              - b
+              - c
+              - d
+              - e
+              - f
+              - g
+              - h
+              - i
+              - ...
+              - z"""
+        )
+        assert_messages_equal(result, expected)

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -7,8 +7,8 @@ import numpy as np
 
 from zipline.pipeline.data import (
     Column,
-    MultiDimensionalDataSet,
-    MultiDimensionalDataSetSlice,
+    DataSetFamily,
+    DataSetFamilySlice,
 )
 from zipline.testing import ZiplineTestCase
 from zipline.testing.predicates import (
@@ -20,37 +20,37 @@ from zipline.testing.predicates import (
 )
 
 
-class TestMultiDimensionalDataSet(ZiplineTestCase):
+class TestDataSetFamily(ZiplineTestCase):
     def test_repr(self):
-        class MD1(MultiDimensionalDataSet):
+        class MD1(DataSetFamily):
             extra_dims = [('dim_0', [])]
 
         expected_repr = (
-            "<MultiDimensionalDataSet: 'MD1', extra_dims=['dim_0']>"
+            "<DataSetFamily: 'MD1', extra_dims=['dim_0']>"
         )
         assert_equal(repr(MD1), expected_repr)
 
-        class MD2(MultiDimensionalDataSet):
+        class MD2(DataSetFamily):
             extra_dims = [('dim_0', []), ('dim_1', [])]
 
         expected_repr = (
-            "<MultiDimensionalDataSet: 'MD2', extra_dims=['dim_0', 'dim_1']>"
+            "<DataSetFamily: 'MD2', extra_dims=['dim_0', 'dim_1']>"
         )
         assert_equal(repr(MD2), expected_repr)
 
-        class MD3(MultiDimensionalDataSet):
+        class MD3(DataSetFamily):
             extra_dims = [('dim_1', []), ('dim_0', [])]
 
         expected_repr = (
-            "<MultiDimensionalDataSet: 'MD3', extra_dims=['dim_1', 'dim_0']>"
+            "<DataSetFamily: 'MD3', extra_dims=['dim_1', 'dim_0']>"
         )
         assert_equal(repr(MD3), expected_repr)
 
     def test_cache(self):
-        class MD1(MultiDimensionalDataSet):
+        class MD1(DataSetFamily):
             extra_dims = [('dim_0', ['a', 'b', 'c'])]
 
-        class MD2(MultiDimensionalDataSet):
+        class MD2(DataSetFamily):
             extra_dims = [('dim_0', ['a', 'b', 'c'])]
 
         MD1Slice = MD1.slice(dim_0='a')
@@ -61,10 +61,10 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
 
     def test_empty_extra_dims(self):
         expected_msg = (
-            'MultiDimensionalDataSet must be defined with non-empty extra_dims'
+            'DataSetFamily must be defined with non-empty extra_dims'
         )
         with assert_raises_str(ValueError, expected_msg):
-            class MD(MultiDimensionalDataSet):
+            class MD(DataSetFamily):
                 extra_dims = []
 
     def spec(*cs):
@@ -91,7 +91,7 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         ),
     ])
     def test_valid_slice(self, dims_spec):
-        class MD(MultiDimensionalDataSet):
+        class MD(DataSetFamily):
             extra_dims = dims_spec
 
             f8 = Column('f8')
@@ -128,9 +128,9 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
             )
             assert_equal(Slice.extra_coords, expected_coords)
 
-            assert_is(Slice.parent_multidimensional_dataset, MD)
+            assert_is(Slice.dataset_family, MD)
 
-            assert_is_subclass(Slice, MultiDimensionalDataSetSlice)
+            assert_is_subclass(Slice, DataSetFamilySlice)
 
             expected_columns = {
                 ('f8', np.dtype('f8'), Slice),
@@ -147,7 +147,7 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
     del spec
 
     def test_slice_unknown_dims(self):
-        class MD(MultiDimensionalDataSet):
+        class MD(DataSetFamily):
             extra_dims = [
                 ('dim_0', {'a', 'b', 'c'}),
                 ('dim_1', {'c', 'd', 'e'}),
@@ -213,7 +213,7 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         )
 
     def test_slice_unknown_dim_label(self):
-        class MD(MultiDimensionalDataSet):
+        class MD(DataSetFamily):
             extra_dims = [
                 ('dim_0', {'a', 'b', 'c'}),
                 ('dim_1', {'c', 'd', 'e'}),
@@ -252,7 +252,7 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         )
 
     def test_inheritence(self):
-        class Parent(MultiDimensionalDataSet):
+        class Parent(DataSetFamily):
             extra_dims = [
                 ('dim_0', {'a', 'b', 'c'}),
                 ('dim_1', {'d', 'e', 'f'}),
@@ -279,7 +279,7 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         assert_equal(ChildSlice.columns, expected_child_slice_columns)
 
     def test_column_access_without_slice(self):
-        class Parent(MultiDimensionalDataSet):
+        class Parent(DataSetFamily):
             extra_dims = [
                 ('dim_0', {'a', 'b', 'c'}),
                 ('dim_1', {'d', 'e', 'f'}),
@@ -295,13 +295,14 @@ class TestMultiDimensionalDataSet(ZiplineTestCase):
         def make_expected_msg(ds, attr):
             return dedent(
                 """\
-                Attempted to access column {c} from multi-dimensional dataset {d}:
+                Attempted to access column {c} from DataSetFamily {d}:
 
-                To work with multi-dimensional datasets, you must first choose a
+                To work with dataset families, you must first select a
                 slice using the ``slice`` method:
 
                     {d}.slice(...).{c}
-                """.format(c=attr, d=ds),  # noqa
+                """
+                .format(c=attr, d=ds),  # noqa
             )
 
         expected_msg = make_expected_msg('Parent', 'column_0')

--- a/zipline/pipeline/data/__init__.py
+++ b/zipline/pipeline/data/__init__.py
@@ -3,8 +3,8 @@ from .dataset import (
     BoundColumn,
     Column,
     DataSet,
-    MultiDimensionalDataSet,
-    MultiDimensionalDataSetSlice,
+    DataSetFamily,
+    DataSetFamilySlice,
 )
 
 __all__ = [
@@ -12,7 +12,7 @@ __all__ = [
     'Column',
     'DataSet',
     'EquityPricing',
-    'MultiDimensionalDataSet',
-    'MultiDimensionalDataSetSlice',
+    'DataSetFamily',
+    'DataSetFamilySlice',
     'USEquityPricing',
 ]

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -25,6 +25,7 @@ from zipline.utils.formatting import s, plural
 from zipline.utils.input_validation import ensure_dtype, expect_types
 from zipline.utils.numpy_utils import NoDefaultMissingValue
 from zipline.utils.preprocess import preprocess
+from zipline.utils.string_formatting import bulleted_list
 
 
 IsSpecialization = sentinel('IsSpecialization')
@@ -496,6 +497,47 @@ class DataSet(with_metaclass(DataSetMeta, object)):
     """
     domain = GENERIC
     ndim = 2
+
+    @classmethod
+    def get_column(cls, name):
+        """Look up a column by name.
+
+        Parameters
+        ----------
+        name : str
+            Name of the column to look up.
+
+        Returns
+        -------
+        column : zipline.pipeline.data.BoundColumn
+            Column with the given name.
+
+        Raises
+        ------
+        AttributeError
+            If no column with the given name exists.
+        """
+        clsdict = vars(cls)
+        try:
+            maybe_column = clsdict[name]
+            if not isinstance(maybe_column, _BoundColumnDescr):
+                raise KeyError(name)
+        except KeyError:
+            raise AttributeError(
+                "{dset} has no column {colname!r}:\n\n"
+                "Possible choices are:\n"
+                "{choices}".format(
+                    dset=cls.qualname,
+                    colname=name,
+                    choices=bulleted_list(
+                        sorted(cls._column_names),
+                        max_count=10,
+                    ),
+                )
+            )
+
+        # Resolve column descriptor into a BoundColumn.
+        return maybe_column.__get__(None, cls)
 
 
 # This attribute is set by DataSetMeta to mark that a class is the root of a

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -286,7 +286,7 @@ def _assert_raises_helper(do_check, exc_type, msg):
     except exc_type as e:
         do_check(e)
     else:
-        raise AssertionError('%s%s was not raised' % (_fmt_msg(msg), e))
+        raise AssertionError('%s%s was not raised' % (_fmt_msg(msg), exc_type))
 
 
 def assert_raises_regex(exc, pattern, msg=''):

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -280,6 +280,15 @@ def assert_regex(result, expected, msg=''):
 
 
 @contextmanager
+def _assert_raises_helper(do_check, exc_type, msg):
+    try:
+        yield
+    except exc_type as e:
+        do_check(e)
+    else:
+        raise AssertionError('%s%s was not raised' % (_fmt_msg(msg), e))
+
+
 def assert_raises_regex(exc, pattern, msg=''):
     """Assert that some exception is raised in a context and that the message
     matches some pattern.
@@ -293,14 +302,16 @@ def assert_raises_regex(exc, pattern, msg=''):
     msg : str, optional
         An extra assertion message to print if this fails.
     """
-    try:
-        yield
-    except exc as e:
+    def check_exception(e):
         assert re.search(pattern, str(e)), (
             '%s%r not found in %r' % (_fmt_msg(msg), pattern, str(e))
         )
-    else:
-        raise AssertionError('%s%s was not raised' % (_fmt_msg(msg), exc))
+
+    return _assert_raises_helper(
+        do_check=check_exception,
+        exc_type=exc,
+        msg=msg,
+    )
 
 
 def assert_raises_str(exc, expected_str, msg=''):
@@ -316,7 +327,15 @@ def assert_raises_str(exc, expected_str, msg=''):
     msg : str, optional
         An extra assertion message to print if this fails.
     """
-    return assert_raises_regex(exc, '^%s$' % re.escape(expected_str), msg=msg)
+    def check_exception(e):
+        result = str(e)
+        assert_messages_equal(result, expected_str, msg=msg)
+
+    return _assert_raises_helper(
+        check_exception,
+        exc_type=exc,
+        msg=msg,
+    )
 
 
 def make_assert_equal_assertion_error(assertion_message, path, msg):
@@ -778,7 +797,7 @@ def assert_isidentical(result, expected, msg=''):
     )
 
 
-def assert_messages_equal(result, expected):
+def assert_messages_equal(result, expected, msg=''):
     """Assertion helper for comparing very long strings (e.g. error messages).
     """
     # The arg here is "keepends" which keeps trailing newlines (which
@@ -791,9 +810,9 @@ def assert_messages_equal(result, expected):
         if ll != rl:
             col = index_of_first_difference(ll, rl)
             raise AssertionError(
-                "Messages differ on line {line}, col {col}:"
+                "{msg}Messages differ on line {line}, col {col}:"
                 "\n{ll!r}\n!=\n{rl!r}".format(
-                    line=line, col=col, ll=ll, rl=rl
+                    msg=_fmt_msg(msg), line=line, col=col, ll=ll, rl=rl
                 )
             )
 

--- a/zipline/utils/string_formatting.py
+++ b/zipline/utils/string_formatting.py
@@ -1,0 +1,11 @@
+def bulleted_list(items, max_count=None, indent=2):
+    """Format a bulleted list of values.
+    """
+    if max_count is not None and len(items) > max_count:
+        item_list = list(items)
+        items = item_list[:max_count - 1]
+        items.append('...')
+        items.append(item_list[-1])
+
+    line_template = (" " * indent) + "- {}"
+    return "\n".join(map(line_template.format, items))


### PR DESCRIPTION
- Adds `DataSet.get_column` for looking up columns by name.
- Renames `MultiDimensionalDataSet` to `DataSetFamily`, and updates a bunch of docs and variable names to match. I think the docstring for DataSetFamily still needs work, but I want to ship the rename first before spending a long time wordsmithing.