### PR TITLE
ENH: Enable abstract DataSetFamily subclasses

### DIFF
--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -251,7 +251,7 @@ class TestDataSetFamily(ZiplineTestCase):
             ),
         )
 
-    def test_inheritence(self):
+    def test_inheritance(self):
         class Parent(DataSetFamily):
             extra_dims = [
                 ('dim_0', {'a', 'b', 'c'}),

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -62,7 +62,7 @@ class TestDataSetFamily(ZiplineTestCase):
     def test_empty_extra_dims(self):
         msg = (
             "DataSetFamily must be defined with non-empty extra_dims,"
-            " or with `__abstract__ = True`"
+            " or with `_abstract = True`"
         )
         with assert_raises_str(ValueError, msg):
             class NoExtraDims(DataSetFamily):
@@ -73,7 +73,7 @@ class TestDataSetFamily(ZiplineTestCase):
                 extra_dims = []
 
         class AbstractParent(DataSetFamily):
-            __abstract__ = True
+            _abstract = True
 
         with assert_raises_str(ValueError, msg):
             class NoExtraDimsChild(AbstractParent):
@@ -84,7 +84,7 @@ class TestDataSetFamily(ZiplineTestCase):
                 extra_dims = []
 
         class AbstractChild(AbstractParent):
-            __abstract__ = True
+            _abstract = True
 
         class Child(AbstractParent):
             extra_dims = [

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -61,25 +61,25 @@ class TestDataSetFamily(ZiplineTestCase):
 
     def test_empty_extra_dims(self):
         msg = (
-            "^DataSetFamily must be defined with non-empty extra_dims,"
-            " or with `__abstract__ = True`$"
+            "DataSetFamily must be defined with non-empty extra_dims,"
+            " or with `__abstract__ = True`"
         )
-        with self.assertRaisesRegexp(ValueError, msg):
+        with assert_raises_str(ValueError, msg):
             class NoExtraDims(DataSetFamily):
                 pass
 
-        with self.assertRaisesRegexp(ValueError, msg):
+        with assert_raises_str(ValueError, msg):
             class EmptyExtraDims(DataSetFamily):
                 extra_dims = []
 
         class AbstractParent(DataSetFamily):
             __abstract__ = True
 
-        with self.assertRaisesRegexp(ValueError, msg):
+        with assert_raises_str(ValueError, msg):
             class NoExtraDimsChild(AbstractParent):
                 pass
 
-        with self.assertRaisesRegexp(ValueError, msg):
+        with assert_raises_str(ValueError, msg):
             class EmptyExtraDimsChild(AbstractParent):
                 extra_dims = []
 

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -60,12 +60,37 @@ class TestDataSetFamily(ZiplineTestCase):
         assert_is_not(MD1Slice, MD2Slice)
 
     def test_empty_extra_dims(self):
-        expected_msg = (
-            'DataSetFamily must be defined with non-empty extra_dims'
+        msg = (
+            "^DataSetFamily must be defined with non-empty extra_dims,"
+            " or with `__abstract__ = True`$"
         )
-        with assert_raises_str(ValueError, expected_msg):
-            class MD(DataSetFamily):
+        with self.assertRaisesRegexp(ValueError, msg):
+            class NoExtraDims(DataSetFamily):
+                pass
+
+        with self.assertRaisesRegexp(ValueError, msg):
+            class EmptyExtraDims(DataSetFamily):
                 extra_dims = []
+
+        class AbstractParent(DataSetFamily):
+            __abstract__ = True
+
+        with self.assertRaisesRegexp(ValueError, msg):
+            class NoExtraDimsChild(AbstractParent):
+                pass
+
+        with self.assertRaisesRegexp(ValueError, msg):
+            class EmptyExtraDimsChild(AbstractParent):
+                extra_dims = []
+
+        class AbstractChild(AbstractParent):
+            __abstract__ = True
+
+        class Child(AbstractParent):
+            extra_dims = [
+                ('dim_0', {'a', 'b', 'c'}),
+                ('dim_1', {'d', 'e', 'f'}),
+            ]
 
     def spec(*cs):
         return (cs,)

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -608,7 +608,7 @@ class DataSetFamilyMeta(abc.ABCMeta):
                 columns[k] = v
                 dict_[k] = _DataSetFamilyColumn(k)
 
-        is_abstract = dict_.pop('__abstract__', False)
+        is_abstract = dict_.pop('_abstract', False)
 
         self = super(DataSetFamilyMeta, cls).__new__(
             cls,
@@ -625,7 +625,7 @@ class DataSetFamilyMeta(abc.ABCMeta):
             if not extra_dims:
                 raise ValueError(
                     'DataSetFamily must be defined with non-empty'
-                    ' extra_dims, or with `__abstract__ = True`',
+                    ' extra_dims, or with `_abstract = True`',
                 )
 
             class BaseSlice(self._SliceType):
@@ -721,7 +721,7 @@ class DataSetFamily(with_metaclass(DataSetFamilyMeta)):
     This sliced dataset represents the rows from the higher dimensional dataset
     where ``(dimension_0 == 'a') & (dimension_1 == 'e')``.
     """
-    __abstract__ = True  # Removed by metaclass
+    _abstract = True  # Removed by metaclass
 
     domain = GENERIC
     slice_ndim = 2

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -736,6 +736,11 @@ class DataSetFamily(_base):
 
     @type.__call__
     class extra_dims(object):
+        """OrderedDict[str, frozenset] of dimension name -> unique values
+
+        May be defined on subclasses as an iterable of pairs: the
+        metaclass converts this attribute to an OrderedDict.
+        """
         __isabstractmethod__ = True
 
         def __get__(self, instance, owner):

--- a/zipline/utils/metautils.py
+++ b/zipline/utils/metautils.py
@@ -65,7 +65,7 @@ def compose_types(a, *cs):
 
     An important note here is that ``M`` did not use ``type.__new__`` and
     instead used ``super()``. This is to support cooperative multiple
-    inheritence which is needed for ``compose_types`` to work as intended.
+    inheritance which is needed for ``compose_types`` to work as intended.
     After we have composed these types ``M.__new__``\'s super will actually
     go to ``ABCMeta.__new__`` and not ``type.__new__``.
 


### PR DESCRIPTION
This change enables us to define "abstract" subclasses of DataSetFamily
which implement some set of attributes, but don't represent tangible
families of DataSets, and thus don't have meaningful values for
`extra_dims`.

Previously, all subclasses of DataSetFamily had to define non-empty
`extra_dims`. Subclasses were detected in DataSetFamilyMeta by checking
if the base classes of the class under construction were specified as
anything other than the designated sentinel value: if so, `extra_dims`
was transformed to an OrderedDict and checked for non-emptiness.

With this change, the metaclass instead checks for an `_abstract`
attribute of the class under construction: if it is found and set to a
truthy value, `extra_dims` (and `_SliceType`) is left unchecked and
unmodified. Regardless of its value, the `_abstract` attribute is
removed from the constructed class' body: each subclass which wishes to
remain abstract must specify this attribute again.