### PR TITLE
ENH: DataSetFamily namedtuple coords

### DIFF
--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -227,6 +227,26 @@ class TestDataSetFamily(ZiplineTestCase):
             ),
         )
 
+        # duplicate positional+keyword arguments
+        expect_slice_fails(
+            'a', 'b', dim_0='a',
+            expected_msg=(
+                'MD got multiple values for dimension dim_0'
+            ),
+        )
+        expect_slice_fails(
+            'a', 'b', dim_1='b',
+            expected_msg=(
+                'MD got multiple values for dimension dim_1'
+            ),
+        )
+        expect_slice_fails(
+            'a', 'b', dim_0='a', dim_1='b',
+            expected_msg=(
+                'MD got multiple values for dimensions dim_0, dim_1'
+            ),
+        )
+
         # the extra keyword dims should be sorted
         expect_slice_fails(
             dim_3='??', dim_2='??',

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -14,6 +14,7 @@ from zipline.testing import ZiplineTestCase
 from zipline.testing.predicates import (
     assert_equal,
     assert_is,
+    assert_is_instance,
     assert_is_not,
     assert_is_subclass,
     assert_raises_str,
@@ -148,10 +149,8 @@ class TestDataSetFamily(ZiplineTestCase):
             for alt in alternate_constructions:
                 assert_is(Slice, alt, msg='Slices are not properly memoized')
 
-            expected_coords = OrderedDict(
-                zip(expected_dims, valid_combination),
-            )
-            assert_equal(Slice.extra_coords, expected_coords)
+            assert_equal(Slice.extra_coords, valid_combination)
+            assert_is_instance(Slice.extra_coords, MD._CoordsType)
 
             assert_is(Slice.dataset_family, MD)
 

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -638,9 +638,9 @@ class DataSetFamilyMeta(abc.ABCMeta):
 
             BaseSlice.__name__ = '%sBaseSlice' % self.__name__
             self._SliceType = BaseSlice
+            # each non-abstract subclass gets a unique cache
+            self._slice_cache = {}
 
-        # each type gets a unique cache
-        self._slice_cache = {}
         return self
 
     def __repr__(self):

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -541,8 +541,8 @@ class DataSet(with_metaclass(DataSetMeta, object)):
 
 
 # This attribute is set by DataSetMeta to mark that a class is the root of a
-# family of datasets with diffent domains. We don't want that behavior for the
-# base DataSet class, and we also don't want to accidentally use a shared
+# family of datasets with different domains. We don't want that behavior for
+# the base DataSet class, and we also don't want to accidentally use a shared
 # version of this attribute if we fail to set this in a subclass somewhere.
 del DataSet._domain_specializations
 

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -596,7 +596,7 @@ class _DataSetFamilyColumn(object):
 
 class DataSetFamilyMeta(abc.ABCMeta):
 
-    def __new__(cls, name, bases, dict_):
+    def __new__(meta, name, bases, dict_):
         columns = {}
         for k, v in dict_.items():
             if isinstance(v, Column):
@@ -609,17 +609,17 @@ class DataSetFamilyMeta(abc.ABCMeta):
 
         is_abstract = dict_.pop('_abstract', False)
 
-        self = super(DataSetFamilyMeta, cls).__new__(
-            cls,
+        cls = super(DataSetFamilyMeta, meta).__new__(
+            meta,
             name,
             bases,
             dict_,
         )
 
         if not is_abstract:
-            self.extra_dims = extra_dims = OrderedDict([
+            cls.extra_dims = extra_dims = OrderedDict([
                 (k, frozenset(v))
-                for k, v in OrderedDict(self.extra_dims).items()
+                for k, v in OrderedDict(cls.extra_dims).items()
             ])
             if not extra_dims:
                 raise ValueError(
@@ -627,30 +627,30 @@ class DataSetFamilyMeta(abc.ABCMeta):
                     ' extra_dims, or with `_abstract = True`',
                 )
 
-            class BaseSlice(self._SliceType):
-                dataset_family = self
+            class BaseSlice(cls._SliceType):
+                dataset_family = cls
 
-                ndim = self.slice_ndim
-                domain = self.domain
+                ndim = cls.slice_ndim
+                domain = cls.domain
 
                 locals().update(columns)
 
-            BaseSlice.__name__ = '%sBaseSlice' % self.__name__
-            self._SliceType = BaseSlice
+            BaseSlice.__name__ = '%sBaseSlice' % cls.__name__
+            cls._SliceType = BaseSlice
             # each non-abstract subclass gets a unique cache
-            self._slice_cache = {}
+            cls._slice_cache = {}
 
-            self._CoordsType = namedtuple(
-                '%sCoords' % self.__name__,
+            cls._CoordsType = namedtuple(
+                '%sCoords' % cls.__name__,
                 extra_dims,
             )
 
-        return self
+        return cls
 
-    def __repr__(self):
+    def __repr__(cls):
         return '<DataSetFamily: %r, extra_dims=%r>' % (
-            self.__name__,
-            list(self.extra_dims),
+            cls.__name__,
+            list(cls.extra_dims),
         )
 
 


### PR DESCRIPTION
This PR adds a `_CoordType` attribute to DataSetFamily classes, which is
a namedtuple whose fields are the extra_dims.

namedtuples have a number of advantages over OrderedDicts for this
purpose:

- Default equality comparison is based on values, but may be easily
  extended to compare types as well;
- They are hashable, removing the need for a separate hash key;
- The constructor provides well-tested argument validation;
- Instances' repr includes the class name, giving some indication of the
  object's intended purpose;
- The fields are stored on the type, rather than redundantly on every
  instance;
- getattr syntax (if you're into that).

Moreover, this change also lets us factor out the `_validate_coords`
method. Currently, subclasses which override `slice` may choose to spell
out the expected extra_dims in the signature, but this will replace our
helpful dimension-specific error messages with Python's less helpful
built-in ones, such as "slice() takes 3 positional arguments but 4 were
given".

Factoring out `_validate_coords` enables subclasses to define their own
validation logic for coord objects while maintaining the original slice
signature, and without having to re-parse `(*args, **kwargs)`.
