### PR TITLE
Pipeline Engine Hooks

### DIFF
--- a/testhooks.py
+++ b/testhooks.py
@@ -1,1 +1,0 @@
-import zipline.pipeline.hooks

--- a/testhooks.py
+++ b/testhooks.py
@@ -1,0 +1,1 @@
+import zipline.pipeline.hooks

--- a/tests/pipeline/base.py
+++ b/tests/pipeline/base.py
@@ -7,9 +7,10 @@ from pandas import DataFrame, Timestamp
 from six import iteritems
 
 from zipline.utils.compat import wraps
+from zipline.pipeline import ExecutionPlan
 from zipline.pipeline.domain import US_EQUITIES
 from zipline.pipeline.engine import SimplePipelineEngine
-from zipline.pipeline import ExecutionPlan
+from zipline.pipeline.hooks import NoHooks
 from zipline.pipeline.term import AssetExists, InputDates
 from zipline.testing import check_arrays
 from zipline.testing.fixtures import (
@@ -113,6 +114,7 @@ class BaseUSEquityPipelineTestCase(WithTradingSessions,
             dates=dates,
             sids=sids,
             initial_workspace=initial_workspace,
+            hooks=NoHooks(),
         )
 
     def check_terms(self,

--- a/tests/pipeline/test_hooks.py
+++ b/tests/pipeline/test_hooks.py
@@ -303,27 +303,19 @@ class ProgressHooksTestCase(WithSeededRandomPipelineEngine, ZiplineTestCase):
 
         # First publish should contain precomputed terms from first chunk.
         first = trace[0]
-        self.assertEqual(first.state, 'loading')
-        self.assertIsInstance(first.percent_complete, float)
-        self.assertEqual(first.execution_bounds,
-                         (pipeline_start_date, pipeline_end_date))
-        self.assertEqual(
-            first.current_chunk_bounds,
-            expected_chunks[0],
+        expected_first = TestingProgressPublisher.TraceState(
+            state='loading',
+            percent_complete=instance_of(float),
+            execution_bounds=(pipeline_start_date, pipeline_end_date),
+            current_chunk_bounds=expected_chunks[0],
+            current_work=instance_of(list)
         )
+        self.assertEqual(first, expected_first)
+        self.assertGreater(first.percent_complete, 0.0)
         self.assertEqual(
-            first.current_work, [AssetExists(), PREPOPULATED_TERM]
+            set(first.current_work),
+            {AssetExists(), PREPOPULATED_TERM},
         )
-
-        # expected_first = TestingProgressPublisher.TraceState(
-        #     state='loading',
-        #     percent_complete=instance_of(float),
-        #     execution_bounds=(pipeline_start_date, pipeline_end_date),
-        #     current_chunk_bounds=expected_chunks[0],
-        #     current_work=[AssetExists(), PREPOPULATED_TERM],
-        # )
-        # self.assertGreater(first.percent_complete, 0.0)
-        # self.assertEqual(first, expected_first)
 
         # Last publish should have a state of success and be 100% complete.
         last = trace[-1]

--- a/tests/pipeline/test_hooks.py
+++ b/tests/pipeline/test_hooks.py
@@ -414,19 +414,10 @@ def two_at_a_time(it):
     """Iterate over ``it``, two elements at a time.
 
     ``it`` must yield an even number of times.
-    """
-    it = iter(it)
-    while True:
-        try:
-            first = next(it)
-        except StopIteration:
-            return
-        try:
-            second = next(it)
-        except StopIteration:
-            raise ValueError(
-                "iterator did not yield an even number of times. "
-                "last value was {}".format(first)
-            )
 
-        yield first, second
+    Examples
+    --------
+    >>> list(two_at_a_time([1, 2, 3, 4]))
+    [(1, 2), (3, 4)]
+    """
+    return toolz.partition(2, it, pad=None)

--- a/tests/pipeline/test_hooks.py
+++ b/tests/pipeline/test_hooks.py
@@ -303,15 +303,27 @@ class ProgressHooksTestCase(WithSeededRandomPipelineEngine, ZiplineTestCase):
 
         # First publish should contain precomputed terms from first chunk.
         first = trace[0]
-        expected_first = TestingProgressPublisher.TraceState(
-            state='loading',
-            percent_complete=instance_of(float),
-            execution_bounds=(pipeline_start_date, pipeline_end_date),
-            current_chunk_bounds=expected_chunks[0],
-            current_work=[AssetExists(), PREPOPULATED_TERM],
+        self.assertEqual(first.state, 'loading')
+        self.assertIsInstance(first.percent_complete, float)
+        self.assertEqual(first.execution_bounds,
+                         (pipeline_start_date, pipeline_end_date))
+        self.assertEqual(
+            first.current_chunk_bounds,
+            expected_chunks[0],
         )
-        self.assertGreater(first.percent_complete, 0.0)
-        self.assertEqual(first, expected_first)
+        self.assertEqual(
+            first.current_work, [AssetExists(), PREPOPULATED_TERM]
+        )
+
+        # expected_first = TestingProgressPublisher.TraceState(
+        #     state='loading',
+        #     percent_complete=instance_of(float),
+        #     execution_bounds=(pipeline_start_date, pipeline_end_date),
+        #     current_chunk_bounds=expected_chunks[0],
+        #     current_work=[AssetExists(), PREPOPULATED_TERM],
+        # )
+        # self.assertGreater(first.percent_complete, 0.0)
+        # self.assertEqual(first, expected_first)
 
         # Last publish should have a state of success and be 100% complete.
         last = trace[-1]

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -56,6 +56,8 @@ implements the following algorithm for executing pipelines:
    screen. This logic lives in SimplePipelineEngine._to_narrow.
 """
 from abc import ABCMeta, abstractmethod
+from functools import partial
+
 from six import iteritems, with_metaclass, viewkeys
 from numpy import array
 from pandas import DataFrame, MultiIndex
@@ -73,22 +75,19 @@ from zipline.utils.pandas_utils import explode
 
 from .domain import Domain, GENERIC
 from .graph import maybe_specialize
+from .hooks import DelegatingHooks
 from .term import AssetExists, InputDates, LoadableTerm
 
 from zipline.utils.date_utils import compute_date_range_chunks
 from zipline.utils.pandas_utils import categorical_df_concat
-from zipline.utils.sharedoc import copydoc
 
 
 class PipelineEngine(with_metaclass(ABCMeta)):
 
     @abstractmethod
-    def run_pipeline(self, pipeline, start_date, end_date):
+    def run_pipeline(self, pipeline, start_date, end_date, hooks=None):
         """
-        Compute values for ``pipeline`` between ``start_date`` and
-        ``end_date``.
-
-        Returns a DataFrame with a MultiIndex of (date, asset) pairs.
+        Compute values for ``pipeline`` from ``start_date`` to ``end_date``.
 
         Parameters
         ----------
@@ -116,11 +115,18 @@ class PipelineEngine(with_metaclass(ABCMeta)):
         raise NotImplementedError("run_pipeline")
 
     @abstractmethod
-    def run_chunked_pipeline(self, pipeline, start_date, end_date, chunksize):
+    def run_chunked_pipeline(self,
+                             pipeline,
+                             start_date,
+                             end_date,
+                             chunksize,
+                             hooks=None):
         """
-        Compute values for `pipeline` in number of days equal to `chunksize`
-        and return stitched up result. Computing in chunks is useful for
-        pipelines computed over a long period of time.
+        Compute values for ``pipeline`` from ``start_date`` to ``end_date``, in
+        date chunks of size ``chunksize``.
+
+        Chunked execution reduces memory consumption, and may reduce
+        computation time depending on the contents of your pipeline.
 
         Parameters
         ----------
@@ -165,13 +171,18 @@ class ExplodingPipelineEngine(PipelineEngine):
     """
     A PipelineEngine that doesn't do anything.
     """
-    def run_pipeline(self, pipeline, start_date, end_date):
+    def run_pipeline(self, pipeline, start_date, end_date, hooks=None):
         raise NoEngineRegistered(
             "Attempted to run a pipeline but no pipeline "
             "resources were registered."
         )
 
-    def run_chunked_pipeline(self, pipeline, start_date, end_date, chunksize):
+    def run_chunked_pipeline(self,
+                             pipeline,
+                             start_date,
+                             end_date,
+                             chunksize,
+                             hooks=None):
         raise NoEngineRegistered(
             "Attempted to run a chunked pipeline but no pipeline "
             "resources were registered."
@@ -228,6 +239,9 @@ class SimplePipelineEngine(PipelineEngine):
         computing a pipeline. See
         :func:`zipline.pipeline.engine.default_populate_initial_workspace`
         for more info.
+    default_hooks : list, optional
+        List of hooks that should be used to instrument all pipelines executed
+        by this engine.
 
     See Also
     --------
@@ -249,7 +263,8 @@ class SimplePipelineEngine(PipelineEngine):
                  get_loader,
                  asset_finder,
                  default_domain=GENERIC,
-                 populate_initial_workspace=None):
+                 populate_initial_workspace=None,
+                 default_hooks=None):
 
         self._get_loader = get_loader
         self._finder = asset_finder
@@ -262,18 +277,36 @@ class SimplePipelineEngine(PipelineEngine):
         )
         self._default_domain = default_domain
 
-    def run_pipeline(self, pipeline, start_date, end_date):
+        if default_hooks is None:
+            self._default_hooks = []
+        else:
+            self._default_hooks = list(default_hooks)
+
+    def run_chunked_pipeline(self,
+                             pipeline,
+                             start_date,
+                             end_date,
+                             chunksize,
+                             hooks=None):
         """
-        Compute a pipeline.
+        Compute values for ``pipeline`` from ``start_date`` to ``end_date``, in
+        date chunks of size ``chunksize``.
+
+        Chunked execution reduces memory consumption, and may reduce
+        computation time depending on the contents of your pipeline.
 
         Parameters
         ----------
-        pipeline : zipline.pipeline.Pipeline
+        pipeline : Pipeline
             The pipeline to run.
         start_date : pd.Timestamp
-            Start date of the computed matrix.
+            The start date to run the pipeline for.
         end_date : pd.Timestamp
-            End date of the computed matrix.
+            The end date to run the pipeline for.
+        chunksize : int
+            The number of days to execute at a time.
+        hooks : list[implements(PipelineHooks)], optional
+            Hooks for instrumenting Pipeline execution.
 
         Returns
         -------
@@ -292,7 +325,72 @@ class SimplePipelineEngine(PipelineEngine):
         See Also
         --------
         :meth:`zipline.pipeline.engine.PipelineEngine.run_pipeline`
-        :meth:`zipline.pipeline.engine.PipelineEngine.run_chunked_pipeline`
+        """
+        domain = self.resolve_domain(pipeline)
+        ranges = compute_date_range_chunks(
+            domain.all_sessions(),
+            start_date,
+            end_date,
+            chunksize,
+        )
+        if hooks is None:
+            hooks = []
+        hooks = self._resolve_hooks(hooks)
+
+        run_pipeline = partial(self._run_pipeline_impl, pipeline, hooks=hooks)
+        with hooks.running_pipeline(pipeline, start_date, end_date):
+            chunks = [run_pipeline(s, e) for s, e in ranges]
+
+        if len(chunks) == 1:
+            # OPTIMIZATION: Don't make an extra copy in `categorical_df_concat`
+            # if we don't have to.
+            return chunks[0]
+
+        return categorical_df_concat(chunks, inplace=True)
+
+    def run_pipeline(self, pipeline, start_date, end_date, hooks=None):
+        """
+        Compute values for ``pipeline`` from ``start_date`` to ``end_date``.
+
+        Parameters
+        ----------
+        pipeline : zipline.pipeline.Pipeline
+            The pipeline to run.
+        start_date : pd.Timestamp
+            Start date of the computed matrix.
+        end_date : pd.Timestamp
+            End date of the computed matrix.
+        hooks : list[implements(PipelineHooks)], optional
+            Hooks for instrumenting Pipeline execution.
+
+        Returns
+        -------
+        result : pd.DataFrame
+            A frame of computed results.
+
+            The ``result`` columns correspond to the entries of
+            `pipeline.columns`, which should be a dictionary mapping strings to
+            instances of :class:`zipline.pipeline.term.Term`.
+
+            For each date between ``start_date`` and ``end_date``, ``result``
+            will contain a row for each asset that passed `pipeline.screen`.
+            A screen of ``None`` indicates that a row should be returned for
+            each asset that existed each day.
+        """
+        if hooks is None:
+            hooks = []
+
+        hooks = self._resolve_hooks(hooks)
+        with hooks.running_pipeline(pipeline, start_date, end_date):
+            return self._run_pipeline_impl(
+                pipeline,
+                start_date,
+                end_date,
+                hooks,
+            )
+
+    def _run_pipeline_impl(self, pipeline, start_date, end_date, hooks):
+        """Shared core for ``run_pipeline`` and ``run_chunked_pipeline``.
         """
         # See notes at the top of this module for a description of the
         # algorithm implemented here.
@@ -300,15 +398,16 @@ class SimplePipelineEngine(PipelineEngine):
             raise ValueError(
                 "start_date must be before or equal to end_date \n"
                 "start_date=%s, end_date=%s" % (start_date, end_date)
-
             )
 
         domain = self.resolve_domain(pipeline)
 
-        graph = pipeline.to_execution_plan(
+        plan = pipeline.to_execution_plan(
             domain, self._root_mask_term, start_date, end_date,
         )
-        extra_rows = graph.extra_rows[self._root_mask_term]
+        hooks.on_create_execution_plan(plan)
+
+        extra_rows = plan.extra_rows[self._root_mask_term]
         root_mask = self._compute_root_mask(
             domain, start_date, end_date, extra_rows,
         )
@@ -320,38 +419,27 @@ class SimplePipelineEngine(PipelineEngine):
                 self._root_mask_dates_term: as_column(dates.values)
             },
             self._root_mask_term,
-            graph,
+            plan,
             dates,
             assets,
         )
 
-        results = self.compute_chunk(graph, dates, assets, initial_workspace)
+        with hooks.computing_chunk(plan, start_date, end_date):
+            results = self.compute_chunk(
+                plan,
+                dates,
+                assets,
+                initial_workspace,
+                hooks,
+            )
 
         return self._to_narrow(
-            graph.outputs,
+            plan.outputs,
             results,
-            results.pop(graph.screen_name),
+            results.pop(plan.screen_name),
             dates[extra_rows:],
             assets,
         )
-
-    @copydoc(PipelineEngine.run_chunked_pipeline)
-    def run_chunked_pipeline(self, pipeline, start_date, end_date, chunksize):
-        domain = self.resolve_domain(pipeline)
-        ranges = compute_date_range_chunks(
-            domain.all_sessions(),
-            start_date,
-            end_date,
-            chunksize,
-        )
-        chunks = [self.run_pipeline(pipeline, s, e) for s, e in ranges]
-
-        if len(chunks) == 1:
-            # OPTIMIZATION: Don't make an extra copy in `categorical_df_concat`
-            # if we don't have to.
-            return chunks[0]
-
-        return categorical_df_concat(chunks, inplace=True)
 
     def _compute_root_mask(self, domain, start_date, end_date, extra_rows):
         """
@@ -481,7 +569,7 @@ class SimplePipelineEngine(PipelineEngine):
                 out.append(input_data)
         return out
 
-    def compute_chunk(self, graph, dates, sids, initial_workspace):
+    def compute_chunk(self, graph, dates, sids, initial_workspace, hooks):
         """
         Compute the Pipeline terms in the graph for the requested start and end
         dates.
@@ -501,6 +589,8 @@ class SimplePipelineEngine(PipelineEngine):
             Must contain at least entry for `self._root_mask_term` whose shape
             is `(len(dates), len(assets))`, but may contain additional
             pre-computed terms for testing or optimization purposes.
+        hooks : implements(PipelineHooks)
+            Hooks to instrument pipeline execution.
 
         Returns
         -------
@@ -549,10 +639,11 @@ class SimplePipelineEngine(PipelineEngine):
         )
 
         for term in graph.execution_order(refcounts):
-            # `term` may have been supplied in `initial_workspace`, and in the
-            # future we may pre-compute loadable terms coming from the same
-            # dataset.  In either case, we will already have an entry for this
-            # term, which we shouldn't re-compute.
+            # `term` may have been supplied in `initial_workspace`, or we may
+            # have loaded `term` as part of a batch with another term coming
+            # from the same loader (see note on loader_group_key above). In
+            # either case, we already have the term computed, so don't
+            # recompute.
             if term in workspace:
                 continue
 
@@ -571,31 +662,33 @@ class SimplePipelineEngine(PipelineEngine):
                     loader_groups[loader_group_key(term)],
                     key=lambda t: t.dataset
                 )
-                loaded = loader.load_adjusted_array(
-                    domain, to_load, mask_dates, sids, mask,
-                )
+                with hooks.loading_terms(to_load):
+                    loaded = loader.load_adjusted_array(
+                        domain, to_load, mask_dates, sids, mask,
+                    )
                 assert set(loaded) == set(to_load), (
-                    'loader did not return an AdjustedArray for each column\n'
+                    'loader did not return AdjustedArray for each column\n'
                     'expected: %r\n'
                     'got:      %r' % (sorted(to_load), sorted(loaded))
                 )
                 workspace.update(loaded)
             else:
-                workspace[term] = term._compute(
-                    self._inputs_for_term(term, workspace, graph, domain),
-                    mask_dates,
-                    sids,
-                    mask,
-                )
+                with hooks.computing_term(term):
+                    workspace[term] = term._compute(
+                        self._inputs_for_term(term, workspace, graph, domain),
+                        mask_dates,
+                        sids,
+                        mask,
+                    )
                 if term.ndim == 2:
                     assert workspace[term].shape == mask.shape
                 else:
                     assert workspace[term].shape == (mask.shape[0], 1)
 
-                # Decref dependencies of ``term``, and clear any terms whose
-                # refcounts hit 0.
-                for garbage_term in graph.decref_dependencies(term, refcounts):
-                    del workspace[garbage_term]
+                # Decref dependencies of ``term``, and clear any terms
+                # whose refcounts hit 0.
+                for garbage in graph.decref_dependencies(term, refcounts):
+                    del workspace[garbage]
 
         # At this point, all the output terms are in the workspace.
         out = {}
@@ -768,3 +861,6 @@ class SimplePipelineEngine(PipelineEngine):
             term is self._root_mask_term
             or term is self._root_mask_dates_term
         )
+
+    def _resolve_hooks(self, hooks):
+        return DelegatingHooks(list(hooks) + self._default_hooks)

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -66,6 +66,9 @@ class TermGraph(object):
         # Mark that no more terms should be added to the graph.
         self._frozen = True
 
+    def __contains__(self, term):
+        return term in self.graph
+
     def _add_to_graph(self, term, parents):
         """
         Add a term and all its children to ``graph``.

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -207,6 +207,9 @@ class TermGraph(object):
                 garbage.add(parent)
         return garbage
 
+    def __len__(self):
+        return len(self.graph)
+
 
 class ExecutionPlan(TermGraph):
     """

--- a/zipline/pipeline/hooks/__init__.py
+++ b/zipline/pipeline/hooks/__init__.py
@@ -1,0 +1,14 @@
+from .iface import PipelineHooks
+from .no import NoHooks
+from .delegate import DelegatingHooks
+from .progress import ProgressHooks
+from .testing import TestingHooks
+
+
+__all__ = [
+    'PipelineHooks',
+    'NoHooks',
+    'DelegatingHooks',
+    'ProgressHooks',
+    'TestingHooks',
+]

--- a/zipline/pipeline/hooks/delegate.py
+++ b/zipline/pipeline/hooks/delegate.py
@@ -50,10 +50,9 @@ class DelegatingHooks(implements(PipelineHooks)):
             # sub-hook.
             return hooks[0]
         else:
-            return super(DelegatingHooks, cls).__new__(cls, hooks)
-
-    def __init__(self, hooks):
-        self._hooks = hooks
+            self = super(DelegatingHooks, cls).__new__(cls)
+            self._hooks = hooks
+            return self
 
     # Implement all interface methods by delegating to corresponding methods on
     # input hooks.

--- a/zipline/pipeline/hooks/delegate.py
+++ b/zipline/pipeline/hooks/delegate.py
@@ -1,0 +1,67 @@
+from contextlib2 import ExitStack
+from interface import implements
+
+from zipline.utils.compat import contextmanager, wraps
+
+from .iface import PipelineHooks, PIPELINE_HOOKS_CONTEXT_MANAGERS
+from .no import NoHooks
+
+
+def delegating_hooks_method(method_name):
+    """Factory function for making DelegatingHooks methods.
+    """
+    if method_name in PIPELINE_HOOKS_CONTEXT_MANAGERS:
+        # Generate a contextmanager that enters the context of all child hooks.
+        @wraps(getattr(PipelineHooks, method_name))
+        @contextmanager
+        def ctx(self, *args, **kwargs):
+            with ExitStack() as stack:
+                for hook in self._hooks:
+                    sub_ctx = getattr(hook, method_name)(*args, **kwargs)
+                    stack.enter_context(sub_ctx)
+                yield stack
+        return ctx
+    else:
+        # Generate a method that calls methods of all child hooks.
+        @wraps(getattr(PipelineHooks, method_name))
+        def method(self, *args, **kwargs):
+            for hook in self._hooks:
+                sub_method = getattr(hook, method_name)
+                sub_method(*args, **kwargs)
+
+        return method
+
+
+class DelegatingHooks(implements(PipelineHooks)):
+    """A PipelineHooks that delegates to one or more other hooks.
+
+    Parameters
+    ----------
+    hooks : list[implements(PipelineHooks)]
+        Sequence of hooks to delegate to.
+    """
+    def __new__(cls, hooks):
+        if len(hooks) == 0:
+            # OPTIMIZATION: Short-circuit to a NoHooks if we don't have any
+            # sub-hooks.
+            return NoHooks()
+        elif len(hooks) == 1:
+            # OPTIMIZATION: Unwrap delegation layer if we only have one
+            # sub-hook.
+            return hooks[0]
+        else:
+            return super(DelegatingHooks, cls).__new__(cls, hooks)
+
+    def __init__(self, hooks):
+        self._hooks = hooks
+
+    # Implement all interface methods by delegating to corresponding methods on
+    # input hooks.
+    locals().update({
+        name: delegating_hooks_method(name)
+        # TODO: Expose this publicly on interface.
+        for name in PipelineHooks._signatures
+    })
+
+
+del delegating_hooks_method

--- a/zipline/pipeline/hooks/iface.py
+++ b/zipline/pipeline/hooks/iface.py
@@ -29,16 +29,11 @@ class PipelineHooks(Interface):
 
     Methods
     -------
-    on_create_execution_plan(self, plan)
     running_pipeline(self, pipeline, start_date, end_date, chunked)
-    computing_chunk(self, plan, start_date, end_date)
+    computing_chunk(self, plan, initial_workspace, start_date, end_date)
     loading_terms(self, terms)
     computing_term(self, term):
     """
-
-    def on_create_execution_plan(self, plan):
-        """Called on resolution of a Pipeline to an ExecutionPlan.
-        """
 
     @contextmanager
     def running_pipeline(self, pipeline, start_date, end_date):
@@ -48,7 +43,7 @@ class PipelineHooks(Interface):
         """
 
     @contextmanager
-    def computing_chunk(self, plan, start_date, end_date):
+    def computing_chunk(self, plan, initial_workspace, start_date, end_date):
         """Contextmanager entered during execution of compute_chunk.
         """
 

--- a/zipline/pipeline/hooks/iface.py
+++ b/zipline/pipeline/hooks/iface.py
@@ -1,0 +1,63 @@
+from zipline.utils.compat import contextmanager as _contextmanager
+
+from interface import Interface
+
+
+# Keep track of which methods of PipelineHooks are contextmanagers. Used by
+# DelegatingHooks to properly delegate to sub-hooks.
+PIPELINE_HOOKS_CONTEXT_MANAGERS = set()
+
+
+def contextmanager(f):
+    """
+    Wrapper for contextlib.contextmanager that tracks which methods of
+    PipelineHooks are contextmanagers in CONTEXT_MANAGER_METHODS.
+    """
+    PIPELINE_HOOKS_CONTEXT_MANAGERS.add(f.__name__)
+    return _contextmanager(f)
+
+
+class PipelineHooks(Interface):
+    """
+    Interface for instrumenting SimplePipelineEngine executions.
+
+    Methods with names like 'on_event()' should be normal methods. They will be
+    called by the engine after the corresponding event.
+
+    Methods with names like 'doing_thing()' should be context managers. They
+    will be entered by the engine around the corresponding event.
+
+    Methods
+    -------
+    on_create_execution_plan(self, plan)
+    running_pipeline(self, pipeline, start_date, end_date, chunked)
+    computing_chunk(self, plan, start_date, end_date)
+    loading_terms(self, terms)
+    computing_term(self, term):
+    """
+
+    def on_create_execution_plan(self, plan):
+        """Called on resolution of a Pipeline to an ExecutionPlan.
+        """
+
+    @contextmanager
+    def running_pipeline(self, pipeline, start_date, end_date):
+        """
+        Contextmanager entered during execution of run_pipeline or
+        run_chunked_pipeline.
+        """
+
+    @contextmanager
+    def computing_chunk(self, plan, start_date, end_date):
+        """Contextmanager entered during execution of compute_chunk.
+        """
+
+    @contextmanager
+    def loading_terms(self, terms):
+        """Contextmanager entered when loading a batch of LoadableTerms.
+        """
+
+    @contextmanager
+    def computing_term(self, term):
+        """Contextmanager entered when computing a ComputableTerm.
+        """

--- a/zipline/pipeline/hooks/no.py
+++ b/zipline/pipeline/hooks/no.py
@@ -1,0 +1,31 @@
+from interface import implements
+
+from zipline.utils.compat import contextmanager
+
+from .iface import PipelineHooks
+
+
+class NoHooks(implements(PipelineHooks)):
+    """A PipelineHooks that defines no-op methods for all available hooks.
+
+    Use this as a base class if you only want to implement a subset of all
+    possible hooks.
+    """
+    def on_create_execution_plan(self, plan):
+        pass
+
+    @contextmanager
+    def running_pipeline(self, pipeline, start_date, end_date):
+        yield
+
+    @contextmanager
+    def computing_chunk(self, plan, start_date, end_date):
+        yield
+
+    @contextmanager
+    def loading_terms(self, terms):
+        yield
+
+    @contextmanager
+    def computing_term(self, term):
+        yield

--- a/zipline/pipeline/hooks/no.py
+++ b/zipline/pipeline/hooks/no.py
@@ -7,19 +7,13 @@ from .iface import PipelineHooks
 
 class NoHooks(implements(PipelineHooks)):
     """A PipelineHooks that defines no-op methods for all available hooks.
-
-    Use this as a base class if you only want to implement a subset of all
-    possible hooks.
     """
-    def on_create_execution_plan(self, plan):
-        pass
-
     @contextmanager
     def running_pipeline(self, pipeline, start_date, end_date):
         yield
 
     @contextmanager
-    def computing_chunk(self, plan, start_date, end_date):
+    def computing_chunk(self, plan, initial_workspace, start_date, end_date):
         yield
 
     @contextmanager

--- a/zipline/pipeline/hooks/progress.py
+++ b/zipline/pipeline/hooks/progress.py
@@ -1,0 +1,494 @@
+"""Pipeline hooks for tracking and displaying progress.
+"""
+import cgi
+from collections import namedtuple
+import time
+
+from interface import implements
+
+from zipline.utils.compat import contextmanager
+from zipline.utils.string_formatting import bulleted_list
+
+from .iface import PipelineHooks
+
+
+class ProgressHooks(implements(PipelineHooks)):
+    """
+    Hooks implementation for displaying progress.
+
+    Parameters
+    ----------
+    publisher_factory : callable
+        Function producing a new object with a ``publish()`` method that takes
+        a ``ProgressModel`` and publishes progress to a consumer.
+    """
+    def __init__(self, publisher_factory):
+        # This object encapsulates state that should be reset between pipeline
+        # executions.
+        self._state = _ProgressHooksState(publisher_factory)
+
+    @classmethod
+    def with_widget_publisher(cls):
+        """
+        Construct a ProgressHooks that publishes to Jupyter via
+        ``IPython.display``.
+        """
+        return cls(publisher_factory=IPythonWidgetProgressPublisher)
+
+    @classmethod
+    def with_static_publisher(cls, publisher):
+        """Construct a ProgressHooks that uses an already-constructed publisher.
+        """
+        return cls(publisher_factory=lambda: publisher)
+
+    # The state manages our ProgressModel because we receive the information
+    # necessary to initialize over the course of several hook callbacks.
+    @property
+    def _model(self):
+        return self._state.model
+
+    def _publish(self):
+        self._state.publish()
+
+    @contextmanager
+    def running_pipeline(self, pipeline, start_date, end_date):
+        self._state.set_bounds(start_date, end_date)
+        try:
+            yield
+        except Exception:
+            self._model.finish(success=False)
+            self._publish()
+            raise
+        else:
+            self._model.finish(success=True)
+            self._publish()
+        finally:
+            self._state.reset()
+
+    def on_create_execution_plan(self, plan):
+        self._state.set_execution_plan(plan)
+        self._publish()
+
+    @contextmanager
+    def computing_chunk(self, plan, start_date, end_date):
+        try:
+            self._model.start_chunk(start_date, end_date)
+            self._publish()
+            yield
+        finally:
+            self._model.finish_chunk(start_date, end_date)
+            self._publish()
+
+    @contextmanager
+    def loading_terms(self, terms):
+        try:
+            self._model.start_load_terms(terms)
+            self._publish()
+            yield
+        finally:
+            self._model.finish_load_terms(terms)
+            self._publish()
+
+    @contextmanager
+    def computing_term(self, term):
+        try:
+            self._model.start_compute_term(term)
+            self._publish()
+            yield
+        finally:
+            self._model.finish_compute_term(term)
+            self._publish()
+
+
+class _ProgressHooksState(object):
+    """
+    Helper class for managing incremental acquisition of pipeline state in
+    ``ProgressHooks``.
+    """
+
+    def __init__(self, publisher_factory):
+        self._publisher_factory = publisher_factory
+        self.reset()
+
+    def reset(self):
+        self._start_date = None
+        self._end_date = None
+        self._plan = None
+
+        self._model = None
+        self._publisher = None
+
+    def set_bounds(self, start_date, end_date):
+        self._start_date = start_date
+        self._end_date = end_date
+
+    def set_execution_plan(self, plan):
+        # NOTE: This will be called multiple times in a chunked execution, but
+        # the plans should always be functionally equivalent.
+        self._plan = plan
+
+    def publish(self):
+        self.publisher.publish(self.model)
+
+    @property
+    def model(self):
+        _model = self._model
+        if _model is None:
+            _model = self._model = self._create_model()
+        return _model
+
+    @property
+    def publisher(self):
+        publisher = self._publisher
+        if publisher is None:
+            publisher = self._publisher = self._publisher_factory()
+        return self._publisher
+
+    def _create_model(self):
+        """
+        Create a ProgressModel.
+
+        Can only be called after ``set_bounds`` and ``set_execution_plan``.
+        """
+        start_date = self._start_date
+        end_date = self._end_date
+        plan = self._plan
+
+        if start_date is None:
+            raise ValueError(
+                "Must have start_date to create a progress model."
+            )
+        elif end_date is None:
+            raise ValueError(
+                "Must have end_date to create a progress model."
+            )
+        elif plan is None:
+            raise ValueError(
+                "Must have an execution plan to create a progress model."
+            )
+
+        # Subtract one from the execution plan length to account for
+        # AssetExists(), which will always be in the pipeline, but won't be
+        # computed.
+        return ProgressModel(len(plan) - 1, start_date, end_date)
+
+
+class ProgressModel(object):
+    """
+    Model object for tracking progress of a Pipeline execution.
+
+    Parameters
+    ----------
+    nterms : int
+        Number of terms in the execution plan of the Pipeline being run.
+    start_date : pd.Timestamp
+        Start date of the range over which ``plan`` will be computed.
+    end_date : pd.Timestamp
+        End date of the range over which ``plan`` will be computed.
+
+    Methods
+    -------
+    start_chunk(start_date, end_date)
+    finish_chunk(start_date, end_date)
+    start_load_terms(terms)
+    finish_load_terms(terms)
+    start_compute_term(term)
+    finish_compute_term(term)
+    finish(success)
+
+    Attributes
+    ----------
+    state : {'init', 'loading', 'computing', 'error', 'success'}
+        Current state of the execution.
+    percent_complete : float
+        Percent of execution that has been completed, on a scale from 0 to 100.
+    execution_time : float
+        Number of seconds that the execution required. Only available if state
+        is 'error' or 'success'.
+    execution_bounds : (pd.Timestamp, pd.Timestamp)
+        Pair of (start_date, end_date) for the entire execution.
+    current_chunk_bounds : (pd.Timestamp, pd.Timestamp)
+        Pair of (start_date, end_date) for the currently executing chunk.
+    current_work : [zipline.pipeline.term.Term]
+        List of terms currently being loaded or computed.
+    """
+
+    def __init__(self, nterms, start_date, end_date):
+        self._start_date = start_date
+        self._end_date = end_date
+
+        # +1 to be inclusive of end_date.
+        total_days = (end_date - start_date).days + 1
+        self._max_progress = total_days * nterms
+
+        self._progress = 0
+        self._days_completed = 0
+
+        self._state = 'init'
+
+        self._current_chunk_size = None
+        self._current_chunk_bounds = None
+        self._current_work = None
+
+        self._start_time = time.time()
+        self._end_time = None
+
+    # These properties form the public interface for Publishers.
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def percent_complete(self):
+        return 100.0 * float(self._progress) / self._max_progress
+
+    @property
+    def execution_time(self):
+        if self._end_time is None:
+            raise ValueError(
+                "Can't get execution_time until execution is complete."
+            )
+        return self._end_time - self._start_time
+
+    @property
+    def execution_bounds(self):
+        return (self._start_date, self._end_date)
+
+    @property
+    def current_chunk_bounds(self):
+        return self._current_chunk_bounds
+
+    @property
+    def current_work(self):
+        return self._current_work
+
+    # These methods form the interface for ProgressHooks.
+    def start_chunk(self, start_date, end_date):
+        days_since_start = (end_date - self._start_date).days + 1
+        self._current_chunk_size = days_since_start - self._days_completed
+        self._current_chunk_bounds = (start_date, end_date)
+
+    def finish_chunk(self, start_date, end_date):
+        self._days_completed += self._current_chunk_size
+
+    def start_load_terms(self, terms):
+        self._state = 'loading'
+        self._current_work = terms
+
+    def finish_load_terms(self, terms):
+        self._increment_progress(nterms=len(terms))
+
+    def start_compute_term(self, term):
+        self._state = 'computing'
+        self._current_work = [term]
+
+    def finish_compute_term(self, term):
+        self._increment_progress(nterms=1)
+
+    def finish(self, success):
+        self._end_time = time.time()
+        if success:
+            self._state = 'success'
+        else:
+            self._state = 'error'
+
+    def _increment_progress(self, nterms):
+        self._progress += nterms * self._current_chunk_size
+
+
+try:
+    import ipywidgets
+    HAVE_WIDGETS = True
+except ImportError:
+    HAVE_WIDGETS = False
+
+try:
+    from IPython.display import display, HTML as IPython_HTML
+    HAVE_IPYTHON = True
+except ImportError:
+    HAVE_IPYTHON = False
+
+
+# XXX: This class is currently untested, because we don't require ipywidgets as
+#      a test dependency. Be careful if you make changes to this.
+class IPythonWidgetProgressPublisher(object):
+    """A progress publisher that publishes to an IPython/Jupyter widget.
+    """
+
+    def __init__(self):
+        missing = []
+        if not HAVE_WIDGETS:
+            missing.append('ipywidgets')
+        elif not HAVE_IPYTHON:
+            missing.append('IPython')
+
+        if missing:
+            raise ValueError(
+                "IPythonWidgetProgressPublisher needs ipywidgets and IPython:"
+                "\nMissing:\n{}".format(bulleted_list(missing))
+            )
+
+        # Heading for progress display.
+        self._heading = ipywidgets.HTML()
+
+        # Percent Complete Indicator to the left of the bar.
+        indicator_width = '120px'
+        self._percent_indicator = ipywidgets.HTML(
+            layout={'width': indicator_width},
+        )
+
+        # The progress bar itself.
+        self._bar = ipywidgets.FloatProgress(
+            value=0.0,
+            min=0.0,
+            max=100.0,
+            bar_style='info',
+            # Leave enough space for the percent indicator.
+            layout={'width': 'calc(100% - {})'.format(indicator_width)},
+        )
+        bar_and_percent = ipywidgets.HBox([self._percent_indicator, self._bar])
+
+        # Collapsable details tab underneath the progress bar.
+        self._details_body = ipywidgets.HTML()
+        self._details_tab = ipywidgets.Accordion(
+            children=[self._details_body],
+            selected_index=None,  # Start in collapsed state.
+            layout={
+                # Override default border settings to make details tab less
+                # heavy.
+                'border': '1px',
+            },
+        )
+        # There's no public interface for setting title in the constructor :/.
+        self._details_tab.set_title(0, 'Details')
+
+        # Container for the combined widget.
+        self._layout = ipywidgets.VBox(
+            [
+                self._heading,
+                bar_and_percent,
+                self._details_tab,
+            ],
+            # Overall layout consumes 75% of the page.
+            layout={'width': '75%'},
+        )
+
+        self._displayed = False
+
+    def publish(self, model):
+        if model.state == 'init':
+            self._heading.value = '<b>Analyzing Pipeline...</b>'
+            self._set_progress(0.0)
+
+            if not self._displayed:
+                display(self._layout)
+                self._displayed = True
+
+        elif model.state in ('loading', 'computing'):
+            term_list = self._render_term_list(model.current_work)
+            if model.state == 'loading':
+                details_heading = '<b>Loading Inputs:</b>'
+            else:
+                details_heading = '<b>Computing Expression:</b>'
+
+            self._details_body.value = details_heading + term_list
+            self._heading.value = (
+                "<b>Running Pipeline</b>: Chunk Start={}, Chunk End={}"
+                .format(*model.current_chunk_bounds)
+            )
+            self._set_progress(model.percent_complete)
+
+        elif model.state == 'success':
+            # Replace widget layout with html that can be persisted.
+            self._layout.close()
+            display(
+                IPython_HTML("<b>Pipeline Execution Time:</b> {}".format(
+                    self._format_execution_time(model.execution_time)
+                ))
+            )
+
+        elif model.state == 'error':
+            self._bar.bar_style = 'danger'
+            self._layout.close()
+
+        else:
+            raise ValueError('Unknown display state: {!r}'.format(model.state))
+
+    @staticmethod
+    def _render_term_list(terms):
+        list_elements = ''.join([
+             '<li><pre>{}</pre></li>'.format(cgi.escape(str(t)))
+             for t in terms
+        ])
+        return '<ul>{}</ul>'.format(list_elements)
+
+    def _set_progress(self, percent_complete):
+        self._bar.value = percent_complete
+        self._percent_indicator.value = (
+            "<b>{:.2f}% Complete</b>".format(percent_complete)
+        )
+
+    @staticmethod
+    def _format_execution_time(total_seconds):
+        """Helper method for displaying total execution time of a Pipeline.
+
+        Parameters
+        ----------
+        total_seconds : float
+            Number of seconds elapsed.
+
+        Returns
+        -------
+        formatted : str
+            User-facing text representation of elapsed time.
+        """
+        def maybe_s(n):
+            if n == 1:
+                return ''
+            return 's'
+
+        minutes, seconds = divmod(total_seconds, 60)
+        minutes = int(minutes)
+        if minutes >= 60:
+            hours, minutes = divmod(minutes, 60)
+            t = "{hours} Hour{hs}, {minutes} Minute{ms}, {seconds:.2f} Seconds"
+            return t.format(
+                hours=hours, hs=maybe_s(hours),
+                minutes=minutes, ms=maybe_s(minutes),
+                seconds=seconds,
+            )
+        elif minutes >= 1:
+            t = "{minutes} Minute{ms}, {seconds:.2f} Seconds"
+            return t.format(
+                minutes=minutes,
+                ms=maybe_s(minutes),
+                seconds=seconds,
+            )
+        else:
+            return "{seconds:.2f} Seconds".format(seconds=seconds)
+
+
+class TestingProgressPublisher(object):
+    """A progress publisher that records a trace of model states for testing.
+    """
+    TraceState = namedtuple('TraceState', [
+        'state',
+        'percent_complete',
+        'execution_bounds',
+        'current_chunk_bounds',
+        'current_work',
+    ])
+
+    def __init__(self):
+        self.trace = []
+
+    def publish(self, model):
+        self.trace.append(
+            self.TraceState(
+                state=model.state,
+                percent_complete=model.percent_complete,
+                execution_bounds=model.execution_bounds,
+                current_chunk_bounds=model.current_chunk_bounds,
+                current_work=model.current_work
+            ),
+        )

--- a/zipline/pipeline/hooks/testing.py
+++ b/zipline/pipeline/hooks/testing.py
@@ -1,0 +1,64 @@
+from collections import namedtuple
+
+from .iface import PipelineHooks, PIPELINE_HOOKS_CONTEXT_MANAGERS
+
+from interface import implements
+
+from zipline.utils.compat import contextmanager, wraps
+
+
+Call = namedtuple('Call', 'method_name args kwargs')
+
+class ContextCall(namedtuple('ContextCall', 'state call')):
+
+    @property
+    def method_name(self):
+        return self.call.method_name
+
+    @property
+    def args(self):
+        return self.call.args
+
+    @property
+    def kwargs(self):
+        return self.call.kwargs
+
+
+def testing_hooks_method(method_name):
+    """Factory function for making testing methods.
+    """
+    if method_name in PIPELINE_HOOKS_CONTEXT_MANAGERS:
+        # Generate a method that enters the context of all sub-hooks.
+        @wraps(getattr(PipelineHooks, method_name))
+        @contextmanager
+        def ctx(self, *args, **kwargs):
+            call = Call(method_name, args, kwargs)
+            self.trace.append(ContextCall('enter', call))
+            yield
+            self.trace.append(ContextCall('exit', call))
+        return ctx
+
+    else:
+        # Generate a method that calls methods of all sub-hooks.
+        @wraps(getattr(PipelineHooks, method_name))
+        def method(self, *args, **kwargs):
+            self.trace.append(Call(method_name, args, kwargs))
+        return method
+
+
+class TestingHooks(implements(PipelineHooks)):
+    """A hooks implementation that keeps a trace of hook method calls.
+    """
+    def __init__(self):
+        self.trace = []
+
+    def clear(self):
+        self.trace = []
+
+    # Implement all interface methods by delegating to corresponding methods on
+    # input hooks.
+    locals().update({
+        name: testing_hooks_method(name)
+        # TODO: Expose this publicly on interface.
+        for name in PipelineHooks._signatures
+    })

--- a/zipline/pipeline/hooks/testing.py
+++ b/zipline/pipeline/hooks/testing.py
@@ -9,6 +9,7 @@ from zipline.utils.compat import contextmanager, wraps
 
 Call = namedtuple('Call', 'method_name args kwargs')
 
+
 class ContextCall(namedtuple('ContextCall', 'state call')):
 
     @property

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -1760,7 +1760,12 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
             get_loader=lambda column: loader,
             asset_finder=cls.asset_finder,
             default_domain=cls.SEEDED_RANDOM_PIPELINE_DEFAULT_DOMAIN,
+            default_hooks=cls.make_seeded_random_pipeline_engine_hooks(),
         )
+
+    @classmethod
+    def make_seeded_random_pipeline_engine_hooks(cls):
+        return []
 
     def raw_expected_values(self, column, start_date, end_date):
         """
@@ -1775,7 +1780,7 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
         row_slice = self.trading_days.slice_indexer(start_date, end_date)
         return all_values[row_slice]
 
-    def run_pipeline(self, pipeline, start_date, end_date):
+    def run_pipeline(self, pipeline, start_date, end_date, hooks=None):
         """
         Run a pipeline with self.seeded_random_engine.
         """
@@ -1787,6 +1792,28 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
             pipeline,
             start_date,
             end_date,
+            hooks=hooks,
+        )
+
+    def run_chunked_pipeline(self,
+                             pipeline,
+                             start_date,
+                             end_date,
+                             chunksize,
+                             hooks=None):
+        """
+        Run a chunked pipeline with self.seeded_random_engine.
+        """
+        if start_date not in self.trading_days:
+            raise AssertionError("Start date not in calendar: %s" % start_date)
+        if end_date not in self.trading_days:
+            raise AssertionError("End date not in calendar: %s" % end_date)
+        return self.seeded_random_engine.run_chunked_pipeline(
+            pipeline,
+            start_date,
+            end_date,
+            chunksize=chunksize,
+            hooks=hooks,
         )
 
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -1761,11 +1761,18 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
             asset_finder=cls.asset_finder,
             default_domain=cls.SEEDED_RANDOM_PIPELINE_DEFAULT_DOMAIN,
             default_hooks=cls.make_seeded_random_pipeline_engine_hooks(),
+            populate_initial_workspace=(
+                cls.make_seeded_random_populate_initial_workspace()
+            ),
         )
 
     @classmethod
     def make_seeded_random_pipeline_engine_hooks(cls):
         return []
+
+    @classmethod
+    def make_seeded_random_populate_initial_workspace(cls):
+        return None
 
     def raw_expected_values(self, column, start_date, end_date):
         """

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -1791,10 +1791,6 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
         """
         Run a pipeline with self.seeded_random_engine.
         """
-        if start_date not in self.trading_days:
-            raise AssertionError("Start date not in calendar: %s" % start_date)
-        if end_date not in self.trading_days:
-            raise AssertionError("End date not in calendar: %s" % end_date)
         return self.seeded_random_engine.run_pipeline(
             pipeline,
             start_date,
@@ -1811,10 +1807,6 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
         """
         Run a chunked pipeline with self.seeded_random_engine.
         """
-        if start_date not in self.trading_days:
-            raise AssertionError("Start date not in calendar: %s" % start_date)
-        if end_date not in self.trading_days:
-            raise AssertionError("End date not in calendar: %s" % end_date)
         return self.seeded_random_engine.run_chunked_pipeline(
             pipeline,
             start_date,

--- a/zipline/utils/compat.py
+++ b/zipline/utils/compat.py
@@ -9,6 +9,7 @@ from six import PY2
 if PY2:
     from abc import ABCMeta
     from types import DictProxyType
+    import contextlib
     from ctypes import py_object, pythonapi
 
     _new_mappingproxy = pythonapi.PyDictProxy_New
@@ -83,7 +84,17 @@ if PY2:
     # This is deprecated in python 3.6+.
     getargspec = inspect.getargspec
 
+    # Updated version of contextlib.contextmanager that uses our updated
+    # `wraps` to preserve function signatures.
+    @wraps(contextlib.contextmanager)
+    def contextmanager(f):
+        @wraps(f)
+        def helper(*args, **kwargs):
+            return contextlib.GeneratorContextManager(f(*args, **kwargs))
+        return helper
+
 else:
+    from contextlib import contextmanager
     from types import MappingProxyType as mappingproxy
     from math import ceil
 
@@ -128,4 +139,5 @@ __all__ = [
     'values_as_list',
     'wraps',
     'consistent_round',
+    'contextmanager',
 ]


### PR DESCRIPTION
Adds a new `PipelineHooks` interface for instrumenting Pipeline executions.

Hooks can be passed to on a per-invocation basis to
`SimplePipelineEngine.run_pipeline`/`SimplePipelineEngine.run_pipeline`. They
can also be passed to `SimplePipelineEngine` to be applied to all pipeline
executions.

There are several implementations of the `PipelineHooks` interface, but the
only one useful to a user right now is `ProgressHooks`, which maintains a model
of the progress of the execution and hands it off to a publisher class to be
displayed to the user. The only interesting user-facing publisher is
`IPythonWidgetProgressPublisher`, which displays via an `ipywidgets` widget.