### PR TITLE
BUG: don't use assert_almost_equal with object arrays

### DIFF
--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -582,7 +582,7 @@ def assert_array_equal(result,
             compare_datetime_arrays,
             header='Arrays are not equal',
         )
-    elif array_decimal is not None:
+    elif array_decimal is not None and expected_dtype.kind != 'O':
         f = partial(
             np.testing.assert_array_almost_equal,
             decimal=array_decimal,


### PR DESCRIPTION
When comparing collections recursively, you may want to compare float arrays
with fuzzy equality, but not all objects (like str) work with almost equal, so
it will fail. We almost never use numeric-like object arrays, so it seems like
this should be the default behavior.