### PR TITLE
BUG: Handle different counts of terms being computed between chunks.

### DIFF
--- a/tests/pipeline/base.py
+++ b/tests/pipeline/base.py
@@ -109,11 +109,16 @@ class BaseUSEquityPipelineTestCase(WithTradingSessions,
         initial_workspace.setdefault(AssetExists(), mask_values)
         initial_workspace.setdefault(InputDates(), dates)
 
+        refcounts = graph.initial_refcounts(initial_workspace)
+        execution_order = graph.execution_order(initial_workspace, refcounts)
+
         return engine.compute_chunk(
             graph=graph,
             dates=dates,
             sids=sids,
-            initial_workspace=initial_workspace,
+            workspace=initial_workspace,
+            execution_order=execution_order,
+            refcounts=refcounts,
             hooks=NoHooks(),
         )
 

--- a/zipline/pipeline/graph.py
+++ b/zipline/pipeline/graph.py
@@ -45,7 +45,9 @@ class TermGraph(object):
     -------
     ordered()
         Return a topologically-sorted iterator over the terms in self.
-    execution_order(refcounts)
+    execution_order(workspace, refcounts)
+        Return a topologically-sorted iterator over the terms in self, skipping
+        entries in ``workspace`` and entries with refcounts of zero.
 
     See Also
     --------
@@ -110,14 +112,29 @@ class TermGraph(object):
         """
         return SCREEN_NAME
 
-    def execution_order(self, refcounts):
+    def execution_order(self, workspace, refcounts):
         """
-        Return a topologically-sorted iterator over the terms in ``self`` which
+        Return a topologically-sorted list of the terms in ``self`` which
         need to be computed.
+
+        Filters out any terms that are already present in ``workspace``, as
+        well as any terms with refcounts of 0.
+
+        Parameters
+        ----------
+        workspace : dict[Term, np.ndarray]
+            Initial state of workspace for a pipeline execution. May contain
+            pre-computed values provided by ``populate_initial_workspace``.
+        refcounts : dict[Term, int]
+            Reference counts for terms to be computed. Terms with reference
+            counts of 0 do not need to be computed.
         """
-        return iter(nx.topological_sort(
+        return list(nx.topological_sort(
             self.graph.subgraph(
-                {term for term, refcount in refcounts.items() if refcount > 0},
+                {
+                    term for term, refcount in refcounts.items()
+                    if refcount > 0 and term not in workspace
+                },
             ),
         ))
 
@@ -242,14 +259,6 @@ class ExecutionPlan(TermGraph):
     extra_rows
     outputs
     offset
-
-    Methods
-    -------
-    ordered()
-        Return a topologically-sorted iterator over the terms in self.
-    execution_order(self, refcounts)
-        Return a topologically-sorted iterator over the terms in self, skipping
-        entries with refcounts of zero.
     """
     def __init__(self,
                  domain,

--- a/zipline/pipeline/hooks/iface.py
+++ b/zipline/pipeline/hooks/iface.py
@@ -30,7 +30,7 @@ class PipelineHooks(Interface):
     Methods
     -------
     running_pipeline(self, pipeline, start_date, end_date, chunked)
-    computing_chunk(self, plan, initial_workspace, start_date, end_date)
+    computing_chunk(self, terms, start_date, end_date)
     loading_terms(self, terms)
     computing_term(self, term):
     """
@@ -40,19 +40,50 @@ class PipelineHooks(Interface):
         """
         Contextmanager entered during execution of run_pipeline or
         run_chunked_pipeline.
+
+        Parameters
+        ----------
+        pipeline : zipline.pipeline.Pipeline
+            The pipeline being executed.
+        start_date : pd.Timestamp
+            First date of the execution.
+        end_date : pd.Timestamp
+            Last date of the execution.
         """
 
     @contextmanager
-    def computing_chunk(self, plan, initial_workspace, start_date, end_date):
-        """Contextmanager entered during execution of compute_chunk.
+    def computing_chunk(self, terms, start_date, end_date):
+        """
+        Contextmanager entered during execution of compute_chunk.
+
+        Parameters
+        ----------
+        terms : list[zipline.pipeline.term.Term]
+            List of terms, in execution order, that will be computed. This
+            value may change between chunks if ``populate_initial_workspace``
+            prepopulates different terms at different times.
+        start_date : pd.Timestamp
+            First date of the chunk.
+        end_date : pd.Timestamp
+            Last date of the chunk.
         """
 
     @contextmanager
     def loading_terms(self, terms):
         """Contextmanager entered when loading a batch of LoadableTerms.
+
+        Parameters
+        ----------
+        terms : list[zipline.pipeline.term.LoadableTerm]
+            Terms being loaded.
         """
 
     @contextmanager
     def computing_term(self, term):
         """Contextmanager entered when computing a ComputableTerm.
+
+        Parameters
+        ----------
+        terms : zipline.pipeline.term.ComputableTerm
+            Terms being computed.
         """

--- a/zipline/pipeline/hooks/no.py
+++ b/zipline/pipeline/hooks/no.py
@@ -13,7 +13,7 @@ class NoHooks(implements(PipelineHooks)):
         yield
 
     @contextmanager
-    def computing_chunk(self, plan, initial_workspace, start_date, end_date):
+    def computing_chunk(self, terms, start_date, end_date):
         yield
 
     @contextmanager

--- a/zipline/pipeline/hooks/progress.py
+++ b/zipline/pipeline/hooks/progress.py
@@ -73,32 +73,21 @@ class ProgressHooks(implements(PipelineHooks)):
             self._reset_transient_state()
 
     @contextmanager
-    def computing_chunk(self, plan, initial_workspace, start_date, end_date):
+    def computing_chunk(self, terms, start_date, end_date):
         # Set up model on first compute_chunk call.
         if self._model is None:
             self._publisher = self._publisher_factory()
             self._model = ProgressModel(
-                nterms=len(plan),
                 start_date=self._start_date,
                 end_date=self._end_date,
             )
 
-        # Account for terms that were pre-computed by
-        # populate_initial_workspace. We take the intersection of
-        # initial_workspace and plan because AssetExists() and InputDates() are
-        # always in the initial workspace even if they're not needed, and we
-        # don't want to increment progress for those terms if they aren't
-        # actually part of the plan.
-        precomputed = [t for t in initial_workspace if t in plan]
-
         try:
-            self._model.start_chunk(start_date, end_date)
-            if precomputed:
-                self._model.load_precomputed_terms(precomputed)
+            self._model.start_chunk(terms, start_date, end_date)
             self._publish()
             yield
         finally:
-            self._model.finish_chunk(start_date, end_date)
+            self._model.finish_chunk(terms, start_date, end_date)
             self._publish()
 
     @contextmanager
@@ -163,23 +152,30 @@ class ProgressModel(object):
         List of terms currently being loaded or computed.
     """
 
-    def __init__(self, nterms, start_date, end_date):
+    def __init__(self, start_date, end_date):
         self._start_date = start_date
         self._end_date = end_date
 
         # +1 to be inclusive of end_date.
-        total_days = (end_date - start_date).days + 1
-        self._max_progress = total_days * nterms
-
-        self._progress = 0
+        self._total_days = (end_date - start_date).days + 1
+        self._progress = 0.0
         self._days_completed = 0
 
         self._state = 'init'
 
+        # Number of days in current chunk.
         self._current_chunk_size = None
+
+        # (start_date, end_date) of current chunk.
         self._current_chunk_bounds = None
+
+        # What % of overall progress is each term worth in the current chunk?
+        self._current_increment = None
+
+        # Terms currently being computed.
         self._current_work = None
 
+        # Tracking state for total elapsed time.
         self._start_time = time.time()
         self._end_time = None
 
@@ -190,7 +186,7 @@ class ProgressModel(object):
 
     @property
     def percent_complete(self):
-        return 100.0 * float(self._progress) / self._max_progress
+        return round(self._progress * 100.0, 3)
 
     @property
     def execution_time(self):
@@ -213,20 +209,19 @@ class ProgressModel(object):
         return self._current_work
 
     # These methods form the interface for ProgressHooks.
-    def start_chunk(self, start_date, end_date):
+    def start_chunk(self, terms, start_date, end_date):
         days_since_start = (end_date - self._start_date).days + 1
         self._current_chunk_size = days_since_start - self._days_completed
         self._current_chunk_bounds = (start_date, end_date)
 
-    def finish_chunk(self, start_date, end_date):
-        self._days_completed += self._current_chunk_size
+        # What percent of our overall progress will happen in this chunk?
+        chunk_percent = float(self._current_chunk_size) / self._total_days
 
-    # There's no begin/end for this because we get all the precomputed terms by
-    # diffing ``initial_workspace`` with ``plan`` in ``computing_chunk``.
-    def load_precomputed_terms(self, terms):
-        self._state = 'loading'
-        self._current_work = terms
-        self._increment_progress(nterms=len(terms))
+        # How much of that is associated with each completed term?
+        self._current_increment = chunk_percent / len(terms)
+
+    def finish_chunk(self, terms, start_date, end_date):
+        self._days_completed += self._current_chunk_size
 
     def start_load_terms(self, terms):
         self._state = 'loading'
@@ -250,7 +245,7 @@ class ProgressModel(object):
             self._state = 'error'
 
     def _increment_progress(self, nterms):
-        self._progress += nterms * self._current_chunk_size
+        self._progress += nterms * self._current_increment
 
 
 try:

--- a/zipline/pipeline/loaders/testing.py
+++ b/zipline/pipeline/loaders/testing.py
@@ -13,9 +13,12 @@ def make_eye_loader(dates, sids):
     return EyeLoader(TestingDataSet.columns, dates, sids)
 
 
-def make_seeded_random_loader(seed, dates, sids):
+def make_seeded_random_loader(seed,
+                              dates,
+                              sids,
+                              columns=TestingDataSet.columns):
     """
     Make a PipelineLoader that emits random arrays seeded with `seed` for the
     columns in ``TestingDataSet``.
     """
-    return SeededRandomLoader(seed, TestingDataSet.columns, dates, sids)
+    return SeededRandomLoader(seed, columns, dates, sids)

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -23,6 +23,7 @@ from zipline.finance.asset_restrictions import NoRestrictions
 from zipline.utils.memoize import classlazyval
 from zipline.pipeline import SimplePipelineEngine
 from zipline.pipeline.data import USEquityPricing
+from zipline.pipeline.data.testing import TestingDataSet
 from zipline.pipeline.domain import GENERIC, US_EQUITIES
 from zipline.pipeline.loaders import USEquityPricingLoader
 from zipline.pipeline.loaders.testing import make_seeded_random_loader
@@ -1755,6 +1756,7 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
             cls.SEEDED_RANDOM_PIPELINE_SEED,
             cls.trading_days,
             cls._sids,
+            columns=cls.make_seeded_random_loader_columns(),
         )
         cls.seeded_random_engine = SimplePipelineEngine(
             get_loader=lambda column: loader,
@@ -1773,6 +1775,10 @@ class WithSeededRandomPipelineEngine(WithTradingSessions, WithAssetFinder):
     @classmethod
     def make_seeded_random_populate_initial_workspace(cls):
         return None
+
+    @classmethod
+    def make_seeded_random_loader_columns(cls):
+        return TestingDataSet.columns
 
     def raw_expected_values(self, column, start_date, end_date):
         """


### PR DESCRIPTION
Fixes a bug where we miscomputed progress when the set of terms provided by
populate_initial_workspace changed between chunks.

The algorithm for accumulating progress is now as follows:

1. For each chunk, compute the percentage of the pipeline execution that the
   chunk will account for (we already did this to determine how to weight the
   contribution of each term).

2. Within each chunk, divide the total percentage to be completed by the number
   of terms that will actually be loaded or computed. This required two
   upstream refactors:
   1. We now compute ``execution_order`` earlier and pass it to
      ``compute_chunk``.
   2. We now filter out pre-populated terms from ``execution_order``.

3. For each term we load or compute, increment the total progress percentage by
   the value computed in (2).

The end result of this is that, at the end of each chunk, we should progress to
the percentage that corresponds to the chunk end's location in the overall
pipeline execution. Within each chunk, we should progress by a uniform amount
with each term. That uniform amount may vary from chunk to chunk however, if we
compute different numbers of terms in each chunk.