### PR TITLE
ENH: remove some extra copies

### DIFF
--- a/zipline/lib/adjusted_array.py
+++ b/zipline/lib/adjusted_array.py
@@ -290,7 +290,7 @@ class AdjustedArray(object):
 
         data = self._data
         if copy:
-            data = data.copy()
+            data = data.copy(order='F')
         else:
             self._invalidated = True
 


### PR DESCRIPTION
When calling traverse, copy only if the `refcount > 1` meaning that we will re-traverse this array.

In `adjusted_array` don't copy the input data if it is already the proper dtype.