### PR TITLE
DOC: Fix incorrect package name

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -52,7 +52,7 @@ dependencies:
 
 .. code-block:: bash
 
-   $ sudo dnf install atlas-devel gcc-c++ gcc-gfortran libgfortran python-devel redhat-rep-config
+   $ sudo dnf install atlas-devel gcc-c++ gcc-gfortran libgfortran python-devel redhat-rpm-config
 
 On `Arch Linux`_, you can acquire the additional dependencies via ``pacman``:
 


### PR DESCRIPTION
There is no `redhat-rep-config` package in RHEL-derived Linux
distributions like Fedora. There is a `redhat-rpm-config` package
though.