### PR TITLE
BLD: Avoid installing `futures` with Python 3

### DIFF
--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -49,7 +49,7 @@ matplotlib==1.5.3
 Markdown==2.6.2
 
 # Checking for old PIP packages
-futures==3.0.5
+futures==3.0.5; python_version < '3.0'
 requests-futures==0.9.7
 piprot==0.9.6
 


### PR DESCRIPTION
The package does not work on Python 3 due to Python 2 syntax being used
in the codebase. Python 3 users should not attempt to install it, since
the package is already included in the standard library.