### PR TITLE
ENH: BoundColumn comparisons now result in an error

### DIFF
--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -99,5 +99,3 @@ class LatestTestCase(WithSeededRandomPipelineEngine,
 
             with self.assertRaises(BoundColumnInvalidCompare):
                 compare(column, 'test')
-
-            

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -112,11 +112,11 @@ class LatestTestCase(WithSeededRandomPipelineEngine,
 
         with self.assertRaises(TypeError) as e:
             column < 1000
-            self.assertEqual(str(e), err_msg)
+        self.assertEqual(str(e.exception), err_msg)
 
         with self.assertRaises(TypeError) as e:
-            1000 < column
-            self.assertEqual(str(e), err_msg)
+            1000 > column
+        self.assertEqual(str(e.exception), err_msg)
 
         try:
             column.latest < 1000

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -1,11 +1,14 @@
 """
 Tests BoundColumn attributes and methods.
 """
+import operator
 from unittest import skipIf
 
+from nose_parameterized import parameterized
 from pandas import Timestamp, DataFrame
 from pandas.util.testing import assert_frame_equal
 
+from zipline.errors import BoundColumnInvalidCompare
 from zipline.lib.labelarray import LabelArray
 from zipline.pipeline import Pipeline
 from zipline.pipeline.data.testing import TestingDataSet as TDS
@@ -81,3 +84,20 @@ class LatestTestCase(WithSeededRandomPipelineEngine,
 
             expected_col_result = self.expected_latest(column, cal_slice)
             assert_frame_equal(col_result, expected_col_result)
+
+    @parameterized.expand([
+        (operator.gt,),
+        (operator.ge,),
+        (operator.lt,),
+        (operator.le,),
+    ])
+    def test_comparison_errors(self, compare):
+        columns = TDS.columns
+        for column in columns:
+            with self.assertRaises(BoundColumnInvalidCompare):
+                compare(column, 1000)
+
+            with self.assertRaises(BoundColumnInvalidCompare):
+                compare(column, 'test')
+
+            

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -105,20 +105,15 @@ class LatestTestCase(WithSeededRandomPipelineEngine,
     def test_comparison_error_message(self):
         column = USEquityPricing.volume
         err_msg = (
-            "'<' not supported between instance of"
-            " 'int' and 'EquityPricing<US>.volume'."
-            " Did you mean to use 'EquityPricing<US>.volume.latest'?"
+            "Can't compare 'EquityPricing<US>.volume' with 'int'."
+            " (Did you mean to use '.latest'?)"
         )
 
         with self.assertRaises(TypeError) as e:
             column < 1000
         self.assertEqual(str(e.exception), err_msg)
 
-        with self.assertRaises(TypeError) as e:
-            1000 > column
-        self.assertEqual(str(e.exception), err_msg)
-
         try:
             column.latest < 1000
-        except Exception:
+        except TypeError:
             self.fail()

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -866,6 +866,6 @@ class BoundColumnInvalidCompare(ZiplineError):
     Frequently occurs when users forget to use '.latest'.
     """
     msg = (
-        "Can't compare BoundColumn with {other}.  Did you mean to append "
+        "Can't compare {column!s} with {other.__class__}.  Did you mean to append "
         ".latest?"
     )

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -858,14 +858,3 @@ class IncompatibleTerms(ZiplineError):
         "{term_1} and {term_2} must have the same mask in order to compute "
         "correlations and regressions asset-wise."
     )
-
-
-class BoundColumnInvalidCompare(ZiplineError):
-    """
-    Raised when trying to use BoundColumn with a comparison operator.
-    Frequently occurs when users forget to use '.latest'.
-    """
-    msg = (
-        "Can't compare {column!s} with {other.__class__}.  Did you mean to "
-        "append .latest?"
-    )

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -866,6 +866,6 @@ class BoundColumnInvalidCompare(ZiplineError):
     Frequently occurs when users forget to use '.latest'.
     """
     msg = (
-        "Can't compare {column!s} with {other.__class__}.  Did you mean to append "
-        ".latest?"
+        "Can't compare {column!s} with {other.__class__}.  Did you mean to "
+        "append .latest?"
     )

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -858,3 +858,14 @@ class IncompatibleTerms(ZiplineError):
         "{term_1} and {term_2} must have the same mask in order to compute "
         "correlations and regressions asset-wise."
     )
+
+
+class BoundColumnInvalidCompare(ZiplineError):
+    """
+    Raised when trying to use BoundColumn with a comparison operator.  
+    Frequently occurs when users forget to use '.latest'.
+    """
+    msg = (
+        "Can't compare BoundColumn with {other}.  Did you mean to append "
+        ".latest?"
+    )

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -862,7 +862,7 @@ class IncompatibleTerms(ZiplineError):
 
 class BoundColumnInvalidCompare(ZiplineError):
     """
-    Raised when trying to use BoundColumn with a comparison operator.  
+    Raised when trying to use BoundColumn with a comparison operator.
     Frequently occurs when users forget to use '.latest'.
     """
     msg = (

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -175,16 +175,16 @@ class BoundColumn(LoadableTerm):
             doc,
             frozenset(sorted(metadata.items(), key=first)),
         )
-    
+
     def __gt__(self, other):
         raise BoundColumnInvalidCompare(other=type(other))
-    
+
     def __ge__(self, other):
         raise BoundColumnInvalidCompare(other=type(other))
-    
+
     def __lt__(self, other):
         raise BoundColumnInvalidCompare(other=type(other))
-    
+
     def __le__(self, other):
         raise BoundColumnInvalidCompare(other=type(other))
 

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -10,6 +10,7 @@ from six import (
 )
 from toolz import first
 
+from zipline.errors import BoundColumnInvalidCompare
 from zipline.pipeline.classifiers import Classifier, Latest as LatestClassifier
 from zipline.pipeline.domain import Domain, GENERIC
 from zipline.pipeline.factors import Factor, Latest as LatestFactor
@@ -174,6 +175,18 @@ class BoundColumn(LoadableTerm):
             doc,
             frozenset(sorted(metadata.items(), key=first)),
         )
+    
+    def __gt__(self, other):
+        raise BoundColumnInvalidCompare(other=type(other))
+    
+    def __ge__(self, other):
+        raise BoundColumnInvalidCompare(other=type(other))
+    
+    def __lt__(self, other):
+        raise BoundColumnInvalidCompare(other=type(other))
+    
+    def __le__(self, other):
+        raise BoundColumnInvalidCompare(other=type(other))
 
     def specialize(self, domain):
         """Specialize ``self`` to a concrete domain.

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -175,31 +175,11 @@ class BoundColumn(LoadableTerm):
             frozenset(sorted(metadata.items(), key=first)),
         )
 
-    _compare_error_msg = (
-        "'{op}' not supported between instance of "
-        "'{other.__class__.__name__}' and '{column.qualname}'. "
-        "Did you mean to use '{column.qualname}.latest'?"
-    )
-
-    def __gt__(self, other):
-        raise TypeError(
-            self._compare_error_msg.format(op='>', other=other, column=self)
-        )
-
-    def __ge__(self, other):
-        raise TypeError(
-            self._compare_error_msg.format(op='>=', other=other, column=self)
-        )
-
     def __lt__(self, other):
-        raise TypeError(
-            self._compare_error_msg.format(op='<', other=other, column=self)
-        )
+        msg = "Can't compare '{}' with '{}'. (Did you mean to use '.latest'?)"
+        raise TypeError(msg.format(self.qualname, other.__class__.__name__))
 
-    def __le__(self, other):
-        raise TypeError(
-            self._compare_error_msg.format(op='<=', other=other, column=self)
-        )
+    __gt__ = __le__ = __ge__ = __lt__
 
     def specialize(self, domain):
         """Specialize ``self`` to a concrete domain.

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -175,24 +175,31 @@ class BoundColumn(LoadableTerm):
             frozenset(sorted(metadata.items(), key=first)),
         )
 
-    def compare_error_msg(self, op, other):
-        return (
-            "'{op}' not supported between instance of "
-            "'{other.__class__.__name__}' and '{column}'. "
-            "Did you mean use '.latest' with '{column}'?"
-        ).format(op=op, other=other, column=self)
+    _compare_error_msg = (
+        "'{op}' not supported between instance of "
+        "'{other.__class__.__name__}' and '{column.qualname}'. "
+        "Did you mean use '{column.qualname}.latest'?"
+    )
 
     def __gt__(self, other):
-        raise TypeError(self.compare_error_msg(op='>', other=other))
+        raise TypeError(
+            self._compare_error_msg.format(op='>', other=other, column=self)
+        )
 
     def __ge__(self, other):
-        raise TypeError(self.compare_error_msg(op='>=', other=other))
+        raise TypeError(
+            self._compare_error_msg.format(op='>=', other=other, column=self)
+        )
 
     def __lt__(self, other):
-        raise TypeError(self.compare_error_msg(op='<', other=other))
+        raise TypeError(
+            self._compare_error_msg.format(op='<', other=other, column=self)
+        )
 
     def __le__(self, other):
-        raise TypeError(self.compare_error_msg(op='<=', other=other))
+        raise TypeError(
+            self._compare_error_msg.format(op='<=', other=other, column=self)
+        )
 
     def specialize(self, domain):
         """Specialize ``self`` to a concrete domain.

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -10,7 +10,6 @@ from six import (
 )
 from toolz import first
 
-from zipline.errors import BoundColumnInvalidCompare
 from zipline.pipeline.classifiers import Classifier, Latest as LatestClassifier
 from zipline.pipeline.domain import Domain, GENERIC
 from zipline.pipeline.factors import Factor, Latest as LatestFactor
@@ -176,17 +175,24 @@ class BoundColumn(LoadableTerm):
             frozenset(sorted(metadata.items(), key=first)),
         )
 
+    def compare_error_msg(self, op, other):
+        return (
+            "'{op}' not supported between instance of "
+            "'{other.__class__.__name__}' and '{column}'. "
+            "Did you mean use '.latest' with '{column}'?"
+        ).format(op=op, other=other, column=self)
+
     def __gt__(self, other):
-        raise BoundColumnInvalidCompare(column=self, other=other)
+        raise TypeError(self.compare_error_msg(op='>', other=other))
 
     def __ge__(self, other):
-        raise BoundColumnInvalidCompare(column=self, other=other)
+        raise TypeError(self.compare_error_msg(op='>=', other=other))
 
     def __lt__(self, other):
-        raise BoundColumnInvalidCompare(column=self, other=other)
+        raise TypeError(self.compare_error_msg(op='<', other=other))
 
     def __le__(self, other):
-        raise BoundColumnInvalidCompare(column=self, other=other)
+        raise TypeError(self.compare_error_msg(op='<=', other=other))
 
     def specialize(self, domain):
         """Specialize ``self`` to a concrete domain.

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -178,7 +178,7 @@ class BoundColumn(LoadableTerm):
     _compare_error_msg = (
         "'{op}' not supported between instance of "
         "'{other.__class__.__name__}' and '{column.qualname}'. "
-        "Did you mean use '{column.qualname}.latest'?"
+        "Did you mean to use '{column.qualname}.latest'?"
     )
 
     def __gt__(self, other):

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -177,16 +177,16 @@ class BoundColumn(LoadableTerm):
         )
 
     def __gt__(self, other):
-        raise BoundColumnInvalidCompare(other=type(other))
+        raise BoundColumnInvalidCompare(column=self, other=other)
 
     def __ge__(self, other):
-        raise BoundColumnInvalidCompare(other=type(other))
+        raise BoundColumnInvalidCompare(column=self, other=other)
 
     def __lt__(self, other):
-        raise BoundColumnInvalidCompare(other=type(other))
+        raise BoundColumnInvalidCompare(column=self, other=other)
 
     def __le__(self, other):
-        raise BoundColumnInvalidCompare(other=type(other))
+        raise BoundColumnInvalidCompare(column=self, other=other)
 
     def specialize(self, domain):
         """Specialize ``self`` to a concrete domain.


### PR DESCRIPTION
Added rich comparison ordering methods to BoundColumn class to prevent users from comparing BoundColumn with anything.  Mainly to prevent the case where users accidentally write `EquityPricing.volume > 1000` instead of `EquityPricing.volume.latest > 1000`.