### PR TITLE
DOC: Update contributing notes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,16 @@ If you are looking to start working with the Zipline codebase, navigate to the G
 
 Feel free to ask questions on the `mailing list <https://groups.google.com/forum/#!forum/zipline>`_ or on `Gitter <https://gitter.im/quantopian/zipline>`_.
 
+.. note::
+
+   Please note that Zipline is not a community-led project. Zipline is
+   maintained by the Quantopian engineering team, and we are quite small and
+   often busy.
+
+   Because of this, we want to warn you that we may not attend to your pull
+   request, issue, or direct mention in months, or even years. We hope you
+   understand, and we hope that this note might help reduce any frustration or
+   wasted time.
 
 
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg


### PR DESCRIPTION
This could be added to the `development-guidelines.rst` in the documentation instead (or apart from).

I think it is important to be clear in this respect to avoid frustration and to avoid wasting your time or anybody's time.

Examples of:

- Ignored PRs for years or months: https://github.com/quantopian/zipline/pull/1976, https://github.com/quantopian/zipline/pull/1804, https://github.com/quantopian/zipline/pull/2510, https://github.com/quantopian/zipline/pull/2512
- Closed PR implementing the same solution on your own: https://github.com/quantopian/zipline/pull/2511

Those are just based on my experience, but I am guessing I am not being treated differently and this may apply to anybody contributing to the project.

Also, it seems clear from the Git logs that you are not really integrating much contributions from the community:

```
git log --merges --pretty=format:"%h %<(15)%ar %s"
```

In the last year in particular, it seems all merged changes were from Quantopian and none from external/community contributions.