### PR TITLE
(fix) Add  'tables': '<=3.4.3' to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ REQ_UPPER_BOUNDS = {
     'bcolz': '<1',
     'pandas': '<=0.22',
     'networkx': '<2.0',
+    'tables': '<=3.4.3',
 }
 
 


### PR DESCRIPTION
Added 'tables': '<=3.4.3' to REQ_UPPER_BOUNDS in setup.py . Docker install tries to install tables 3.6 which is python 3.5 incompatible. docker install worked correctly after changes.