### PR TITLE
BUG: Fix bug concatenating empty chunks with strings.

### DIFF
--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -1522,10 +1522,14 @@ class ChunkedPipelineTestCase(zf.WithSeededRandomPipelineEngine,
                     inputs=[TestingDataSet.float_col],
                     window_length=10,
                 ),
-                'categorical': TestingDataSet.categorical_col.latest,
             },
             domain=US_EQUITIES,
         )
+
+        if not new_pandas:
+            # Categoricals only work on old pandas.
+            pipe.add(TestingDataSet.categorical_col.latest, 'categorical')
+
         pipeline_result = self.run_pipeline(
             pipe,
             start_date=self.PIPELINE_START_DATE,
@@ -1557,13 +1561,16 @@ class ChunkedPipelineTestCase(zf.WithSeededRandomPipelineEngine,
             columns={
                 'float': TestingDataSet.float_col.latest,
                 'bool': TestingDataSet.bool_col.latest,
-                'categorical': TestingDataSet.categorical_col.latest,
             },
             # Define a screen that's False for all assets a significant portion
             # of the time.
             screen=FalseOnOddMonths(),
             domain=US_EQUITIES,
         )
+
+        if not new_pandas:
+            # Categoricals only work on old pandas.
+            pipe.add(TestingDataSet.categorical_col.latest, 'categorical')
 
         self.run_chunked_pipeline(
             pipeline=pipe,

--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -348,7 +348,10 @@ class SimplePipelineEngine(PipelineEngine):
             # if we don't have to.
             return chunks[0]
 
-        return categorical_df_concat(chunks, inplace=True)
+        # Filter out empty chunks. Empty dataframes lose dtype information,
+        # which makes concatenation fail.
+        nonempty_chunks = [c for c in chunks if len(c)]
+        return categorical_df_concat(nonempty_chunks, inplace=True)
 
     def run_pipeline(self, pipeline, start_date, end_date, hooks=None):
         """

--- a/zipline/utils/pandas_utils.py
+++ b/zipline/utils/pandas_utils.py
@@ -274,10 +274,8 @@ def categorical_df_concat(df_list, inplace=False):
     categorical_columns = df.columns[df.dtypes == 'category']
 
     for col in categorical_columns:
-        new_categories = sorted(
-            set().union(
-                *(frame[col].cat.categories for frame in df_list)
-            )
+        new_categories = _sort_set_none_first(
+            _union_all(frame[col].cat.categories for frame in df_list)
         )
 
         with ignore_pandas_nan_categorical_warning():
@@ -285,6 +283,25 @@ def categorical_df_concat(df_list, inplace=False):
                 df[col].cat.set_categories(new_categories, inplace=True)
 
     return pd.concat(df_list)
+
+
+def _union_all(iterables):
+    """Union entries in ``iterables`` into a set.
+    """
+    return set().union(*iterables)
+
+
+def _sort_set_none_first(set_):
+    """Sort a set, sorting ``None`` before other elements, if present.
+    """
+    if None in set_:
+        set_.remove(None)
+        out = [None]
+        out.extend(sorted(set_))
+        set_.add(None)
+        return out
+    else:
+        return sorted(set_)
 
 
 def empty_dataframe(*columns):


### PR DESCRIPTION
Fixes a bug where running chunked pipelines containing string columns would
fail if some of the chunks were completely empty. We failed because the empty
chunks would have different dtypes (all `object`) than the non-empty chunks,
because pandas can't determine a dtype for an empty DataFrame.

We fix the bug by filtering out empty chunks before concatenation.