### PR TITLE
MAINT: Fix SyntaxError in python 3.7+

### DIFF
--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -326,7 +326,7 @@ def _check_symbol_mappings(df, exchanges, asset_exchange):
                     for (symbol, country_code), (intersections, cs) in sorted(
                         ambigious.items(),
                         key=first,
-                    ),
+                    )
                 ),
             )
         )

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -659,7 +659,7 @@ class AssetFinder(object):
                 for sid_group in partition_all(
                     SQLITE_MAX_VARIABLE_NUMBER,
                     sids
-                ),
+                )
             )
         }
 


### PR DESCRIPTION
as per https://bugs.python.org/issue32012
"Disallow ambiguous syntax f(x for x in [1],)"