### PR TITLE
ENH: Prototype currency conversions for EquityPricing.

### DIFF
--- a/conda/iso4217/meta.yaml
+++ b/conda/iso4217/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "python -m pip install . -vv"
 
 requirements:
   host:

--- a/conda/iso4217/meta.yaml
+++ b/conda/iso4217/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "iso4217" %}
+{% set version = "1.6.20180829" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 33f404b5eeb3cb8572f132b7c697782eccffeb00630900f305244ffa058e875c
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - iso4217
+
+about:
+  home: "https://github.com/dahlia/iso4217"
+  license: Public Domain
+  license_family: PUBLIC-DOMAIN
+  license_file:
+  summary: "ISO 4217 currency data package for Python"
+  doc_url:
+  dev_url:
+
+extra:
+  recipe-maintainers: ''

--- a/conda/python-interface/meta.yaml
+++ b/conda/python-interface/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "python-interface" %}
-{% set version = "1.5.1" %}
+{% set version = "1.5.3" %}
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_value = "7a79690b3340df7d01d81028c18f66488e5a7c504841ecdc8542d50a6984f8be" %}
+{% set hash_value = "697cdfafc421d7b6919bbc5768730af7b8f27906fd35ecbf40553ec911bdc48f" %}
 
 package:
   name: '{{ name|lower }}'

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -91,7 +91,7 @@ tables==3.4.3
 trading-calendars==1.11.1
 
 # Interface definitions.
-python-interface==1.5.1
+python-interface==1.5.3
 funcsigs==1.0.2
 typing==3.6.2
 

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -97,3 +97,4 @@ typing==3.6.2
 
 # Country Codes
 iso3166==0.9
+iso4217==1.6.20180829

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -97,4 +97,6 @@ typing==3.6.2
 
 # Country Codes
 iso3166==0.9
+
+# Currency Codes
 iso4217==1.6.20180829

--- a/tests/data/test_adjustments.py
+++ b/tests/data/test_adjustments.py
@@ -20,14 +20,14 @@ from zipline.testing.fixtures import (
 nat = pd.Timestamp('nat')
 
 
-class TestSQLiteAdjustementsWriter(WithTradingCalendars,
-                                   WithInstanceTmpDir,
-                                   WithLogger,
-                                   ZiplineTestCase):
+class TestSQLiteAdjustmentsWriter(WithTradingCalendars,
+                                  WithInstanceTmpDir,
+                                  WithLogger,
+                                  ZiplineTestCase):
     make_log_handler = logbook.TestHandler
 
     def init_instance_fixtures(self):
-        super(TestSQLiteAdjustementsWriter, self).init_instance_fixtures()
+        super(TestSQLiteAdjustmentsWriter, self).init_instance_fixtures()
         self.db_path = self.instance_tmpdir.getpath('adjustments.db')
 
     def writer(self, session_bar_reader):
@@ -54,7 +54,11 @@ class TestSQLiteAdjustementsWriter(WithTradingCalendars,
             for key in ('open', 'high', 'low', 'close', 'volume')
         }
 
-        return InMemoryDailyBarReader(frames, self.trading_calendar)
+        return InMemoryDailyBarReader(
+            frames,
+            self.trading_calendar,
+            currency_codes=pd.Series(index=sids, data='USD'),
+        )
 
     def writer_without_pricing(self, dates, sids):
         return self.writer(self.empty_in_memory_reader(dates, sids))
@@ -68,7 +72,11 @@ class TestSQLiteAdjustementsWriter(WithTradingCalendars,
         frames = {'close': close}
         for key in 'open', 'high', 'low', 'volume':
             frames[key] = nan_frame
-        return InMemoryDailyBarReader(frames, self.trading_calendar)
+        return InMemoryDailyBarReader(
+            frames,
+            self.trading_calendar,
+            currency_codes=pd.Series(index=close.columns, data='USD'),
+        )
 
     def writer_from_close(self, close):
         return self.writer(self.in_memory_reader_for_close(close))

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -945,7 +945,7 @@ class SyntheticBcolzTestCase(zf.WithAdjustmentReader,
         super(SyntheticBcolzTestCase, cls).init_class_fixtures()
         cls.all_asset_ids = cls.asset_finder.sids
         cls.last_asset_end = cls.equity_info['end_date'].max()
-        cls.pipeline_loader = EquityPricingLoader(
+        cls.pipeline_loader = EquityPricingLoader.without_fx(
             cls.bcolz_equity_daily_bar_reader,
             cls.adjustment_reader,
         )

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -290,7 +290,10 @@ class InternationalEquityTestCase(WithInternationalPricingPipelineEngine,
 
         sessions = self.daily_bar_sessions[calendar_name]
 
-        start, end = sessions[[-17, -10]]
+        # The dates here are arbitrary. We're just running a couple days in the
+        # middle of the data that's configured in this suite.
+        execution_sessions = sessions[-17:-9]
+        start, end = execution_sessions[[0, -1]]
         result = self.run_pipeline(pipe, start, end)
 
         # Raw closes as a (dates, assets) dataframe.
@@ -321,7 +324,8 @@ class InternationalEquityTestCase(WithInternationalPricingPipelineEngine,
                 quote=target,
                 bases=np.array(currency_codes, dtype='S3'),
                 # Exchange rates used for pipeline output with label N should
-                # be from day N - 1.
+                # be from day N - 1, so shift back from `execution_sessions` by
+                # a day.
                 dates=sessions[-18:-10],
             )
 

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -2,6 +2,7 @@
 """
 from itertools import cycle, islice
 
+from nose_parameterized import parameterized
 import numpy as np
 import pandas as pd
 
@@ -56,7 +57,7 @@ class WithInternationalDailyBarData(zf.WithAssetFinder):
         == INTERNATIONAL_PRICING_CURRENCIES.keys()
     )
 
-    EXCHANGE_RATES_CURRENCIES = ["USD", "CAD", "GBP", "EUR"]
+    FX_RATES_CURRENCIES = ["USD", "CAD", "GBP", "EUR"]
 
     @classmethod
     def make_daily_bar_data(cls, assets, calendar, sessions):
@@ -97,6 +98,7 @@ class WithInternationalDailyBarData(zf.WithAssetFinder):
         cls.daily_bar_sessions = {}
         cls.daily_bar_data = {}
         cls.daily_bar_readers = {}
+        cls.daily_bar_currency_codes = {}
 
         for calendar, assets, in cls.assets_by_calendar.items():
             name = calendar.name
@@ -114,14 +116,21 @@ class WithInternationalDailyBarData(zf.WithAssetFinder):
 
             panel = (pd.Panel.from_dict(cls.daily_bar_data[name])
                      .transpose(2, 1, 0))
+
+            cls.daily_bar_currency_codes[name] = cls.make_currency_codes(
+                calendar,
+                assets,
+            )
+
             cls.daily_bar_readers[name] = InMemoryDailyBarReader.from_panel(
                 panel,
                 calendar,
-                currency_codes=cls.make_currency_codes(calendar, assets)
+                currency_codes=cls.daily_bar_currency_codes[name],
             )
 
 
-class WithInternationalPricingPipelineEngine(WithInternationalDailyBarData):
+class WithInternationalPricingPipelineEngine(zf.WithFXRates,
+                                             WithInternationalDailyBarData):
 
     @classmethod
     def init_class_fixtures(cls):
@@ -133,14 +142,17 @@ class WithInternationalPricingPipelineEngine(WithInternationalDailyBarData):
             GB_EQUITIES: EquityPricingLoader(
                 cls.daily_bar_readers['XLON'],
                 adjustments,
+                cls.in_memory_fx_rate_reader,
             ),
             US_EQUITIES: EquityPricingLoader(
                 cls.daily_bar_readers['XNYS'],
                 adjustments,
+                cls.in_memory_fx_rate_reader,
             ),
             CA_EQUITIES: EquityPricingLoader(
                 cls.daily_bar_readers['XTSE'],
                 adjustments,
+                cls.in_memory_fx_rate_reader,
             )
         }
         cls.engine = SimplePipelineEngine(
@@ -258,6 +270,64 @@ class InternationalEquityTestCase(WithInternationalPricingPipelineEngine,
                     self.check_expected_latest_value(
                         calendar, col, date, asset, value,
                     )
+
+    @parameterized.expand([
+        ('US', US_EQUITIES, 'XNYS'),
+        ('CA', CA_EQUITIES, 'XTSE'),
+        ('GB', GB_EQUITIES, 'XLON'),
+    ])
+    def test_currency_convert_prices(self, name, domain, calendar_name):
+        # Test running a pipeline on a domain whose assets are all denominated
+        # in the same currency.
+
+        pipe = Pipeline({
+            'close': EquityPricing.close.latest,
+            'close_USD': EquityPricing.close.fx('USD').latest,
+            'close_CAD': EquityPricing.close.fx('CAD').latest,
+            'close_EUR': EquityPricing.close.fx('EUR').latest,
+            'close_GBP': EquityPricing.close.fx('GBP').latest,
+        }, domain=domain)
+
+        sessions = self.daily_bar_sessions[calendar_name]
+
+        start, end = sessions[[-17, -10]]
+        result = self.run_pipeline(pipe, start, end)
+
+        # Raw closes as a (dates, assets) dataframe.
+        closes_2d = result['close'].unstack(fill_value=np.nan)
+
+        # Currency codes for all sids on this domain.
+        all_currency_codes = self.daily_bar_currency_codes[calendar_name]
+
+        # Currency codes for sids in the pipeline result.
+        currency_codes = all_currency_codes.loc[[
+            a.sid for a in closes_2d.columns
+        ]]
+
+        # For each possible target currency, we should be able to reconstruct
+        # the currency-converted pipeline result by manually fetching exchange
+        # rate values and multiplying by the unconverted pricing values.
+        fx_reader = self.in_memory_fx_rate_reader
+        for target in self.FX_RATES_CURRENCIES:
+
+            # Closes, converted to target currency, as reported by pipeline, as
+            # a (dates, assets) dataframe.
+            result_2d = result['close_' + target].unstack(fill_value=np.nan)
+
+            # (dates, sids) dataframe giving the exchange rate from each
+            # asset's currency to the target currency.
+            expected_rates = fx_reader.get_rates(
+                field='mid',
+                quote=target,
+                bases=np.array(currency_codes, dtype='S3'),
+                # Exchange rates used for pipeline output with label N should
+                # be from day N - 1.
+                dates=sessions[-18:-10],
+            )
+
+            expected_result_2d = closes_2d * expected_rates.values
+
+            assert_equal(result_2d, expected_result_2d)
 
     def test_explicit_specialization_matches_implicit(self):
         pipeline_specialized = Pipeline({

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -496,7 +496,7 @@ class PipelineAlgorithmTestCase(WithMakeAlgo,
     @classmethod
     def init_class_fixtures(cls):
         super(PipelineAlgorithmTestCase, cls).init_class_fixtures()
-        cls.pipeline_loader = USEquityPricingLoader(
+        cls.pipeline_loader = USEquityPricingLoader.without_fx(
             cls.bcolz_equity_daily_bar_reader,
             cls.adjustment_reader,
         )

--- a/tests/pipeline/test_us_equity_pricing_loader.py
+++ b/tests/pipeline/test_us_equity_pricing_loader.py
@@ -509,7 +509,7 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
         )
         self.assertEqual(adjustments, [{}, {}])
 
-        pricing_loader = USEquityPricingLoader(
+        pricing_loader = USEquityPricingLoader.without_fx(
             self.bcolz_equity_daily_bar_reader,
             adjustment_reader,
         )
@@ -589,7 +589,7 @@ class USEquityPricingLoaderTestCase(WithAdjustmentReader,
             shift=-1,
         )
 
-        pricing_loader = USEquityPricingLoader(
+        pricing_loader = USEquityPricingLoader.without_fx(
             self.bcolz_equity_daily_bar_reader,
             self.adjustment_reader,
         )

--- a/zipline/currency.py
+++ b/zipline/currency.py
@@ -1,0 +1,70 @@
+from functools import partial, total_ordering
+
+from iso4217 import Currency as ISO4217Currency
+
+import numpy as np
+
+_ALL_CURRENCIES = {}
+
+
+def strs_to_sids(strs, category_num):
+    """TODO: Improve this.
+    """
+    out = np.full(len(strs), category_num << 50, dtype='i8')
+    casted_buffer = np.ndarray(
+        shape=out.shape,
+        dtype='S6',
+        buffer=out,
+        strides=out.strides,
+    )
+    casted_buffer[:] = np.array(strs, dtype='S6')
+    return out
+
+
+def str_to_sid(str_, category_num):
+    return strs_to_sids([str_], category_num)[0]
+
+
+iso_currency_to_sid = partial(str_to_sid, category_num=3)
+
+
+@total_ordering
+class Currency(object):
+    """A currency identifier, as defined by ISO-4217.
+
+    Parameters
+    ----------
+    code : str
+        ISO-4217 code for the currency.
+    """
+    def __new__(cls, code):
+        try:
+            return _ALL_CURRENCIES[code]
+        except KeyError:
+            iso_currency = ISO4217Currency(code)
+            obj = _ALL_CURRENCIES[code] = super(Currency, cls).__new__(cls)
+            obj._currency = iso_currency
+            obj._sid = iso_currency_to_sid(iso_currency.value)
+            return obj
+
+    @property
+    def code(self):
+        return self._currency.value
+
+    @property
+    def name(self):
+        return self._currency.currency_name
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return NotImplemented
+        return self.code == other.code
+
+    def __lt__(self, other):
+        return self.code < other.code
+
+    def __repr__(self):
+        return "{}({!r})".format(
+            type(self).__name__,
+            self.code
+        )

--- a/zipline/currency.py
+++ b/zipline/currency.py
@@ -36,12 +36,24 @@ class Currency(object):
     ----------
     code : str
         ISO-4217 code for the currency.
+
+    Attributes
+    ----------
+    code : str
+        ISO-4217 currency code for the currency, e.g., 'USD'.
+    name : str
+        Plain english name for the currency, e.g., 'US Dollar'.
     """
     def __new__(cls, code):
         try:
             return _ALL_CURRENCIES[code]
         except KeyError:
-            iso_currency = ISO4217Currency(code)
+            try:
+                iso_currency = ISO4217Currency(code)
+            except ValueError:
+                raise ValueError(
+                    "{!r} is not a valid currency code.".format(code)
+                )
             obj = _ALL_CURRENCIES[code] = super(Currency, cls).__new__(cls)
             obj._currency = iso_currency
             obj._sid = iso_currency_to_sid(iso_currency.value)
@@ -49,16 +61,37 @@ class Currency(object):
 
     @property
     def code(self):
+        """ISO-4217 currency code for the currency.
+
+        Returns
+        -------
+        code : str
+        """
         return self._currency.value
 
     @property
     def name(self):
+        """Plain english name for the currency.
+
+        Returns
+        -------
+        name : str
+        """
         return self._currency.currency_name
+
+    @property
+    def sid(self):
+        """Unique integer identifier for this currency.
+        """
+        return self._sid
 
     def __eq__(self, other):
         if type(self) != type(other):
             return NotImplemented
         return self.code == other.code
+
+    def __hash__(self):
+        return hash(self.code)
 
     def __lt__(self, other):
         return self.code < other.code

--- a/zipline/data/bcolz_daily_bars.py
+++ b/zipline/data/bcolz_daily_bars.py
@@ -34,7 +34,7 @@ from six import iteritems, viewkeys
 from toolz import compose
 from trading_calendars import get_calendar
 
-from zipline.data.session_bars import SessionBarReader
+from zipline.data.session_bars import CurrencyAwareSessionBarReader
 from zipline.data.bar_reader import (
     NoDataAfterDate,
     NoDataBeforeDate,
@@ -373,7 +373,7 @@ class BcolzDailyBarWriter(object):
         return ctable.fromdataframe(processed)
 
 
-class BcolzDailyBarReader(SessionBarReader):
+class BcolzDailyBarReader(CurrencyAwareSessionBarReader):
     """
     Reader for raw pricing data written by BcolzDailyOHLCVWriter.
 
@@ -704,3 +704,7 @@ class BcolzDailyBarReader(SessionBarReader):
                 return price * 0.001
         else:
             return price
+
+    def currency_codes(self, sids):
+        # TODO: Better handling for this.
+        return np.full(len(sids), b'USD', dtype='S3')

--- a/zipline/data/fx.py
+++ b/zipline/data/fx.py
@@ -1,0 +1,60 @@
+"""
+"""
+
+from interface import implements, Interface
+
+
+class FXRateReader(Interface):
+
+    def get_rates(self, field, quote, bases, dates):
+        """
+        Get rates to convert ``bases`` into ``quote``.
+
+        Parameters
+        ----------
+        field : str
+            Currency field to load.
+        quote : str
+            Currency code of the currency into which we want to convert.
+        bases : np.array[S3]
+            Array of codes of the currencies from which we want to convert. A
+            single currency may appear multiple times.
+        dates : pd.DatetimeIndex
+            Dates for which to load currencies.
+
+        Returns
+        -------
+        rates : pd.DataFrame
+            DataFrame indexed by (dates, bases) containing exchange rates
+            mapping from base -> quote currency.
+        """
+
+
+class InMemoryFXRateReader(implements(FXRateReader)):
+    """
+    A simple in-memory FXRateReader.
+
+    This is primarily used for testing.
+
+    Parameters
+    ----------
+    data : dict
+        Nested map from field name -> quote currency -> pd.DataFrame
+        Leaf frames should be indexed by (dates, base currencies).
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    def get_rates(self, field, quote, bases, dates):
+        return self._data[field][quote][bases].reindex(dates, method='ffill')
+
+
+class ExplodingFXRateReader(implements(FXRateReader)):
+    """An FXRateReader that raises an error when used.
+
+    This is useful for testing contexts where FX rates aren't actually needed.
+    """
+
+    def get_rates(self, field, quote, bases, dates):
+        raise AssertionError("FX rates requested unexpectedly!")

--- a/zipline/data/fx.py
+++ b/zipline/data/fx.py
@@ -1,5 +1,6 @@
+"""Interface and definitions for foreign exchange rate readers.
 """
-"""
+import six
 
 from interface import implements, Interface
 
@@ -47,6 +48,11 @@ class InMemoryFXRateReader(implements(FXRateReader)):
         self._data = data
 
     def get_rates(self, field, quote, bases, dates):
+        if six.PY3:
+            # DataFrames in self._data should contain str as column keys, which
+            # don't compare equal to bases in Python 3. Convert to unicode.
+            bases = bases.astype('U3')
+
         return self._data[field][quote][bases].reindex(dates, method='ffill')
 
 

--- a/zipline/data/in_memory_daily_bars.py
+++ b/zipline/data/in_memory_daily_bars.py
@@ -1,16 +1,18 @@
 from six import iteritems
 
+import numpy as np
+import pandas as pd
 from pandas import NaT
 
 from trading_calendars import TradingCalendar
 
 from zipline.data.bar_reader import OHLCV, NoDataOnDate, NoDataForSid
-from zipline.data.session_bars import SessionBarReader
+from zipline.data.session_bars import CurrencyAwareSessionBarReader
 from zipline.utils.input_validation import expect_types, validate_keys
 from zipline.utils.pandas_utils import check_indexes_all_same
 
 
-class InMemoryDailyBarReader(SessionBarReader):
+class InMemoryDailyBarReader(CurrencyAwareSessionBarReader):
     """
     A SessionBarReader backed by a dictionary of in-memory DataFrames.
 
@@ -21,15 +23,27 @@ class InMemoryDailyBarReader(SessionBarReader):
         "volume") to DataFrame containing data for that field.
     calendar : str or trading_calendars.TradingCalendar
         Calendar (or name of calendar) to which data is aligned.
+    currency_codes : pd.Series
+        Map from sid -> listing currency for that sid.
     verify_indices : bool, optional
         Whether or not to verify that input data is correctly aligned to the
         given calendar. Default is True.
     """
-    @expect_types(frames=dict, calendar=TradingCalendar, verify_indices=bool)
-    def __init__(self, frames, calendar, verify_indices=True):
+    @expect_types(
+        frames=dict,
+        calendar=TradingCalendar,
+        verify_indices=bool,
+        currency_codes=pd.Series,
+    )
+    def __init__(self,
+                 frames,
+                 calendar,
+                 currency_codes,
+                 verify_indices=True):
         self._frames = frames
         self._values = {key: frame.values for key, frame in iteritems(frames)}
         self._calendar = calendar
+        self._currency_codes = currency_codes
 
         validate_keys(frames, set(OHLCV), type(self).__name__)
         if verify_indices:
@@ -39,10 +53,10 @@ class InMemoryDailyBarReader(SessionBarReader):
         self._sids = frames['close'].columns
 
     @classmethod
-    def from_panel(cls, panel, calendar):
+    def from_panel(cls, panel, calendar, currency_codes):
         """Helper for construction from a pandas.Panel.
         """
-        return cls(dict(panel.iteritems()), calendar)
+        return cls(dict(panel.iteritems()), calendar, currency_codes)
 
     @property
     def last_available_dt(self):
@@ -119,6 +133,10 @@ class InMemoryDailyBarReader(SessionBarReader):
     @property
     def first_trading_day(self):
         return self._sessions[0]
+
+    def currency_codes(self, sids):
+        codes = self._currency_codes
+        return np.array([codes[sid] for sid in sids])
 
 
 def verify_frames_aligned(frames, calendar):

--- a/zipline/data/session_bars.py
+++ b/zipline/data/session_bars.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import abstractproperty
+from abc import abstractproperty, abstractmethod
 
 from zipline.data.bar_reader import BarReader
 
@@ -32,4 +32,24 @@ class SessionBarReader(BarReader):
         sessions : DatetimeIndex
            All session labels (unioning the range for all assets) which the
            reader can provide.
+        """
+
+
+class CurrencyAwareSessionBarReader(SessionBarReader):
+
+    @abstractmethod
+    def currency_codes(self, sids):
+        """Get currencies in which prices are quoted for the requested sids.
+
+        Assumes that a sid's prices are always quoted in a single currency.
+
+        Parameters
+        ----------
+        sids : np.array[int64]
+            Array of sids for which currencies are needed.
+
+        Returns
+        -------
+        currency_codes : np.array[S3]
+            Array of currency codes for listing currencies of ``sids``.
         """

--- a/zipline/pipeline/data/dataset.py
+++ b/zipline/pipeline/data/dataset.py
@@ -1,5 +1,5 @@
 import abc
-from collections import OrderedDict
+from collections import namedtuple, OrderedDict
 from itertools import repeat
 from textwrap import dedent
 from weakref import WeakKeyDictionary
@@ -10,6 +10,7 @@ from six import (
 )
 from toolz import first
 
+from zipline.currency import Currency
 from zipline.pipeline.classifiers import Classifier, Latest as LatestClassifier
 from zipline.pipeline.domain import Domain, GENERIC
 from zipline.pipeline.factors import Factor, Latest as LatestFactor
@@ -21,7 +22,11 @@ from zipline.pipeline.term import (
     validate_dtype,
 )
 from zipline.utils.formatting import s, plural
-from zipline.utils.input_validation import ensure_dtype, expect_types
+from zipline.utils.input_validation import (
+    coerce_types,
+    ensure_dtype,
+    expect_types,
+)
 from zipline.utils.numpy_utils import NoDefaultMissingValue
 from zipline.utils.preprocess import preprocess
 from zipline.utils.string_formatting import bulleted_list
@@ -105,6 +110,7 @@ class _BoundColumnDescr(object):
             name=self.name,
             doc=self.doc,
             metadata=self.metadata,
+            currency_conversion=None,
         )
 
 
@@ -145,7 +151,8 @@ class BoundColumn(LoadableTerm):
                 dataset,
                 name,
                 doc,
-                metadata):
+                metadata,
+                currency_conversion):
         return super(BoundColumn, cls).__new__(
             cls,
             domain=dataset.domain,
@@ -156,23 +163,38 @@ class BoundColumn(LoadableTerm):
             ndim=dataset.ndim,
             doc=doc,
             metadata=metadata,
+            currency_conversion=currency_conversion,
         )
 
-    def _init(self, dataset, name, doc, metadata, *args, **kwargs):
+    def _init(self,
+              dataset,
+              name,
+              doc,
+              metadata,
+              currency_conversion,
+              *args, **kwargs):
         self._dataset = dataset
         self._name = name
         self.__doc__ = doc
         self._metadata = metadata
+        self._currency_conversion = currency_conversion
         return super(BoundColumn, self)._init(*args, **kwargs)
 
     @classmethod
-    def _static_identity(cls, dataset, name, doc, metadata, *args, **kwargs):
+    def _static_identity(cls,
+                         dataset,
+                         name,
+                         doc,
+                         metadata,
+                         currency_conversion,
+                         *args, **kwargs):
         return (
             super(BoundColumn, cls)._static_identity(*args, **kwargs),
             dataset,
             name,
             doc,
             frozenset(sorted(metadata.items(), key=first)),
+            currency_conversion,
         )
 
     def __lt__(self, other):
@@ -181,20 +203,27 @@ class BoundColumn(LoadableTerm):
 
     __gt__ = __le__ = __ge__ = __lt__
 
+    def _replace(self, **kwargs):
+        kw = dict(
+            dtype=self.dtype,
+            missing_value=self.missing_value,
+            dataset=self._dataset,
+            name=self._name,
+            doc=self.__doc__,
+            metadata=self._metadata,
+            currency_conversion=self._currency_conversion,
+        )
+        kw.update(kwargs)
+
+        return type(self)(**kw)
+
     def specialize(self, domain):
         """Specialize ``self`` to a concrete domain.
         """
         if domain == self.domain:
             return self
 
-        return type(self)(
-            dtype=self.dtype,
-            missing_value=self.missing_value,
-            dataset=self._dataset.specialize(domain),
-            name=self._name,
-            doc=self.__doc__,
-            metadata=self._metadata,
-        )
+        return self._replace(dataset=self._dataset.specialize(domain))
 
     def unspecialize(self):
         """
@@ -203,6 +232,42 @@ class BoundColumn(LoadableTerm):
         This is equivalent to ``column.specialize(GENERIC)``.
         """
         return self.specialize(GENERIC)
+
+    @coerce_types(currency=(str, Currency))
+    def fx(self, currency):
+        """
+        Construct a currency-converted version of this column.
+
+        Parameters
+        ----------
+        currency : str or zipline.currency.Currency
+            Currency into which to convert this column's data.
+
+        Returns
+        -------
+        column : BoundColumn
+            Column producing the same data as ``self``, but currency-converted
+            into ``currency``.
+        """
+        conversion = self._currency_conversion
+        if conversion is not None and conversion.currency == currency:
+            return self
+
+        return self._replace(
+            currency_conversion=CurrencyConversion(
+                currency=currency,
+                # TODO: Figure out what to do with this.
+                # For now, only support converting with mid. We might
+                # eventually support other fields
+                field='mid',
+            )
+        )
+
+    @property
+    def currency_conversion(self):
+        """Specification for currency conversions applied for this term.
+        """
+        return self._currency_conversion
 
     @property
     def dataset(self):
@@ -867,3 +932,9 @@ class DataSetFamily(with_metaclass(DataSetFamilyMeta)):
         Slice = cls._make_dataset(coords)
         cls._slice_cache[hash_key] = Slice
         return Slice
+
+
+CurrencyConversion = namedtuple(
+    'CurrencyConversion',
+    ['currency', 'field'],
+)

--- a/zipline/pipeline/hooks/progress.py
+++ b/zipline/pipeline/hooks/progress.py
@@ -5,7 +5,7 @@ import time
 
 from interface import implements
 
-from zipline.utils.compat import contextmanager, escape
+from zipline.utils.compat import contextmanager, escape_html
 from zipline.utils.string_formatting import bulleted_list
 
 from .iface import PipelineHooks
@@ -489,4 +489,4 @@ def repr_htmlsafe(t):
     except Exception:
         r = "(Error Displaying {})".format(type(t).__name__)
 
-    return escape(str(r))
+    return escape_html(str(r), quote=True)

--- a/zipline/pipeline/loaders/base.py
+++ b/zipline/pipeline/loaders/base.py
@@ -7,6 +7,7 @@ from interface import default, Interface
 class PipelineLoader(Interface):
     """Interface for PipelineLoaders.
     """
+
     def load_adjusted_array(self, domain, columns, dates, sids, mask):
         """
         Load data for ``columns`` as AdjustedArrays.
@@ -35,18 +36,10 @@ class PipelineLoader(Interface):
         """
 
     @default
-    def validate_domain(self, domain):
+    @property
+    def currency_aware(self):
+        """Whether or not this loader supports currency-conversions.
+
+        By default, assume that loaders to not support currency conversions.
         """
-        Verify that a domain is supported before attempting to load it.
-
-        This can be implemented by a loader to raise a useful error before
-        performing any potentially-expensive work.
-
-        The default implementation is a no-op.
-
-        Parameters
-        ----------
-        domain : zipline.pipeline.domain.Domain
-            The domain on which a pipeline is about to be run.
-        """
-        pass
+        return False

--- a/zipline/pipeline/loaders/blaze/core.py
+++ b/zipline/pipeline/loaders/blaze/core.py
@@ -153,6 +153,7 @@ from datashape import (
     isscalar,
     integral,
 )
+from interface import implements
 import numpy as np
 from odo import odo
 import pandas as pd
@@ -176,6 +177,7 @@ from zipline.pipeline.common import (
 )
 from zipline.pipeline.data.dataset import DataSet, Column
 from zipline.pipeline.domain import GENERIC
+from zipline.pipeline.loaders.base import PipelineLoader
 from zipline.pipeline.sentinels import NotSpecified
 from zipline.lib.adjusted_array import can_represent_dtype
 from zipline.utils.input_validation import expect_element
@@ -805,7 +807,7 @@ class ExprData(object):
         )
 
 
-class BlazeLoader(object):
+class BlazeLoader(implements(PipelineLoader)):
     """A PipelineLoader for datasets constructed with ``from_blaze``.
 
     Parameters

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from interface import implements
-from numpy import iinfo, uint32
+from collections import defaultdict
 
+from interface import implements
+from numpy import iinfo, uint32, multiply
+
+from zipline.data.fx import ExplodingFXRateReader
 from zipline.lib.adjusted_array import AdjustedArray
 
 from .base import PipelineLoader
@@ -31,28 +34,71 @@ class EquityPricingLoader(implements(PipelineLoader)):
         Reader providing raw prices.
     adjustments_reader : zipline.data.adjustments.SQLiteAdjustmentReader
         Reader providing price/volume adjustments.
+    fx_reader : zipline.data.fx.FXRateReader
+       Reader providing currency conversions.
     """
-    def __init__(self, raw_price_reader, adjustments_reader):
+
+    def __init__(self,
+                 raw_price_reader,
+                 adjustments_reader,
+                 fx_reader):
         self.raw_price_reader = raw_price_reader
         self.adjustments_reader = adjustments_reader
+        self.fx_reader = fx_reader
+
+    @classmethod
+    def without_fx(cls, raw_price_reader, adjustments_reader):
+        """
+        Construct an EquityPricingLoader without support for fx rates.
+
+        The returned loader will raise an error if requested to load
+        currency-converted columns.
+
+        Parameters
+        ----------
+        raw_price_reader : zipline.data.session_bars.SessionBarReader
+            Reader providing raw prices.
+        adjustments_reader : zipline.data.adjustments.SQLiteAdjustmentReader
+            Reader providing price/volume adjustments.
+
+        Returns
+        -------
+        loader : EquityPricingLoader
+            A loader that can only provide currency-naive data.
+        """
+        return cls(
+            raw_price_reader=raw_price_reader,
+            adjustments_reader=adjustments_reader,
+            fx_reader=ExplodingFXRateReader(),
+        )
 
     def load_adjusted_array(self, domain, columns, dates, sids, mask):
         # load_adjusted_array is called with dates on which the user's algo
         # will be shown data, which means we need to return the data that would
-        # be known at the start of each date.  We assume that the latest data
-        # known on day N is the data from day (N - 1), so we shift all query
-        # dates back by a day.
+        # be known at the **start** of each date. We assume that the latest
+        # data known on day N is the data from day (N - 1), so we shift all
+        # query dates back by a trading session.
         sessions = domain.all_sessions()
-        start_date, end_date = shift_dates(
-            sessions, dates[0], dates[-1], shift=1,
-        )
+        shifted_dates = shift_dates(sessions, dates[0], dates[-1], shift=1)
+
         colnames = [c.name for c in columns]
         raw_arrays = self.raw_price_reader.load_raw_arrays(
             colnames,
-            start_date,
-            end_date,
+            shifted_dates[0],
+            shifted_dates[-1],
             sids,
         )
+
+        # Currency convert raw_arrays in place if necessary. We use shifted
+        # dates to load currency conversion rates to make them line up with
+        # dates used to fetch prices.
+        self._inplace_currency_convert(
+            columns,
+            raw_arrays,
+            shifted_dates,
+            sids,
+        )
+
         adjustments = self.adjustments_reader.load_pricing_adjustments(
             colnames,
             dates,
@@ -67,6 +113,61 @@ class EquityPricingLoader(implements(PipelineLoader)):
                 c.missing_value,
             )
         return out
+
+    @property
+    def currency_aware(self):
+        # Tell the pipeline engine that this loader supports currency
+        # conversion.
+        return True
+
+    def _inplace_currency_convert(self, columns, arrays, dates, sids):
+        """
+        Currency convert raw data loaded for ``column``.
+
+        Parameters
+        ----------
+        columns : list[zipline.pipeline.data.BoundColumn]
+            List of columns whose raw data has been loaded.
+        arrays : list[np.array]
+            List of arrays, parallel to ``columns`` containing data for the
+            column.
+        dates : pd.DatetimeIndex
+            Labels for rows of ``arrays``. These are the dates that should
+            be used to fetch fx rates for conversion.
+        sids : np.array[int64]
+            Labels for columns of ``arrays``.
+
+        Returns
+        -------
+        None
+
+        Side Effects
+        ------------
+        Modifies ``arrays`` in place by applying currency conversions.
+        """
+        # Group columns by currency conversion spec.
+        by_spec = defaultdict(list)
+        for column, array in zip(columns, arrays):
+            by_spec[column.currency_conversion].append(array)
+
+        # Nothing to do for terms with no currency conversion.
+        by_spec.pop(None)
+        if not by_spec:
+            return
+
+        fx_reader = self.fx_reader
+        base_currencies = self.raw_price_reader.currency_codes(sids)
+
+        # Columns with the same conversion spec will use the same multipliers.
+        for spec, arrays in by_spec.items():
+            rates = fx_reader.get_rates(
+                field=spec.field,
+                quote=spec.currency.code,
+                bases=base_currencies,
+                dates=dates,
+            )
+            for arr in arrays:
+                multiply(arr, rates, out=arr)
 
 
 # Backwards compat alias.

--- a/zipline/pipeline/loaders/utils.py
+++ b/zipline/pipeline/loaders/utils.py
@@ -266,14 +266,7 @@ def ffill_across_cols(df, columns, name_map):
 
 def shift_dates(dates, start_date, end_date, shift):
     """
-    Shift dates of a pipeline query back by `shift` days.
-
-    load_adjusted_array is called with dates on which the user's algo
-    will be shown data, which means we need to return the data that would
-    be known at the start of each date.  This is often labeled with a
-    previous date in the underlying data (e.g. at the start of today, we
-    have the data as of yesterday). In this case, we can shift the query
-    dates back to query the appropriate values.
+    Shift dates of a pipeline query back by ``shift`` days.
 
     Parameters
     ----------
@@ -285,6 +278,20 @@ def shift_dates(dates, start_date, end_date, shift):
         End date of the pipeline query.
     shift : int
         The number of days to shift back the query dates.
+
+    Returns
+    -------
+    shifted : pd.DatetimeIndex
+        The range [start_date, end_date] from ``dates``, shifted backwards by
+        ``shift`` days.
+
+    Raises
+    ------
+    ValueError
+        If ``start_date`` or ``end_date`` is not in ``dates``.
+    NoFurtherDataError
+        If shifting ``start_date`` back by ``shift`` days would push it off the
+        end of ``dates``.
     """
     try:
         start = dates.get_loc(start_date)
@@ -327,4 +334,5 @@ def shift_dates(dates, start_date, end_date, shift):
             )
         else:
             raise ValueError("Query end %s not in calendar" % end_date)
-    return dates[start - shift], dates[end - shift]
+
+    return dates[start - shift:end - shift + 1]  # +1 to be inclusive

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -1785,14 +1785,23 @@ def create_simple_domain(start, end, country_code):
 def write_hdf5_daily_bars(writer,
                           asset_finder,
                           country_codes,
-                          generate_data):
+                          generate_data,
+                          generate_currency_codes):
     """Write an HDF5 file of pricing data using an HDF5DailyBarWriter.
     """
     asset_finder = asset_finder
     for country_code in country_codes:
         sids = asset_finder.equities_sids_for_country_code(country_code)
+        currency_codes = generate_currency_codes(
+            country_code=country_code,
+            sids=sids,
+        )
         data_generator = generate_data(country_code=country_code, sids=sids)
-        writer.write_from_sid_df_pairs(country_code, data_generator)
+        writer.write_from_sid_df_pairs(
+            country_code,
+            data_generator,
+            currency_codes=currency_codes,
+        )
 
 
 def exchange_info_for_domains(domains):

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -770,18 +770,14 @@ class WithEquityDailyBarData(WithAssetFinder, WithTradingCalendars):
 
     Methods
     -------
-    make_equity_daily_bar_data() -> iterable[(int, pd.DataFrame)]
-        A class method that returns an iterator of (sid, dataframe) pairs
-        which will be written to the bcolz files that the class's
-        ``BcolzDailyBarReader`` will read from. By default this creates
-        some simple synthetic data with
-        :func:`~zipline.testing.create_daily_bar_data`
+    make_equity_daily_bar_data(country_code, sids)
+    make_equity_daily_bar_currency_codes(country_code, sids)
 
     See Also
     --------
     WithEquityMinuteBarData
     zipline.testing.create_daily_bar_data
-    """
+    """  # noqa
     EQUITY_DAILY_BAR_START_DATE = alias('START_DATE')
     EQUITY_DAILY_BAR_END_DATE = alias('END_DATE')
     EQUITY_DAILY_BAR_SOURCE_FROM_MINUTE = None
@@ -814,6 +810,8 @@ class WithEquityDailyBarData(WithAssetFinder, WithTradingCalendars):
     @classmethod
     def make_equity_daily_bar_data(cls, country_code, sids):
         """
+        Create daily pricing data.
+
         Parameters
         ----------
         country_code : str
@@ -836,6 +834,27 @@ class WithEquityDailyBarData(WithAssetFinder, WithTradingCalendars):
             return cls._make_equity_daily_bar_from_minute()
         else:
             return create_daily_bar_data(cls.equity_daily_bar_days, sids)
+
+    @classmethod
+    def make_equity_daily_bar_currency_codes(cls, country_code, sids):
+        """Create listing currencies.
+
+        Default is to list all assets in USD.
+
+        Parameters
+        ----------
+        country_code : str
+            An ISO 3166 alpha-2 country code. Data should be created for
+            this country.
+        sids : tuple[int]
+            The sids to include in the data.
+
+        Returns
+        -------
+        currency_codes : pd.Series[int, str]
+            Map from sids to currency for that sid's prices.
+        """
+        return pd.Series(index=list(sids), data='USD')
 
     @classmethod
     def init_class_fixtures(cls):
@@ -1217,6 +1236,7 @@ class WithWriteHDF5DailyBars(WithEquityDailyBarData,
             cls.asset_finder,
             country_codes,
             cls.make_equity_daily_bar_data,
+            cls.make_equity_daily_bar_currency_codes,
         )
 
         # Open the file and mark it for closure during teardown.

--- a/zipline/utils/compat.py
+++ b/zipline/utils/compat.py
@@ -8,8 +8,8 @@ from six import PY2
 
 if PY2:
     from abc import ABCMeta
-    from cgi import escape
     from types import DictProxyType
+    from cgi import escape as escape_html
     import contextlib
     from ctypes import py_object, pythonapi
 
@@ -96,7 +96,7 @@ if PY2:
 
 else:
     from contextlib import contextmanager
-    from html import escape
+    from html import escape as escape_html
     from types import MappingProxyType as mappingproxy
     from math import ceil
 
@@ -134,13 +134,13 @@ unicode = type(u'')
 
 __all__ = [
     'PY2',
-    'escape',
+    'consistent_round',
+    'contextmanager',
+    'escape_html',
     'exc_clear',
     'mappingproxy',
     'unicode',
     'update_wrapper',
     'values_as_list',
     'wraps',
-    'consistent_round',
-    'contextmanager',
 ]

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -155,7 +155,7 @@ def _run(handle_data,
         adjustment_reader=bundle_data.adjustment_reader,
     )
 
-    pipeline_loader = USEquityPricingLoader(
+    pipeline_loader = USEquityPricingLoader.without_fx(
         bundle_data.equity_daily_bar_reader,
         bundle_data.adjustment_reader,
     )


### PR DESCRIPTION
Initial work on adding support for currency data.

This adds the basic scaffolding for supporting currency conversions in Pipeline. Currently, we only support conversions for EquityPricing, and the only source of currency data is via an `InMemoryFXRatesReader`. Subsequent updates will provide alternative interfaces to fx rates data.