### PR TITLE
More Currency Fixes

### DIFF
--- a/tests/data/test_daily_bars.py
+++ b/tests/data/test_daily_bars.py
@@ -36,7 +36,6 @@ from six.moves import range
 from toolz import merge
 from trading_calendars import get_calendar
 
-from zipline.currency import MISSING_CURRENCY_CODE
 from zipline.data.bar_reader import (
     NoDataAfterDate,
     NoDataBeforeDate,
@@ -188,7 +187,7 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
         # Evenly distribute choices among ``sids``.
         choices = cls.DAILY_BARS_TEST_CURRENCIES[country_code]
         codes = list(islice(cycle(choices), len(sids)))
-        return Series(index=sids, data=np.array(codes, dtype='S3'))
+        return Series(index=sids, data=np.array(codes, dtype=object))
 
     @classproperty
     def holes(cls):
@@ -531,6 +530,10 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
         ).values
         assert_equal(all_results, all_expected)
 
+        self.assertEqual(all_results.dtype, np.dtype(object))
+        for code in all_results:
+            self.assertIsInstance(code, str)
+
         # Check all possible subsets of assets.
         for indices in map(list, powerset(range(len(all_assets)))):
             # Empty queries aren't currently supported.
@@ -557,10 +560,7 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
         # queries.
         mixed = np.array(invalid_sids + [valid_sid])
         result = self.daily_bar_reader.currency_codes(mixed)
-        expected = np.array(
-            [MISSING_CURRENCY_CODE] * 2 + [valid_currency],
-            dtype='S3'
-        )
+        expected = np.array([None] * 2 + [valid_currency])
         assert_equal(result, expected)
 
 

--- a/tests/data/test_fx.py
+++ b/tests/data/test_fx.py
@@ -146,7 +146,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
 
             for rate in self.FX_RATES_RATE_NAMES:
                 quote = 'USD'
-                bases = np.array(['CAD'], dtype='S3')
+                bases = np.array(['CAD'], dtype=object)
                 dts = pd.DatetimeIndex([bad_date])
                 with self.assertRaises(ValueError):
                     self.reader.get_rates(rate, quote, bases, dts)
@@ -157,7 +157,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
 
             for rate in self.FX_RATES_RATE_NAMES:
                 quote = 'USD'
-                bases = np.array(['CAD'], dtype='S3')
+                bases = np.array(['CAD'], dtype=object)
                 dts = pd.DatetimeIndex([bad_date])
                 with self.assertRaises(ValueError):
                     self.reader.get_rates(rate, quote, bases, dts)

--- a/zipline/currency.py
+++ b/zipline/currency.py
@@ -4,10 +4,6 @@ from iso4217 import Currency as ISO4217Currency
 _ALL_CURRENCIES = {}
 
 
-# Special sentinel used to represent unknown or missing currencies.
-MISSING_CURRENCY_CODE = 'XXX'
-
-
 @total_ordering
 class Currency(object):
     """A currency identifier, as defined by ISO-4217.
@@ -28,8 +24,7 @@ class Currency(object):
         try:
             return _ALL_CURRENCIES[code]
         except KeyError:
-            # This isn't a real
-            if code == MISSING_CURRENCY_CODE:
+            if code is None:
                 name = "NO CURRENCY"
             else:
                 try:

--- a/zipline/data/bcolz_daily_bars.py
+++ b/zipline/data/bcolz_daily_bars.py
@@ -34,7 +34,6 @@ from six import iteritems, viewkeys
 from toolz import compose
 from trading_calendars import get_calendar
 
-from zipline.currency import MISSING_CURRENCY_CODE
 from zipline.data.session_bars import CurrencyAwareSessionBarReader
 from zipline.data.bar_reader import (
     NoDataAfterDate,
@@ -708,13 +707,13 @@ class BcolzDailyBarReader(CurrencyAwareSessionBarReader):
 
     def currency_codes(self, sids):
         # XXX: This is pretty inefficient. This reader doesn't really support
-        # country codes, so we always either return USD or
-        # MISSING_CURRENCY_CODE if we don't know about the sid at all.
+        # country codes, so we always either return USD or None if we don't
+        # know about the sid at all.
         first_rows = self._first_rows
         out = []
         for sid in sids:
             if sid in first_rows:
                 out.append('USD')
             else:
-                out.append(MISSING_CURRENCY_CODE)
-        return np.array(out, dtype='S3')
+                out.append(None)
+        return np.array(out, dtype=object)

--- a/zipline/data/hdf5_daily_bars.py
+++ b/zipline/data/hdf5_daily_bars.py
@@ -107,7 +107,6 @@ import pandas as pd
 from six import iteritems, raise_from, viewkeys
 from six.moves import reduce
 
-from zipline.currency import MISSING_CURRENCY_CODE
 from zipline.data.bar_reader import (
     NoDataAfterDate,
     NoDataBeforeDate,
@@ -116,6 +115,7 @@ from zipline.data.bar_reader import (
 )
 from zipline.data.session_bars import CurrencyAwareSessionBarReader
 from zipline.utils.memoize import lazyval
+from zipline.utils.numpy_utils import bytes_array_to_native_str_object_array
 from zipline.utils.pandas_utils import check_indexes_all_same
 
 
@@ -696,7 +696,8 @@ class HDF5DailyBarReader(CurrencyAwareSessionBarReader):
 
     @lazyval
     def _currency_codes(self):
-        return self._country_group[CURRENCY][CODE][:]
+        bytes_array = self._country_group[CURRENCY][CODE][:]
+        return bytes_array_to_native_str_object_array(bytes_array)
 
     def currency_codes(self, sids):
         """Get currencies in which prices are quoted for the requested sids.
@@ -708,7 +709,7 @@ class HDF5DailyBarReader(CurrencyAwareSessionBarReader):
 
         Returns
         -------
-        currency_codes : np.array[S3]
+        currency_codes : np.array[object]
             Array of currency codes for listing currencies of ``sids``.
         """
         # Find the index of requested sids in our stored sids.
@@ -720,7 +721,7 @@ class HDF5DailyBarReader(CurrencyAwareSessionBarReader):
         # fails. Fill these sids with the special "missing" sentinel.
         not_found = (self.sids[ixs] != sids)
 
-        result[not_found] = MISSING_CURRENCY_CODE
+        result[not_found] = None
 
         return result
 

--- a/zipline/data/session_bars.py
+++ b/zipline/data/session_bars.py
@@ -39,7 +39,8 @@ class CurrencyAwareSessionBarReader(SessionBarReader):
 
     @abstractmethod
     def currency_codes(self, sids):
-        """Get currencies in which prices are quoted for the requested sids.
+        """
+        Get currencies in which prices are quoted for the requested sids.
 
         Assumes that a sid's prices are always quoted in a single currency.
 
@@ -50,9 +51,8 @@ class CurrencyAwareSessionBarReader(SessionBarReader):
 
         Returns
         -------
-        currency_codes : np.array[S3]
+        currency_codes : np.array[object]
             Array of currency codes for listing currencies of
-            ``sids``. Implementations should return
-            zipline.currency.MISSING_CURRENCY_CODE for sids whose currency is
-            unknown.
+            ``sids``. Implementations should return None for sids whose
+            currency is unknown.
         """

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -141,8 +141,8 @@ class EquityPricingLoader(implements(PipelineLoader)):
     @property
     def currency_aware(self):
         # Tell the pipeline engine that this loader supports currency
-        # conversion.
-        return True
+        # conversion if we have a non-dummy fx rates reader.
+        return not isinstance(self.fx_reader, ExplodingFXRateReader)
 
     def _inplace_currency_convert(self, columns, arrays, dates, sids):
         """

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -16,13 +16,9 @@ from collections import defaultdict
 from interface import implements
 from numpy import iinfo, uint32, multiply
 
-from zipline.currency import MISSING_CURRENCY_CODE
 from zipline.data.fx import ExplodingFXRateReader
 from zipline.lib.adjusted_array import AdjustedArray
-from zipline.utils.numpy_utils import (
-    repeat_first_axis,
-    bytes_array_to_native_str_object_array,
-)
+from zipline.utils.numpy_utils import repeat_first_axis
 
 from .base import PipelineLoader
 from .utils import shift_dates
@@ -123,12 +119,7 @@ class EquityPricingLoader(implements(PipelineLoader)):
             )
 
         for c in currency_cols:
-            codes_1d = bytes_array_to_native_str_object_array(
-                self.raw_price_reader.currency_codes(sids)
-            )
-            # XXX: Should this just be the contract of `currency_codes`?
-            codes_1d[codes_1d == MISSING_CURRENCY_CODE] = None
-
+            codes_1d = self.raw_price_reader.currency_codes(sids)
             codes = repeat_first_axis(codes_1d, len(dates))
             out[c] = AdjustedArray(
                 codes,

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -2182,7 +2182,7 @@ class WithFXRates(object):
 
             writer.write(
                 dts=sessions.values,
-                currencies=np.array(cls.FX_RATES_CURRENCIES, dtype='S3'),
+                currencies=np.array(cls.FX_RATES_CURRENCIES, dtype=object),
                 data=fx_data,
             )
 


### PR DESCRIPTION
- Use the exploding-ness of fx rate reader to determine whether `EquityPricingLoader.currency_aware` should be True or False. This gives a more useful error message to users when they try to load currency-converted data with a loader created via `EquityPricingLoader.without_fx`.
- Switch back to using object arrays with `None` as missing representation for outputs of currency code queries. This is the representation we want for `EquityPricing.currency`, and it's also easier to work with in 2/3 compat code. Also switch to using `None` as the `code` for missing currency. 