### PR TITLE
BUG: Fix crash in pipeline with all currency-converted data.

### DIFF
--- a/tests/data/test_fx.py
+++ b/tests/data/test_fx.py
@@ -84,6 +84,9 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
             expected = self.get_expected_fx_rate_scalar(rate, quote, base, dt)
             assert_equal(result_scalar, expected)
 
+            alt_result_scalar = reader.get_rate_scalar(rate, quote, base, dt)
+            assert_equal(result_scalar, alt_result_scalar)
+
     def test_vectorized_lookup(self):
         rand = np.random.RandomState(42)
 

--- a/zipline/data/fx/base.py
+++ b/zipline/data/fx/base.py
@@ -28,7 +28,7 @@ class FXRateReader(Interface):
             may appear multiple times.
         dts : pd.DatetimeIndex
             Datetimes for which to load rates. Must be sorted in ascending
-            order.
+            order and localized to UTC.
 
         Returns
         -------

--- a/zipline/data/fx/base.py
+++ b/zipline/data/fx/base.py
@@ -1,4 +1,7 @@
-from interface import Interface
+from interface import default, Interface
+
+import numpy as np
+import pandas as pd
 
 from zipline.utils.sentinel import sentinel
 
@@ -19,10 +22,10 @@ class FXRateReader(Interface):
             will be used by default for Pipeline API terms that don't specify a
             specific rate.
         quote : str
-            Currency code of the currency into to convert.
+            Currency code of the currency to convert into.
         bases : np.array[object]
-            Array of codes of the currencies from which to convert. A single
-            currency may appear multiple times.
+            Array of codes of the currencies to convert from. A single currency
+            may appear multiple times.
         dts : pd.DatetimeIndex
             Datetimes for which to load rates. Must be sorted in ascending
             order.
@@ -36,3 +39,34 @@ class FXRateReader(Interface):
             The row at index i corresponds to the dt in dts[i].
             The column at index j corresponds to the base currency in bases[j].
         """
+
+    @default
+    def get_rate_scalar(self, rate, quote, base, dt):
+        """Scalar version of ``get_rates``.
+
+        Parameters
+        ----------
+        rate : str
+            Rate type to load. Readers intended for use with the Pipeline API
+            should support at least ``zipline.data.fx.DEFAULT_FX_RATE``, which
+            will be used by default for Pipeline API terms that don't specify a
+            specific rate.
+        quote : str
+            Currency code of the currency to convert into.
+        base : str
+            Currency code of the currency to convert from.
+        dt : np.datetime64 or pd.Timestamp
+            Datetime on which to load rate.
+
+        Returns
+        -------
+        rate : np.float64
+            Exchange rate from base -> quote on dt.
+        """
+        rates_array = self.get_rates(
+            rate,
+            quote,
+            bases=np.array([base], dtype=object),
+            dts=pd.DatetimeIndex([dt], tz='UTC'),
+        )
+        return rates_array[0, 0]

--- a/zipline/pipeline/loaders/equity_pricing_loader.py
+++ b/zipline/pipeline/loaders/equity_pricing_loader.py
@@ -166,7 +166,7 @@ class EquityPricingLoader(implements(PipelineLoader)):
             by_spec[column.currency_conversion].append(array)
 
         # Nothing to do for terms with no currency conversion.
-        by_spec.pop(None)
+        by_spec.pop(None, None)
         if not by_spec:
             return
 


### PR DESCRIPTION
Fixes a bug where we would crash when trying to run a pipeline that contained
only currency-converted data.