### PR TITLE
Migrating from nose-parameterized to parameterized

### DIFF
--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -1,6 +1,6 @@
 import os
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import pandas as pd
 import sqlalchemy as sa
 from toolz import valmap

--- a/tests/data/test_daily_bars.py
+++ b/tests/data/test_daily_bars.py
@@ -16,7 +16,7 @@ from itertools import cycle, islice
 from sys import maxsize
 import re
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy import (
     arange,

--- a/tests/data/test_resample.py
+++ b/tests/data/test_resample.py
@@ -14,7 +14,7 @@
 from collections import OrderedDict
 from numbers import Real
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from numpy.testing import assert_almost_equal
 from numpy import nan, array, full, isnan
 import pandas as pd

--- a/tests/events/test_events.py
+++ b/tests/events/test_events.py
@@ -18,7 +18,7 @@ import random
 from unittest import TestCase
 import warnings
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import pandas as pd
 from six import iteritems
 from six.moves import range, map

--- a/tests/events/test_events_nyse.py
+++ b/tests/events/test_events_nyse.py
@@ -16,7 +16,7 @@ from functools import partial
 from unittest import TestCase
 from datetime import timedelta
 import pandas as pd
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from zipline.utils.events import NDaysBeforeLastTradingDayOfWeek, AfterOpen, \
     BeforeClose

--- a/tests/finance/test_commissions.py
+++ b/tests/finance/test_commissions.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from pandas import DataFrame
 
 from zipline.assets import Equity, Future

--- a/tests/finance/test_slippage.py
+++ b/tests/finance/test_slippage.py
@@ -20,7 +20,7 @@ from collections import namedtuple
 import datetime
 from math import sqrt
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 import pandas as pd
 import pytz

--- a/tests/pipeline/test_adjusted_array.py
+++ b/tests/pipeline/test_adjusted_array.py
@@ -7,7 +7,7 @@ from string import ascii_lowercase, ascii_uppercase
 from textwrap import dedent
 from unittest import TestCase
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from numpy import (
     arange,
     array,

--- a/tests/pipeline/test_adjustment.py
+++ b/tests/pipeline/test_adjustment.py
@@ -2,7 +2,7 @@
 Tests for zipline.lib.adjustment
 """
 from unittest import TestCase
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from zipline.lib import adjustment as adj
 from zipline.utils.numpy_utils import make_datetime64ns

--- a/tests/pipeline/test_blaze.py
+++ b/tests/pipeline/test_blaze.py
@@ -12,7 +12,7 @@ import warnings
 
 import blaze as bz
 from datashape import dshape, var, Record
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy.testing.utils import assert_array_almost_equal
 from odo import odo

--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -4,7 +4,7 @@ Tests BoundColumn attributes and methods.
 import operator
 from unittest import skipIf
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from pandas import Timestamp, DataFrame
 from pandas.util.testing import assert_frame_equal
 

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -7,7 +7,7 @@ from itertools import product
 from operator import add, sub
 from unittest import skipIf
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy import (
     arange,

--- a/tests/pipeline/test_factor.py
+++ b/tests/pipeline/test_factor.py
@@ -3,7 +3,7 @@ Tests for Factor terms.
 """
 from functools import partial
 from itertools import product
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from unittest import TestCase, skipIf
 
 from toolz import compose

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -2,7 +2,7 @@
 """
 from itertools import cycle, islice
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 import pandas as pd
 

--- a/tests/pipeline/test_multidimensional_dataset.py
+++ b/tests/pipeline/test_multidimensional_dataset.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import itertools
 from textwrap import dedent
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 
 from zipline.pipeline.data import (

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -7,7 +7,7 @@ from os.path import (
     realpath,
 )
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy import (
     array,

--- a/tests/pipeline/test_quarters_estimates.py
+++ b/tests/pipeline/test_quarters_estimates.py
@@ -6,7 +6,7 @@ from functools import partial
 import blaze as bz
 import itertools
 from nose.tools import assert_true
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy.testing import assert_array_equal, assert_almost_equal
 import pandas as pd

--- a/tests/pipeline/test_technical.py
+++ b/tests/pipeline/test_technical.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from six.moves import range
 import numpy as np
 import pandas as pd

--- a/tests/pipeline/test_us_equity_pricing_loader.py
+++ b/tests/pipeline/test_us_equity_pricing_loader.py
@@ -15,7 +15,7 @@
 """
 Tests for USEquityPricingLoader and related classes.
 """
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from numpy import (
     arange,
     datetime64,

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 import logbook
 import toolz
 from logbook import TestHandler, WARNING
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from six import iteritems, itervalues, string_types
 from six.moves import range
 from testfixtures import TempDirectory

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -28,7 +28,7 @@ from unittest import TestCase
 import uuid
 import warnings
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy import full, int32, int64
 import pandas as pd

--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -15,7 +15,7 @@
 from datetime import timedelta, time
 from itertools import chain
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy import nan
 from numpy.testing import assert_almost_equal

--- a/tests/test_blotter.py
+++ b/tests/test_blotter.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 import pandas as pd
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,7 @@ from functools import partial
 import tarfile
 
 import matplotlib
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import pandas as pd
 
 from zipline import examples

--- a/tests/test_execution_styles.py
+++ b/tests/test_execution_styles.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from six.moves import range
 import pandas as pd
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 import pandas as pd
 import numpy as np

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -15,7 +15,7 @@
 from collections import OrderedDict
 from textwrap import dedent
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import numpy as np
 from numpy import nan
 import pandas as pd

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,4 +1,4 @@
-from nose_parameterized import parameterized
+from parameterized import parameterized
 import pandas as pd
 
 from zipline.algorithm import TradingAlgorithm

--- a/tests/test_security_list.py
+++ b/tests/test_security_list.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 import pandas as pd
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from zipline.algorithm import TradingAlgorithm
 from zipline.errors import TradingControlViolation

--- a/tests/utils/test_date_utils.py
+++ b/tests/utils/test_date_utils.py
@@ -1,5 +1,5 @@
 from pandas import Timestamp
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from trading_calendars import get_calendar
 
 from zipline.testing import ZiplineTestCase

--- a/tests/utils/test_preprocess.py
+++ b/tests/utils/test_preprocess.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 from types import FunctionType
 from unittest import TestCase
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from numpy import arange, array, dtype
 import pytz
 from six import PY3

--- a/zipline/testing/core.py
+++ b/zipline/testing/core.py
@@ -947,7 +947,7 @@ def subtest(iterator, *_names):
     * Have a large parameter space we are testing
       (see tests/utils/test_events.py).
 
-    ``nose_parameterized.expand`` will create a test for each parameter
+    ``parameterized.expand`` will create a test for each parameter
     combination which bloats the test output and makes the travis pages slow.
 
     We cannot use ``unittest2.TestCase.subTest`` because nose, pytest, and


### PR DESCRIPTION
Since nose-parameterized package is deprecated, replace all references to nose_parameterized with parameterized.