### PR TITLE
DEP: Replacing the assertRaisesRegexp which is deprecated by assertRaisesRegex

### DIFF
--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -275,8 +275,10 @@ class BundleCoreTestCase(WithInstanceTmpDir,
             called[0] = True
 
         now = pd.Timestamp.utcnow()
-        with self.assertRaisesRegexp(ValueError,
-                                     "ingest .* creates writers .* downgrade"):
+        with self.assertRaisesRegex(
+                ValueError,
+                "ingest .* creates writers .* downgrade"
+        ):
             self.ingest('bundle', self.environ, assets_versions=versions,
                         timestamp=now - pd.Timedelta(seconds=1))
         assert_false(called[0])

--- a/tests/data/test_daily_bars.py
+++ b/tests/data/test_daily_bars.py
@@ -336,9 +336,9 @@ class _DailyBarsTestCase(WithEquityDailyBarData,
         # E.g.
         #   INVALID VALID INVALID VALID ... VALID INVALID
         query_assets = (
-            [self.assets[-1] + 1] +
-            list(range(self.assets[0], self.assets[-1] + 1)) +
-            [self.assets[-1] + 3]
+                [self.assets[-1] + 1] +
+                list(range(self.assets[0], self.assets[-1] + 1)) +
+                [self.assets[-1] + 3]
         )
 
         columns = [CLOSE, VOLUME]
@@ -609,10 +609,10 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, _DailyBarsTestCase):
         result = self.bcolz_daily_bar_ctable
         expected_first_row = {
             '1': 0,
-            '3': 5,    # Asset 1 has 5 trading days.
-            '5': 12,   # Asset 3 has 7 trading days.
-            '7': 33,   # Asset 5 has 21 trading days.
-            '9': 44,   # Asset 7 has 11 trading days.
+            '3': 5,  # Asset 1 has 5 trading days.
+            '5': 12,  # Asset 3 has 7 trading days.
+            '7': 33,  # Asset 5 has 21 trading days.
+            '9': 44,  # Asset 7 has 11 trading days.
             '11': 49,  # Asset 9 has 5 trading days.
         }
         expected_last_row = {
@@ -621,14 +621,14 @@ class BcolzDailyBarTestCase(WithBcolzEquityDailyBarReader, _DailyBarsTestCase):
             '5': 32,
             '7': 43,
             '9': 48,
-            '11': 57,    # Asset 11 has 9 trading days.
+            '11': 57,  # Asset 11 has 9 trading days.
         }
         expected_calendar_offset = {
-            '1': 0,    # Starts on 6-01, 1st trading day of month.
-            '3': 15,   # Starts on 6-22, 16th trading day of month.
-            '5': 1,    # Starts on 6-02, 2nd trading day of month.
-            '7': 0,    # Starts on 6-01, 1st trading day of month.
-            '9': 9,    # Starts on 6-12, 10th trading day of month.
+            '1': 0,  # Starts on 6-01, 1st trading day of month.
+            '3': 15,  # Starts on 6-22, 16th trading day of month.
+            '5': 1,  # Starts on 6-02, 2nd trading day of month.
+            '7': 0,  # Starts on 6-01, 1st trading day of month.
+            '9': 9,  # Starts on 6-12, 10th trading day of month.
             '11': 10,  # Starts on 6-15, 11th trading day of month.
         }
         self.assertEqual(result.attrs['first_row'], expected_first_row)
@@ -706,7 +706,7 @@ class BcolzDailyBarWriterMissingDataTestCase(WithAssetFinder,
             "[Timestamp('2015-06-15 00:00:00+0000', tz='UTC')]\n"
             "Extra sessions: []"
         )
-        with self.assertRaisesRegexp(AssertionError, expected_msg):
+        with self.assertRaisesRegex(AssertionError, expected_msg):
             writer.write(bar_data)
 
 

--- a/tests/pipeline/test_downsampling.py
+++ b/tests/pipeline/test_downsampling.py
@@ -197,7 +197,7 @@ class ComputeExtraRowsTestCase(WithTradingSessions, ZiplineTestCase):
         # land prior to the first date of 2012. The downsampled terms will fail
         # to request enough extra rows.
         for i in range(0, 30, 5):
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 NoFurtherDataError,
                 r'\s*Insufficient data to compute Pipeline'
             ):

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -226,7 +226,7 @@ class ConstantInputTestCase(WithConstantInputs,
         p = Pipeline()
 
         msg = "start_date must be before or equal to end_date .*"
-        with self.assertRaisesRegexp(ValueError, msg):
+        with self.assertRaisesRegex(ValueError, msg):
             self.engine.run_pipeline(p, self.dates[2], self.dates[1])
 
     def test_fail_usefully_on_insufficient_data(self):

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -4,6 +4,7 @@ Tests for zipline.pipeline.Pipeline
 from unittest import TestCase
 
 from mock import patch
+from six import PY2
 
 from zipline.pipeline import Factor, Filter, Pipeline
 from zipline.pipeline.data import Column, DataSet, USEquityPricing
@@ -42,6 +43,10 @@ class SomeOtherFilter(Filter):
 
 
 class PipelineTestCase(TestCase):
+
+    if PY2:
+        def assertRaisesRegex(self, *args, **kwargs):
+            return self.assertRaisesRegexp(*args, **kwargs)
 
     def test_construction(self):
         p0 = Pipeline()

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -208,7 +208,7 @@ class PipelineTestCase(TestCase):
             r"but got 'fizzbuzz' instead."
         )
 
-        with self.assertRaisesRegexp(ValueError, expected):
+        with self.assertRaisesRegex(ValueError, expected):
             p.show_graph(format='fizzbuzz')
 
     def test_infer_domain_no_terms(self):

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1267,7 +1267,7 @@ class AssetFinderTestCase(WithTradingCalendars, ZiplineTestCase):
         self.assertEqual(asset_1.sid, 1)
 
         # We don't know about this ALT_ID yet.
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueNotFoundForField,
             "Value '{}' was not found for field '{}'.".format(
                 '100000002',
@@ -1294,7 +1294,7 @@ class AssetFinderTestCase(WithTradingCalendars, ZiplineTestCase):
             "Multiple occurrences of the value '{}' found for field '{}'."
         ).format('100000000', 'ALT_ID')
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             MultipleValuesFoundForField,
             expected_in_repr,
         ):
@@ -1377,7 +1377,7 @@ class AssetFinderTestCase(WithTradingCalendars, ZiplineTestCase):
 
         # Since sid 2 has not yet started, we don't know about its
         # ALT_ID.
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             NoValueForSid,
             "No '{}' value found for sid '{}'.".format('ALT_ID', 2),
         ):
@@ -1395,7 +1395,7 @@ class AssetFinderTestCase(WithTradingCalendars, ZiplineTestCase):
             )
 
         # Sid 0 has historically held two values for ALT_ID by this dt.
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             MultipleValuesFoundForSid,
             "Multiple '{}' values found for sid '{}'.".format('ALT_ID', 0),
         ):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -627,7 +627,7 @@ class MinuteEquityHistoryTestCase(WithHistory,
         """
         Negative bar counts leak future information.
         """
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "bar_count must be >= 1, but got -1"
         ):
@@ -1388,7 +1388,7 @@ class MinuteEquityHistoryTestCase(WithHistory,
             'window, start the backtest on or after 2014-01-06.'
         )
         for field in OHLCP:
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                     HistoryWindowStartsBeforeData, exp_msg):
                 self.data_portal.get_history_window(
                     [self.ASSET1],
@@ -2030,7 +2030,7 @@ class DailyEquityHistoryTestCase(WithHistory, zf.ZiplineTestCase):
             'window, start the backtest on or after 2014-01-09.'
         )
 
-        with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
+        with self.assertRaisesRegex(HistoryWindowStartsBeforeData, exp_msg):
             self.data_portal.get_history_window(
                 [self.ASSET1],
                 second_day,
@@ -2040,7 +2040,7 @@ class DailyEquityHistoryTestCase(WithHistory, zf.ZiplineTestCase):
                 'daily',
             )[self.ASSET1]
 
-        with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
+        with self.assertRaisesRegex(HistoryWindowStartsBeforeData, exp_msg):
             self.data_portal.get_history_window(
                 [self.ASSET1],
                 second_day,
@@ -2054,7 +2054,7 @@ class DailyEquityHistoryTestCase(WithHistory, zf.ZiplineTestCase):
         first_minute = \
             self.trading_calendar.schedule.market_open[self.TRADING_START_DT]
 
-        with self.assertRaisesRegexp(HistoryWindowStartsBeforeData, exp_msg):
+        with self.assertRaisesRegex(HistoryWindowStartsBeforeData, exp_msg):
             self.data_portal.get_history_window(
                 [self.ASSET2],
                 first_minute,

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -7,7 +7,7 @@ from contextlib2 import ExitStack
 from logbook import NullHandler, Logger
 import numpy as np
 import pandas as pd
-from six import with_metaclass, iteritems, itervalues
+from six import with_metaclass, iteritems, itervalues, PY2
 import responses
 from toolz import flip, groupby, merge
 from trading_calendars import (
@@ -250,6 +250,10 @@ class ZiplineTestCase(with_metaclass(DebugMROMeta, TestCase)):
             The callback to invoke at the end of each test.
         """
         return self._instance_teardown_stack.callback(callback)
+
+    if PY2:
+        def assertRaisesRegex(self, *args, **kwargs):
+            return self.assertRaisesRegexp(*args, **kwargs)
 
 
 def alias(attr_name):


### PR DESCRIPTION
This deprecation will enable the upgrade to add support for python 3.7 and higher
https://docs.python.org/3/library/unittest.html