### PR TITLE
MAINT: Stop always importing all zipline examples

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -36,6 +36,8 @@ _multiprocess_can_split_ = False
 
 matplotlib.use('Agg')
 
+EXAMPLE_MODULES = examples.load_example_modules()
+
 
 class ExamplesTests(WithTmpDir, ZiplineTestCase):
     # some columns contain values with unique ids that will not be the same
@@ -66,9 +68,10 @@ class ExamplesTests(WithTmpDir, ZiplineTestCase):
                 )
             )
 
-    @parameterized.expand(sorted(examples.EXAMPLE_MODULES))
+    @parameterized.expand(sorted(EXAMPLE_MODULES))
     def test_example(self, example_name):
         actual_perf = examples.run_example(
+            EXAMPLE_MODULES,
             example_name,
             # This should match the invocation in
             # zipline/tests/resources/rebuild_example_data

--- a/zipline/examples/__init__.py
+++ b/zipline/examples/__init__.py
@@ -8,17 +8,19 @@ from zipline import run_algorithm
 
 
 # These are used by test_examples.py to discover the examples to run.
-EXAMPLE_MODULES = {}
-for f in os.listdir(os.path.dirname(__file__)):
-    if not f.endswith('.py') or f == '__init__.py':
-        continue
-    modname = f[:-len('.py')]
-    mod = import_module('.' + modname, package=__name__)
-    EXAMPLE_MODULES[modname] = mod
-    globals()[modname] = mod
+def load_example_modules():
+    example_modules = {}
+    for f in os.listdir(os.path.dirname(__file__)):
+        if not f.endswith('.py') or f == '__init__.py':
+            continue
+        modname = f[:-len('.py')]
+        mod = import_module('.' + modname, package=__name__)
+        example_modules[modname] = mod
+        globals()[modname] = mod
 
-    # Remove noise from loop variables.
-    del f, modname, mod
+        # Remove noise from loop variables.
+        del f, modname, mod
+    return example_modules
 
 
 # Columns that we expect to be able to reliably deterministic
@@ -61,11 +63,11 @@ _cols_to_check = [
 ]
 
 
-def run_example(example_name, environ):
+def run_example(example_modules, example_name, environ):
     """
     Run an example module from zipline.examples.
     """
-    mod = EXAMPLE_MODULES[example_name]
+    mod = example_modules[example_name]
 
     register_calendar("YAHOO", get_calendar("NYSE"), force=True)
 

--- a/zipline/examples/dual_ema_talib.py
+++ b/zipline/examples/dual_ema_talib.py
@@ -27,7 +27,14 @@ momentum).
 from zipline.api import order, record, symbol
 from zipline.finance import commission, slippage
 # Import exponential moving average from talib wrapper
-from talib import EMA
+try:
+    from talib import EMA
+except ImportError:
+    msg = "Unable to import module TA-lib. Use `pip install TA-lib` to "\
+          "install. Note: if installation fails, you might need to install "\
+          "the underlying TA-lib library (more information can be found in "\
+          "the zipline installation documentation)."
+    raise ImportError(msg)
 
 
 def initialize(context):


### PR DESCRIPTION
After installing zipline in a fresh virtualenv, when trying to run `from zipline.examples import buyapple` (the next step in the installation docs) we would get an `ImportError` from trying to import `TA-lib` (see: https://github.com/quantopian/zipline/issues/2533).  This is because in `zipline/examples/__init__.py` we were always importing all of the examples, even when just trying to import `buyapple`.  We were doing this to generate a dictionary of all of the examples to run in `test_examples.py`.

This change:
 - wraps the example module generation in a function so the examples no longer get imported when `zipline.examples` is called.
 - adds a more informative error message when trying to import TA-lib in `dual_ema_talib.py`, as we explicitly do not require TA-lib in the zipline install, but require it in one of the examples.

A corresponding update to the zipline documentation that touches on TA-lib is also going to be needed.