### PR TITLE
MAINT: Clarify edge case handling for FX Rate Readers.

### DIFF
--- a/tests/data/test_fx.py
+++ b/tests/data/test_fx.py
@@ -231,7 +231,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
         for rate in self.FX_RATES_RATE_NAMES:
             quote = 'USD'
             for unknown_base in 'XXX', None:
-                bases = np.array(['XXX'], dtype=object)
+                bases = np.array([unknown_base], dtype=object)
                 dts = pd.DatetimeIndex([self.FX_RATES_START_DATE])
                 result = self.reader.get_rates(rate, quote, bases, dts)[0, 0]
                 assert_equal(result, np.nan)

--- a/zipline/data/fx/base.py
+++ b/zipline/data/fx/base.py
@@ -128,8 +128,7 @@ class FXRateReader(Interface):
             may appear multiple times.
         dts : np.DatetimeIndex
             Datetimes for which to load rates. The same value may appear
-            multiple times, and datetimes do not need to be sorted because
-            `np.unique` sorts in ascending order.
+            multiple times. Datetimes do not need to be sorted.
         """
         if len(bases) != len(dts):
             raise ValueError(
@@ -139,8 +138,11 @@ class FXRateReader(Interface):
         bases_ix, unique_bases, _ = factorize_strings(
             bases,
             missing_value=None,
-            sort=True,
+            # Only dts need to be sorted, not bases.
+            sort=False,
         )
+        # NOTE: np.unique returns unique_dts in sorted order, which is required
+        # for calling get_rates.
         unique_dts, dts_ix = np.unique(dts.values, return_inverse=True)
         rates_2d = self.get_rates(
             rate,

--- a/zipline/data/fx/base.py
+++ b/zipline/data/fx/base.py
@@ -136,8 +136,6 @@ class FXRateReader(Interface):
                 "len(bases) ({}) != len(dts) ({})".format(len(bases), len(dts))
             )
 
-        # TODO: Casting `bases` to str here is a temporary fix for the bug
-        # where having any `None` in `bases` causes `np.unique` to error.
         bases_ix, unique_bases, _ = factorize_strings(
             bases,
             missing_value=None,

--- a/zipline/data/fx/base.py
+++ b/zipline/data/fx/base.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from zipline.utils.sentinel import sentinel
+from zipline.lib._factorize import factorize_strings
 
 DEFAULT_FX_RATE = sentinel('DEFAULT_FX_RATE')
 
@@ -137,8 +138,11 @@ class FXRateReader(Interface):
 
         # TODO: Casting `bases` to str here is a temporary fix for the bug
         # where having any `None` in `bases` causes `np.unique` to error.
-        unique_bases, bases_ix = np.unique(bases.astype(str),
-                                           return_inverse=True)
+        bases_ix, unique_bases, _ = factorize_strings(
+            bases,
+            missing_value=None,
+            sort=True,
+        )
         unique_dts, dts_ix = np.unique(dts.values, return_inverse=True)
         rates_2d = self.get_rates(
             rate,

--- a/zipline/data/fx/base.py
+++ b/zipline/data/fx/base.py
@@ -127,15 +127,18 @@ class FXRateReader(Interface):
             may appear multiple times.
         dts : np.DatetimeIndex
             Datetimes for which to load rates. The same value may appear
-            multiple times, but datetimes must be sorted in ascending order and
-            localized to UTC.
+            multiple times, and datetimes do not need to be sorted because
+            `np.unique` sorts in ascending order.
         """
         if len(bases) != len(dts):
             raise ValueError(
                 "len(bases) ({}) != len(dts) ({})".format(len(bases), len(dts))
             )
 
-        unique_bases, bases_ix = np.unique(bases, return_inverse=True)
+        # TODO: Casting `bases` to str here is a temporary fix for the bug
+        # where having any `None` in `bases` causes `np.unique` to error.
+        unique_bases, bases_ix = np.unique(bases.astype(str),
+                                           return_inverse=True)
         unique_dts, dts_ix = np.unique(dts.values, return_inverse=True)
         rates_2d = self.get_rates(
             rate,

--- a/zipline/data/fx/hdf5.py
+++ b/zipline/data/fx/hdf5.py
@@ -104,6 +104,7 @@ from zipline.utils.memoize import lazyval
 from zipline.utils.numpy_utils import bytes_array_to_native_str_object_array
 
 from .base import FXRateReader, DEFAULT_FX_RATE
+from .utils import check_dts, is_sorted_ascending
 
 HDF5_FX_VERSION = 0
 
@@ -189,10 +190,7 @@ class HDF5FXRateReader(implements(FXRateReader)):
         if rate == DEFAULT_FX_RATE:
             rate = self._default_rate
 
-        # TODO: Commenting this _check_dts out for now to bypass the
-        # estimates loader date bounds issue.  Will need to address
-        # this before finalizing anything.
-        # self._check_dts(self.dts, dts)
+        check_dts(self.dts, dts)
 
         row_ixs = self.dts.searchsorted(dts, side='right') - 1
         col_ixs = self.currencies.get_indexer(bases)
@@ -207,50 +205,47 @@ class HDF5FXRateReader(implements(FXRateReader)):
 
         # OPTIMIZATION: Row indices correspond to dates, which must be in
         # sorted order. Rather than reading the entire dataset from h5, we can
-        # read just the interval from min_row to max_row inclusive.
+        # read just the interval from min_row to max_row inclusive
         #
-        # We don't bother with a similar optimization for columns because in
-        # expectation we're going to load most of the
+        # However, we also need to handle two important edge cases:
+        #
+        #   1. row_ixs contains -1 for dts before the start of self.dts.
+        #   2. col_ixs contains -1 for any currencies we don't know about.
+        #
+        # If either of the above cases obtains, we want to return NaN for the
+        # corresponding output locations.
 
-        # array, so it's easier to pull all columns and reindex in memory. For
-        # rows, however, a quick and easy optimization is to pull just the
-        # slice from min(row_ixs) to max(row_ixs).
-        min_row = max(row_ixs[0], 0)
-        max_row = row_ixs[-1]
-        rows = dataset[min_row:max_row + 1]  # +1 to be inclusive of end
+        # We handle (1) by reading raw data into a buffer with one extra
+        # row. When we then apply the row index to permute the raw data into
+        # the correct order, any rows with values of -1 will pull from the
+        # extra row, which will always contain NaN>
+        #
+        # We handle (2) by overwriting columns with indices of -1 with NaN as a
+        # postprocessing step.
+        slice_begin = max(row_ixs[0], 0)
+        slice_end = max(row_ixs[-1], 0) + 1  # +1 to be inclusive of end date.
 
-        out = rows[row_ixs - min_row][:, col_ixs]
+        # Allocate a buffer full of NaNs with one extra row/column. See
+        # OPTIMIZATION notes above.
+        buf = np.full(
+            (slice_end - slice_begin + 1, len(self.currencies)),
+            np.nan,
+        )
 
-        # get_indexer returns -1 for failed lookups. Fill these in with NaN.
+        # Read data into all but the last row/column of the buffer.
+        dataset.read_direct(
+            buf[:-1],
+            np.s_[slice_begin:slice_end],
+        )
+
+        # Permute the rows into place, pulling from the empty NaN locations for
+        # row/column indices of -1.
+        out = buf[:, col_ixs][row_ixs - slice_begin]
+
+        # Fill missing columns with NaN. See OPTIMIZATION notes above.
         out[:, col_ixs == -1] = np.nan
 
-        # TODO: searchsorted also gives -1 for failed lookups. However, these
-        # failed lookups arise due to the estimates date bounds bug that we
-        # have not yet addressed, so this is a temporary fix.
-        out[row_ixs == -1, :] = np.nan
-
         return out
-
-    def _check_dts(self, stored, requested):
-        """Validate that requested dates are in bounds for what we have stored.
-        """
-        request_start, request_end = requested[[0, -1]]
-        data_start, data_end = stored[[0, -1]]
-
-        if request_start < data_start:
-            raise ValueError(
-                "Requested fx rates starting at {}, but data starts at {}"
-                .format(request_start, data_start)
-            )
-
-        if request_end > data_end:
-            raise ValueError(
-                "Requested fx rates ending at {}, but data ends at {}"
-                .format(request_end, data_end)
-            )
-
-        if not is_sorted_ascending(requested):
-            raise ValueError("Requested fx rates with non-ascending dts.")
 
 
 class HDF5FXRateWriter(object):
@@ -320,7 +315,3 @@ class HDF5FXRateWriter(object):
 
     def _log_writing(self, *path):
         log.debug("Writing {}", '/'.join(path))
-
-
-def is_sorted_ascending(array):
-    return (np.maximum.accumulate(array) <= array).all()

--- a/zipline/data/fx/utils.py
+++ b/zipline/data/fx/utils.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+
+def check_dts(stored_dts, requested_dts):
+    """
+    Validate that ``requested_dts`` are valid for querying from an FX reader
+    that has data for ``stored_dts``.
+    """
+    request_end = requested_dts[-1]
+    data_end = stored_dts[-1]
+
+    if not is_sorted_ascending(requested_dts):
+        raise ValueError("Requested fx rates with non-ascending dts.")
+
+    if request_end > data_end:
+        raise ValueError(
+            "Requested fx rates ending at {}, but data ends at {}"
+            .format(request_end, data_end)
+        )
+
+
+def is_sorted_ascending(array):
+    return (np.maximum.accumulate(array) <= array).all()

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -2197,6 +2197,9 @@ class WithFXRates(object):
     def get_expected_fx_rate_scalar(cls, rate, quote, base, dt):
         """Get the expected FX rate for the given scalar coordinates.
         """
+        if base is None:
+            return np.nan
+
         if rate == DEFAULT_FX_RATE:
             rate = cls.FX_RATES_DEFAULT_RATE
 

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -2201,6 +2201,11 @@ class WithFXRates(object):
             rate = cls.FX_RATES_DEFAULT_RATE
 
         col = cls.fx_rates[rate][quote][base]
+        if dt < col.index[0]:
+            return np.nan
+        elif dt > col.index[-1]:
+            raise ValueError("dt={} > max dt={}".format(dt, col.index[-1]))
+
         # PERF: We call this function a lot in some suites, and get_loc is
         # surprisingly expensive, so optimizing it has a meaningful impact on
         # overall suite performance. See test_fast_get_loc_ffilled_for


### PR DESCRIPTION
- When reading before the start of data, return NaN. We do this because it's
  hard to reliably apply a lower bound to the queried dates in core-loader
  style pipeline loaders.

- When reading an unknown base currency, return NaN. We might get data from
  third parties with unknown currencies. Doing so should not be an error.

- When reading after the end of data, emit an error rather than forward-filling
  forever. We may want to revisit this in the future.