### PR TITLE
MAINT: Forward-fill fx rates past file end.

### DIFF
--- a/tests/data/test_fx.py
+++ b/tests/data/test_fx.py
@@ -69,7 +69,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
         bases = self.FX_RATES_CURRENCIES + [None]
         dates = pd.date_range(
             self.FX_RATES_START_DATE - pd.Timedelta('1 day'),
-            self.FX_RATES_END_DATE,
+            self.FX_RATES_END_DATE + pd.Timedelta('1 day'),
         )
         cases = itertools.product(rates, quotes, bases, dates)
 
@@ -98,7 +98,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
 
         dates = pd.date_range(
             self.FX_RATES_START_DATE - pd.Timedelta('2 days'),
-            self.FX_RATES_END_DATE
+            self.FX_RATES_END_DATE + pd.Timedelta('2 days'),
         )
         rates = self.FX_RATES_RATE_NAMES + [DEFAULT_FX_RATE]
         possible_quotes = self.FX_RATES_CURRENCIES
@@ -131,7 +131,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
 
         dates = pd.date_range(
             self.FX_RATES_START_DATE - pd.Timedelta('2 days'),
-            self.FX_RATES_END_DATE,
+            self.FX_RATES_END_DATE + pd.Timedelta('2 days'),
         )
         rates = self.FX_RATES_RATE_NAMES + [DEFAULT_FX_RATE]
         possible_quotes = self.FX_RATES_CURRENCIES
@@ -204,6 +204,7 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
                 quote = 'USD'
                 bases = np.array(['CAD'], dtype=object)
                 dts = pd.DatetimeIndex([bad_date])
+
                 result = self.reader.get_rates(rate, quote, bases, dts)
                 assert_equal(result.shape, (1, 1))
                 assert_equal(np.nan, result[0, 0])
@@ -221,11 +222,15 @@ class _FXReaderTestCase(zp_fixtures.WithFXRates,
                 bases = np.array(['CAD'], dtype=object)
                 dts = pd.DatetimeIndex([bad_date])
 
-                with self.assertRaises(ValueError):
-                    self.reader.get_rates(rate, quote, bases, dts)
-
-                with self.assertRaises(ValueError):
-                    self.reader.get_rates_columnar(rate, quote, bases, dts)
+                result = self.reader.get_rates(rate, quote, bases, dts)
+                assert_equal(result.shape, (1, 1))
+                expected = self.get_expected_fx_rate_scalar(
+                    rate,
+                    quote,
+                    'CAD',
+                    self.FX_RATES_END_DATE,
+                )
+                assert_equal(expected, result[0, 0])
 
     def test_read_unknown_base(self):
         for rate in self.FX_RATES_RATE_NAMES:

--- a/zipline/data/fx/hdf5.py
+++ b/zipline/data/fx/hdf5.py
@@ -190,7 +190,7 @@ class HDF5FXRateReader(implements(FXRateReader)):
         if rate == DEFAULT_FX_RATE:
             rate = self._default_rate
 
-        check_dts(self.dts, dts)
+        check_dts(dts)
 
         row_ixs = self.dts.searchsorted(dts, side='right') - 1
         col_ixs = self.currencies.get_indexer(bases)

--- a/zipline/data/fx/in_memory.py
+++ b/zipline/data/fx/in_memory.py
@@ -36,7 +36,7 @@ class InMemoryFXRateReader(implements(FXRateReader)):
 
         df = self._data[rate][quote]
 
-        check_dts(df.index, dts)
+        check_dts(dts)
 
         # Get raw values out of the frame.
         #

--- a/zipline/data/fx/utils.py
+++ b/zipline/data/fx/utils.py
@@ -1,22 +1,11 @@
 import numpy as np
 
 
-def check_dts(stored_dts, requested_dts):
+def check_dts(requested_dts):
+    """Validate that ``requested_dts`` are valid for querying from an FX reader.
     """
-    Validate that ``requested_dts`` are valid for querying from an FX reader
-    that has data for ``stored_dts``.
-    """
-    request_end = requested_dts[-1]
-    data_end = stored_dts[-1]
-
     if not is_sorted_ascending(requested_dts):
         raise ValueError("Requested fx rates with non-ascending dts.")
-
-    if request_end > data_end:
-        raise ValueError(
-            "Requested fx rates ending at {}, but data ends at {}"
-            .format(request_end, data_end)
-        )
 
 
 def is_sorted_ascending(array):

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -2205,8 +2205,6 @@ class WithFXRates(object):
         col = cls.fx_rates[rate][quote][base]
         if dt < col.index[0]:
             return np.nan
-        elif dt > col.index[-1]:
-            raise ValueError("dt={} > max dt={}".format(dt, col.index[-1]))
 
         # PERF: We call this function a lot in some suites, and get_loc is
         # surprisingly expensive, so optimizing it has a meaningful impact on


### PR DESCRIPTION
If an FX rate query requests a date that's greater than the last date in the fx
rate file, forward-fill from the last value in the file rather than raising an
error.

We do this for a few reasons:

1. We'd like to gracefully handle the possibility of an FX rates file that's
   older than another input file.

2. Relative to other non-erroring behaviors, forward-filling is the simplest
   thing to implement. Specifically, it's what the implementation prior to this
   change would do naturally if there weren't an explicit check to prevent it.

3. For an FX rates file containing prices on a 24/5 calendar, some amount of
   forward-filling is required to handle any market with a non-weekday date.