### PR TITLE
PERF: Avoid unnecessary copy in LabelArray.

### DIFF
--- a/tests/test_labelarray.py
+++ b/tests/test_labelarray.py
@@ -607,3 +607,24 @@ class LabelArrayTestCase(ZiplineTestCase):
         # before #1927 we didn't take a copy and would insert the missing value
         # (None) into the list
         assert_equal(categories, ['a', 'b', 'c'])
+
+    def test_fortran_contiguous_input(self):
+
+        strs = np.array([['a', 'b', 'c', 'd'],
+                         ['a', 'b', 'c', 'd'],
+                         ['a', 'b', 'c', 'd']], dtype=object)
+        strs_F = strs.T
+        self.assertTrue(strs_F.flags.f_contiguous)
+
+        arr = LabelArray(
+            strs_F,
+            missing_value=None,
+            categories=['a', 'b', 'c', 'd', None],
+        )
+        assert_equal(arr.as_string_array(), strs_F)
+
+        arr = LabelArray(
+            strs_F,
+            missing_value=None,
+        )
+        assert_equal(arr.as_string_array(), strs_F)

--- a/zipline/lib/labelarray.py
+++ b/zipline/lib/labelarray.py
@@ -166,16 +166,21 @@ class LabelArray(ndarray):
         if not is_object(values):
             values = values.astype(object)
 
+        if values.flags.f_contiguous:
+            ravel_order = 'F'
+        else:
+            ravel_order = 'C'
+
         if categories is None:
             codes, categories, reverse_categories = factorize_strings(
-                values.ravel(),
+                values.ravel(ravel_order),
                 missing_value=missing_value,
                 sort=sort,
             )
         else:
             codes, categories, reverse_categories = (
                 factorize_strings_known_categories(
-                    values.ravel(),
+                    values.ravel(ravel_order),
                     categories=categories,
                     missing_value=missing_value,
                     sort=sort,
@@ -184,7 +189,7 @@ class LabelArray(ndarray):
         categories.setflags(write=False)
 
         return cls.from_codes_and_metadata(
-            codes=codes.reshape(values.shape),
+            codes=codes.reshape(values.shape, order=ravel_order),
             categories=categories,
             reverse_categories=reverse_categories,
             missing_value=missing_value,


### PR DESCRIPTION
Avoid making an extra copy of non-C-contiguous arrays when factorizing inputs
to LabelArray. This requires taking care to ensure that we use the same memory
order both when ravelling and unravelling the input arrays.