### PR TITLE
Inform Pipeline Columns of Currency Awareness

### DIFF
--- a/tests/pipeline/test_column.py
+++ b/tests/pipeline/test_column.py
@@ -11,6 +11,7 @@ from pandas.util.testing import assert_frame_equal
 from zipline.lib.labelarray import LabelArray
 from zipline.pipeline import Pipeline
 from zipline.pipeline.data import USEquityPricing
+from zipline.pipeline.data.dataset import Column
 from zipline.pipeline.data.testing import TestingDataSet as TDS
 from zipline.pipeline.domain import US_EQUITIES
 from zipline.testing.fixtures import (
@@ -18,6 +19,7 @@ from zipline.testing.fixtures import (
     WithTradingSessions,
     ZiplineTestCase
 )
+from zipline.utils.numpy_utils import datetime64ns_dtype
 from zipline.utils.pandas_utils import ignore_pandas_nan_categorical_warning, \
     new_pandas, skip_pipeline_new_pandas
 
@@ -117,3 +119,14 @@ class LatestTestCase(WithSeededRandomPipelineEngine,
             column.latest < 1000
         except TypeError:
             self.fail()
+
+    def test_construction_error_message(self):
+        with self.assertRaises(ValueError) as exc:
+            Column(dtype=datetime64ns_dtype, currency_aware=True)
+
+        self.assertEqual(
+            str(exc.exception),
+            'Columns cannot be constructed with currency_aware=True, '
+            'dtype=datetime64[ns]. Currency aware columns must have a float64 '
+            'dtype.',
+        )

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -402,6 +402,16 @@ class InternationalEquityTestCase(WithInternationalPricingPipelineEngine,
             sessions[-1],
         )
 
+    def test_cannot_convert_volume_data(self):
+        with self.assertRaises(TypeError) as exc:
+            EquityPricing.volume.fx('EUR')
+
+        assert_equal(
+            str(exc.exception),
+            'The .fx() method cannot be called on EquityPricing.volume '
+            'because it does not produce currency-denominated data.',
+        )
+
     def check_expected_latest_value(self, calendar, col, date, asset, value):
         """Check the expected result of column.latest from a pipeline.
         """

--- a/zipline/pipeline/data/equity_pricing.py
+++ b/zipline/pipeline/data/equity_pricing.py
@@ -12,10 +12,10 @@ class EquityPricing(DataSet):
     :class:`~zipline.pipeline.data.DataSet` containing daily trading prices and
     volumes.
     """
-    open = Column(float64_dtype)
-    high = Column(float64_dtype)
-    low = Column(float64_dtype)
-    close = Column(float64_dtype)
+    open = Column(float64_dtype, currency_aware=True)
+    high = Column(float64_dtype, currency_aware=True)
+    low = Column(float64_dtype, currency_aware=True)
+    close = Column(float64_dtype, currency_aware=True)
     volume = Column(float64_dtype)
     currency = Column(categorical_dtype)
 


### PR DESCRIPTION
Add the ability to instantiate pipeline `Column`s with a `currency_aware` flag, indicating whether or not it makes sense to call `.fx`/convert the column's values to another currency. For example, OHLC data is currency-aware, but Volume is not.