### PR TITLE
Conda forge prep

### DIFF
--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -43,7 +43,7 @@ sqlalchemy>=1.0.8
 alembic>=0.7.7
 
 # On disk storage format for pipeline data.
-bcolz>=0.12.1,<1
+bcolz>=0.12.1
 # On disk storage format for pricing data.
 h5py>=2.7.1
 tables>=3.4.3

--- a/etc/requirements_locked.txt
+++ b/etc/requirements_locked.txt
@@ -4,99 +4,99 @@
 #
 #    pip-compile --no-index --output-file=etc/requirements_locked.txt etc/requirements.in etc/requirements_blaze.in etc/requirements_build.in etc/requirements_dev.in etc/requirements_docs.in etc/requirements_talib.in
 #
--e git+git://github.com/quantopian/blaze.git@f26375a6708eab85b7acc7869d6c518df2f974eb#egg=blaze
--e git+git://github.com/quantopian/datashape.git@cae16a85406ca4302ff1f985b74a3809be0a83a1#egg=datashape
--e git+git://github.com/quantopian/odo.git@ba84238eb8dbcac4784ae7ebf62988d7e163c283#egg=odo
+-e git+git://github.com/quantopian/blaze.git@f26375a6708eab85b7acc7869d6c518df2f974eb#egg=blaze  # via -r etc/requirements_blaze.in
+-e git+git://github.com/quantopian/datashape.git@cae16a85406ca4302ff1f985b74a3809be0a83a1#egg=datashape  # via -r etc/requirements_blaze.in
+-e git+git://github.com/quantopian/odo.git@ba84238eb8dbcac4784ae7ebf62988d7e163c283#egg=odo  # via -r etc/requirements_blaze.in
 alabaster==0.7.12         # via sphinx
-alembic==0.7.7
+alembic==0.7.7            # via -r etc/requirements.in
 argh==0.26.2              # via sphinx-autobuild, watchdog
 babel==2.6.0              # via sphinx
 backports-abc==0.5        # via tornado
-bcolz==0.12.1
-bottleneck==1.0.0
+bcolz==1.2.1              # via -r etc/requirements.in
+bottleneck==1.0.0         # via -r etc/requirements.in, empyrical
 certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
-click==7.0.0
+click==7.0.0              # via -r etc/requirements.in, flask, pip-tools
 cloudpickle==0.2.1        # via dask
 configparser==3.5.0       # via flake8
-contextlib2==0.4.0
+contextlib2==0.4.0        # via -r etc/requirements.in, blaze
 cookies==2.2.1            # via responses
-coverage==4.0.3
+coverage==4.0.3           # via -r etc/requirements_dev.in
 cycler==0.10.0            # via matplotlib
-cython==0.25.2
-cytoolz==0.8.2
-dask[dataframe]==0.13.0
+cython==0.25.2            # via -r etc/requirements_build.in
+cytoolz==0.8.2            # via -r etc/requirements_blaze.in
+dask[dataframe]==0.13.0   # via -r etc/requirements_blaze.in, blaze, odo
 decorator==4.0.0          # via networkx
 docutils==0.14            # via sphinx
-empyrical==0.5.0
+empyrical==0.5.0          # via -r etc/requirements.in
 enum34==1.1.6             # via flake8
-flake8==3.6.0
-flask-cors==2.1.3
-flask==1.1.1              # via flask-cors
+flake8==3.6.0             # via -r etc/requirements_dev.in
+flask-cors==2.1.3         # via blaze
+flask==1.1.1              # via blaze, flask-cors
 funcsigs==1.0.2           # via mock, python-interface
 futures==3.2.0            # via tornado
-h5py==2.7.1
+h5py==2.7.1               # via -r etc/requirements.in
 idna==2.7                 # via requests
-intervaltree==2.1.0
-iso3166==0.9
-iso4217==1.6.20180829
+intervaltree==2.1.0       # via -r etc/requirements.in
+iso3166==0.9              # via -r etc/requirements.in
+iso4217==1.6.20180829     # via -r etc/requirements.in
 itsdangerous==0.24        # via flask
 jinja2==2.10.1            # via flask, sphinx
 livereload==2.6.0         # via sphinx-autobuild
 locket==0.2.0             # via partd
-logbook==0.12.5
-lru-dict==1.1.4
+logbook==0.12.5           # via -r etc/requirements.in
+lru-dict==1.1.4           # via -r etc/requirements.in, trading-calendars
 mako==1.0.1               # via alembic
 markupsafe==0.23          # via jinja2, mako
-matplotlib==1.5.3
+matplotlib==1.5.3         # via -r etc/requirements_dev.in
 mccabe==0.6.0             # via flake8
-mock==2.0.0
-multipledispatch==0.6.0
-networkx==1.9.1
-nose-ignore-docstring==0.2
-nose-parameterized==0.5.0
-nose-timer==0.5.0
-nose==1.3.7
-numexpr==2.6.1
-numpy==1.11.3
-numpydoc==0.5.0
-pandas-datareader==0.2.1
-pandas==0.18.1
+mock==2.0.0               # via -r etc/requirements_dev.in, responses
+multipledispatch==0.6.0   # via -r etc/requirements.in, datashape, odo
+networkx==1.9.1           # via -r etc/requirements.in, odo
+nose-ignore-docstring==0.2  # via -r etc/requirements_dev.in
+nose-parameterized==0.5.0  # via -r etc/requirements_dev.in
+nose-timer==0.5.0         # via -r etc/requirements_dev.in
+nose==1.3.7               # via -r etc/requirements_dev.in, nose-timer
+numexpr==2.6.1            # via -r etc/requirements.in, tables
+numpy==1.11.3             # via -r etc/requirements.in, -r etc/requirements_build.in, bcolz, bottleneck, dask, datashape, empyrical, h5py, matplotlib, numexpr, odo, pandas, patsy, scipy, tables, trading-calendars
+numpydoc==0.5.0           # via -r etc/requirements_docs.in
+pandas-datareader==0.2.1  # via -r etc/requirements.in, empyrical
+pandas==0.18.1            # via -r etc/requirements.in, dask, empyrical, odo, pandas-datareader, trading-calendars
 partd==0.3.7              # via dask
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
-patsy==0.4.0
+patsy==0.4.0              # via -r etc/requirements.in
 pbr==4.3.0                # via mock
-pip-tools==4.3.0
+pip-tools==4.5.1          # via -r etc/requirements_dev.in
 port-for==0.3.1           # via sphinx-autobuild
-psutil==5.6.7
+psutil==5.6.7             # via blaze
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 pygments==2.2.0           # via sphinx
 pyparsing==2.0.3          # via matplotlib
-python-dateutil==2.4.2    # via matplotlib, pandas
-python-interface==1.5.3
-pytz==2018.5
+python-dateutil==2.4.2    # via datashape, matplotlib, pandas
+python-interface==1.5.3   # via -r etc/requirements.in
+pytz==2018.5              # via -r etc/requirements.in, babel, matplotlib, pandas, trading-calendars
 pyyaml==3.13              # via sphinx-autobuild, watchdog
 requests-file==1.4.1      # via pandas-datareader
-requests==2.20.1
-responses==0.9.0
-scipy==0.17.1
+requests==2.20.1          # via -r etc/requirements.in, pandas-datareader, requests-file, responses
+responses==0.9.0          # via -r etc/requirements_dev.in
+scipy==0.17.1             # via -r etc/requirements.in, empyrical
 singledispatch==3.4.0.3   # via tornado
-six==1.11.0
+six==1.11.0               # via -r etc/requirements.in, cycler, flask-cors, h5py, livereload, mock, multipledispatch, patsy, pip-tools, python-dateutil, python-interface, requests-file, responses, sphinx, tables
 snowballstemmer==1.2.1    # via sphinx
 sortedcontainers==2.1.0   # via intervaltree
-sphinx-autobuild==0.6.0
+sphinx-autobuild==0.6.0   # via -r etc/requirements_docs.in
 sphinx-rtd-theme==0.4.2   # via sphinx
-sphinx==1.3.2
-sqlalchemy==1.3.11
-statsmodels==0.6.1
-ta-lib==0.4.9
-tables==3.4.3
+sphinx==1.3.2             # via -r etc/requirements_docs.in, sphinx-rtd-theme
+sqlalchemy==1.3.11        # via -r etc/requirements.in, alembic, blaze
+statsmodels==0.6.1        # via -r etc/requirements.in
+ta-lib==0.4.9             # via -r etc/requirements_talib.in
+tables==3.4.3             # via -r etc/requirements.in
 termcolor==1.1.0          # via nose-timer
-testfixtures==6.10.1
-toolz==0.8.2
+testfixtures==6.10.1      # via -r etc/requirements_dev.in
+toolz==0.8.2              # via -r etc/requirements.in, blaze, cytoolz, dask, odo, partd, trading-calendars
 tornado==5.1.1            # via livereload, sphinx-autobuild
-trading-calendars==1.11.2
+trading-calendars==1.11.2  # via -r etc/requirements.in
 typing==3.6.2             # via python-interface
 urllib3==1.24.3           # via requests
 watchdog==0.9.0           # via sphinx-autobuild


### PR DESCRIPTION
- Conda packaging is much easier if we allow newer bcolz.
- Bump pip-tools and bcolz in CI requirements lockfile