### PR TITLE
ENH: Add Filter.if_else and ComputableTerm.fillna.

### DIFF
--- a/tests/pipeline/base.py
+++ b/tests/pipeline/base.py
@@ -6,6 +6,7 @@ from numpy import arange, prod
 from pandas import DataFrame, Timestamp
 from six import iteritems
 
+from zipline.lib.labelarray import LabelArray
 from zipline.utils.compat import wraps
 from zipline.pipeline import ExecutionPlan
 from zipline.pipeline.domain import US_EQUITIES
@@ -171,9 +172,42 @@ class BaseUSEquityPipelineTestCase(WithTradingSessions,
     @with_default_shape
     def randn_data(self, seed, shape):
         """
-        Build a block of testing data from a seeded RandomState.
+        Build a block of random numerical data.
         """
         return np.random.RandomState(seed).randn(*shape)
+
+    @with_default_shape
+    def rand_ints(self, seed, shape, low=0, high=10):
+        """
+        Build a block of random numerical data.
+        """
+        rand = np.random.RandomState(seed)
+        return rand.randint(low, high, shape, dtype='i8')
+
+    @with_default_shape
+    def rand_datetimes(self, seed, shape):
+        ints = self.rand_ints(seed=seed, shape=shape, low=0, high=10000)
+        return ints.astype('datetime64[D]').astype('datetime64[ns]')
+
+    @with_default_shape
+    def rand_categoricals(self, categories, seed, shape, missing_value=None):
+        """Build a block of random categorical data.
+
+        Categories should not include ``missing_value``.
+        """
+        categories = list(categories) + [missing_value]
+        data = np.random.RandomState(seed).choice(categories, shape)
+        return LabelArray(
+            data,
+            missing_value=missing_value,
+            categories=categories,
+        )
+
+    @with_default_shape
+    def rand_mask(self, seed, shape):
+        """Build a block of random boolean data.
+        """
+        return np.random.RandomState(seed).randint(0, 2, shape).astype(bool)
 
     @with_default_shape
     def eye_mask(self, shape):

--- a/tests/pipeline/test_computable_term.py
+++ b/tests/pipeline/test_computable_term.py
@@ -244,17 +244,17 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         self.assertEqual(message, expected_message)
 
     def test_bad_inputs(self):
-        def dtype_for_str(s):
-            return str(np.array([s]).dtype)
+        def dtype_for(o):
+            return np.array([o]).dtype
 
         self.should_error(
             lambda: Floats().fillna('3.0'),
             TypeError,
             "Fill value '3.0' is not a valid choice for term Floats with"
             " dtype float64.\n\n"
-            "Coercion attempt failed with: Cannot cast array from dtype('{}')"
-            " to dtype('float64') according to the rule 'same_kind'"
-            .format(dtype_for_str('3.0'))
+            "Coercion attempt failed with: Cannot cast array from {!r}"
+            " to {!r} according to the rule 'same_kind'"
+            .format(dtype_for('3.0'), np.dtype(float))
         )
 
         self.should_error(
@@ -262,9 +262,9 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
             TypeError,
             "Fill value '2014-01-02' is not a valid choice for term Dates with"
             " dtype datetime64[ns].\n\n"
-            "Coercion attempt failed with: Cannot cast array from dtype('{}')"
-            " to dtype('<M8[ns]') according to the rule 'same_kind'"
-            .format(dtype_for_str('2014-01-02'))
+            "Coercion attempt failed with: Cannot cast array from {!r}"
+            " to {!r} according to the rule 'same_kind'"
+            .format(dtype_for('2014-01-02'), np.dtype('M8[ns]'))
         )
 
         self.should_error(
@@ -272,9 +272,9 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
             TypeError,
             "Fill value '300' is not a valid choice for term Ints with"
             " dtype int64.\n\n"
-            "Coercion attempt failed with: Cannot cast array from dtype('{}')"
-            " to dtype('int64') according to the rule 'same_kind'"
-            .format(dtype_for_str('300'))
+            "Coercion attempt failed with: Cannot cast array from {!r}"
+            " to {!r} according to the rule 'same_kind'"
+            .format(dtype_for('300'), np.dtype('i8')),
         )
 
         self.should_error(
@@ -282,8 +282,9 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
             TypeError,
             "Fill value 10.0 is not a valid choice for term Strs with dtype"
             " object.\n\n"
-            "Coercion attempt failed with: Classifiers can only produce values"
-            " of type bytes or str or NoneType."
+            "Coercion attempt failed with: "
+            "String-dtype classifiers can only produce strings or None."
+
         )
 
     def make_labelarray(self, strs):

--- a/tests/pipeline/test_computable_term.py
+++ b/tests/pipeline/test_computable_term.py
@@ -244,31 +244,37 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         self.assertEqual(message, expected_message)
 
     def test_bad_inputs(self):
+        def dtype_for_str(s):
+            return str(np.array([s]).dtype)
+
         self.should_error(
-            lambda: Floats().fillna(u'asdf'),
+            lambda: Floats().fillna('3.0'),
             TypeError,
-            "Fill value 'asdf' is not a valid choice for term Floats with "
-            "dtype float64.\n\n"
-            "Coercion attempt failed with: Cannot cast array from dtype('<U4')"
+            "Fill value '3.0' is not a valid choice for term Floats with"
+            " dtype float64.\n\n"
+            "Coercion attempt failed with: Cannot cast array from dtype('{}')"
             " to dtype('float64') according to the rule 'same_kind'"
+            .format(dtype_for_str('3.0'))
         )
 
         self.should_error(
-            lambda: Dates().fillna(u'asdf'),
+            lambda: Dates().fillna('2014-01-02'),
             TypeError,
-            "Fill value 'asdf' is not a valid choice for term Dates with "
-            "dtype datetime64[ns].\n\n"
-            "Coercion attempt failed with: Cannot cast array from dtype('<U4')"
+            "Fill value '2014-01-02' is not a valid choice for term Dates with"
+            " dtype datetime64[ns].\n\n"
+            "Coercion attempt failed with: Cannot cast array from dtype('{}')"
             " to dtype('<M8[ns]') according to the rule 'same_kind'"
+            .format(dtype_for_str('2014-01-02'))
         )
 
         self.should_error(
-            lambda: Ints().fillna(u'asdf'),
+            lambda: Ints().fillna('300'),
             TypeError,
-            "Fill value 'asdf' is not a valid choice for term Ints with "
-            "dtype int64.\n\n"
-            "Coercion attempt failed with: Cannot cast array from dtype('<U4')"
+            "Fill value '300' is not a valid choice for term Ints with"
+            " dtype int64.\n\n"
+            "Coercion attempt failed with: Cannot cast array from dtype('{}')"
             " to dtype('int64') according to the rule 'same_kind'"
+            .format(dtype_for_str('300'))
         )
 
         self.should_error(

--- a/tests/pipeline/test_computable_term.py
+++ b/tests/pipeline/test_computable_term.py
@@ -1,0 +1,284 @@
+"""Tests for common behaviors shared by all ComputableTerms.
+"""
+import numpy as np
+
+from zipline.lib.labelarray import LabelArray
+from zipline.pipeline import Classifier, Factor, Filter
+from zipline.testing import parameter_space
+from zipline.utils.numpy_utils import (
+    categorical_dtype,
+    datetime64ns_dtype,
+    float64_dtype,
+    int64_dtype,
+    NaTns,
+)
+
+from .base import BaseUSEquityPipelineTestCase
+
+
+class Floats(Factor):
+    inputs = ()
+    window_length = 0
+    dtype = float64_dtype
+
+
+class AltFloats(Factor):
+    inputs = ()
+    window_length = 0
+    dtype = float64_dtype
+
+
+class Dates(Factor):
+    inputs = ()
+    window_length = 0
+    dtype = datetime64ns_dtype
+
+
+class AltDates(Factor):
+    inputs = ()
+    window_length = 0
+    dtype = datetime64ns_dtype
+
+
+class Bools(Filter):
+    inputs = ()
+    window_length = 0
+
+
+class AltBools(Filter):
+    inputs = ()
+    window_length = 0
+
+
+class Strs(Classifier):
+    inputs = ()
+    window_length = 0
+    dtype = categorical_dtype
+    missing_value = None
+
+
+class AltStrs(Classifier):
+    inputs = ()
+    window_length = 0
+    dtype = categorical_dtype
+    missing_value = None
+
+
+class Ints(Classifier):
+    inputs = ()
+    window_length = 0
+    dtype = int64_dtype
+    missing_value = -1
+
+
+class AltInts(Classifier):
+    inputs = ()
+    window_length = 0
+    dtype = int64_dtype
+    missing_value = -1
+
+
+class FillNATestCase(BaseUSEquityPipelineTestCase):
+
+    @parameter_space(
+        null_locs=[
+            # No NaNs.
+            np.zeros((4, 4), dtype=bool),
+            # All NaNs.
+            np.ones((4, 4), dtype=bool),
+            # NaNs on Diagonal
+            np.eye(4, dtype=bool),
+            # Nans every third element.
+            (np.arange(16).reshape(4, 4) % 3) == 0,
+        ]
+    )
+    def test_fillna_with_scalar(self, null_locs):
+        shape = (4, 4)
+        num_cells = shape[0] * shape[1]
+
+        floats = np.arange(num_cells, dtype=float).reshape(shape)
+        floats[null_locs] = np.nan
+        float_fillval = 999.0
+        float_expected = np.where(null_locs, float_fillval, floats)
+        float_expected_zero = np.where(null_locs, 0.0, floats)
+
+        dates = (
+            np.arange(num_cells).view('M8[D]').astype('M8[ns]').reshape(shape)
+        )
+        dates[null_locs] = NaTns
+        date_fillval = np.datetime64('2014-01-02', 'ns')
+        date_expected = np.where(null_locs, date_fillval, dates)
+
+        strs = np.arange(num_cells).astype(str).astype(object).reshape(shape)
+        strs[null_locs] = None
+        str_fillval = "filled"
+        str_expected = np.where(null_locs, str_fillval, strs)
+
+        ints = np.arange(num_cells).reshape(shape)
+        ints[null_locs] = -1
+        int_fillval = 777
+        int_expected = np.where(null_locs, int_fillval, ints)
+
+        terms = {
+            'floats': Floats().fillna(float_fillval),
+            # Make sure we accept integer as a fill value on float-dtype
+            # factors.
+            'floats_fill_zero': Floats().fillna(0),
+            'dates': Dates().fillna(date_fillval),
+            'strs': Strs().fillna(str_fillval),
+            'ints': Ints().fillna(int_fillval),
+        }
+
+        expected = {
+            'floats': float_expected,
+            'floats_fill_zero': float_expected_zero,
+            'dates': date_expected,
+            'strs': self.make_labelarray(str_expected),
+            'ints': int_expected,
+        }
+
+        self.check_terms(
+            terms,
+            expected,
+            initial_workspace={
+                Floats(): floats,
+                Dates(): dates,
+                Strs(): self.make_labelarray(strs),
+                Ints(): ints,
+            },
+            mask=self.build_mask(self.ones_mask(shape=(4, 4))),
+        )
+
+    @parameter_space(
+        null_locs=[
+            # No NaNs.
+            np.zeros((4, 4), dtype=bool),
+            # # All NaNs.
+            np.ones((4, 4), dtype=bool),
+            # NaNs on Diagonal
+            np.eye(4, dtype=bool),
+            # Nans every third element.
+            (np.arange(16).reshape((4, 4)) % 3) == 0,
+        ]
+    )
+    def test_fillna_with_expression(self, null_locs):
+        shape = (4, 4)
+        mask = self.build_mask(self.ones_mask(shape=(4, 4)))
+        state = np.random.RandomState(4)
+        assets = self.asset_finder.retrieve_all(mask.columns)
+
+        def rand_vals(dtype):
+            return state.randint(1, 100, shape).astype(dtype)
+
+        floats = np.arange(16, dtype=float).reshape(shape)
+        floats[null_locs] = np.nan
+        float_fillval = rand_vals(float)
+        float_expected = np.where(null_locs, float_fillval, floats)
+        float_expected_1d = np.where(null_locs, float_fillval[:, [0]], floats)
+
+        dates = np.arange(16).view('M8[D]').astype('M8[ns]').reshape(shape)
+        dates[null_locs] = NaTns
+        date_fillval = rand_vals('M8[D]').astype('M8[ns]')
+        date_expected = np.where(null_locs, date_fillval, dates)
+        date_expected_1d = np.where(null_locs, date_fillval[:, [1]], dates)
+
+        strs = np.arange(16).astype(str).astype(object).reshape(shape)
+        strs[null_locs] = None
+        str_fillval = rand_vals(str)
+        str_expected = np.where(null_locs, str_fillval, strs)
+        str_expected_1d = np.where(null_locs, str_fillval[:, [2]], strs)
+
+        ints = np.arange(16).reshape(shape)
+        ints[null_locs] = -1
+        int_fillval = rand_vals(int64_dtype)
+        int_expected = np.where(null_locs, int_fillval, ints)
+        int_expected_1d = np.where(null_locs, int_fillval[:, [3]], ints)
+
+        terms = {
+            'floats': Floats().fillna(AltFloats()),
+            'floats_1d': Floats().fillna(AltFloats()[assets[0]]),
+
+            'dates': Dates().fillna(AltDates()),
+            'dates_1d': Dates().fillna(AltDates()[assets[1]]),
+
+            'strs': Strs().fillna(AltStrs()),
+            'strs_1d': Strs().fillna(AltStrs()[assets[2]]),
+
+            'ints': Ints().fillna(AltInts()),
+            'ints_1d': Ints().fillna(AltInts()[assets[3]]),
+        }
+
+        expected = {
+            'floats': float_expected,
+            'floats_1d': float_expected_1d,
+            'dates': date_expected,
+            'dates_1d': date_expected_1d,
+            'strs': self.make_labelarray(str_expected),
+            'strs_1d': self.make_labelarray(str_expected_1d),
+            'ints': int_expected,
+            'ints_1d': int_expected_1d,
+        }
+
+        self.check_terms(
+            terms,
+            expected,
+            initial_workspace={
+                Floats(): floats,
+                Dates(): dates,
+                Strs(): self.make_labelarray(strs),
+                Ints(): ints,
+
+                AltFloats(): float_fillval,
+                AltDates(): date_fillval,
+                AltStrs(): self.make_labelarray(str_fillval),
+                AltInts(): int_fillval,
+            },
+            mask=mask,
+        )
+
+    def should_error(self, f, exc_type, expected_message):
+        with self.assertRaises(exc_type) as e:
+            f()
+
+        message = str(e.exception)
+        self.assertEqual(message, expected_message)
+
+    def test_bad_inputs(self):
+        self.should_error(
+            lambda: Floats().fillna('asdf'),
+            TypeError,
+            "Fill value 'asdf' is not a valid choice for term Floats with "
+            "dtype float64.\n\n"
+            "Coercion attempt failed with: Cannot cast array from dtype('<U4')"
+            " to dtype('float64') according to the rule 'same_kind'"
+        )
+
+        self.should_error(
+            lambda: Dates().fillna('asdf'),
+            TypeError,
+            "Fill value 'asdf' is not a valid choice for term Dates with "
+            "dtype datetime64[ns].\n\n"
+            "Coercion attempt failed with: Cannot cast array from dtype('<U4')"
+            " to dtype('<M8[ns]') according to the rule 'same_kind'"
+        )
+
+        self.should_error(
+            lambda: Ints().fillna('asdf'),
+            TypeError,
+            "Fill value 'asdf' is not a valid choice for term Ints with "
+            "dtype int64.\n\n"
+            "Coercion attempt failed with: Cannot cast array from dtype('<U4')"
+            " to dtype('int64') according to the rule 'same_kind'"
+        )
+
+        self.should_error(
+            lambda: Strs().fillna(10.0),
+            TypeError,
+            "Fill value 10.0 is not a valid choice for term Strs with dtype"
+            " object.\n\n"
+            "Coercion attempt failed with: Classifiers can only produce values"
+            " of type bytes or str or NoneType."
+        )
+
+    def make_labelarray(self, strs):
+        return LabelArray(strs, missing_value=None)

--- a/tests/pipeline/test_computable_term.py
+++ b/tests/pipeline/test_computable_term.py
@@ -245,7 +245,7 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
 
     def test_bad_inputs(self):
         self.should_error(
-            lambda: Floats().fillna('asdf'),
+            lambda: Floats().fillna(u'asdf'),
             TypeError,
             "Fill value 'asdf' is not a valid choice for term Floats with "
             "dtype float64.\n\n"
@@ -254,7 +254,7 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         )
 
         self.should_error(
-            lambda: Dates().fillna('asdf'),
+            lambda: Dates().fillna(u'asdf'),
             TypeError,
             "Fill value 'asdf' is not a valid choice for term Dates with "
             "dtype datetime64[ns].\n\n"
@@ -263,7 +263,7 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         )
 
         self.should_error(
-            lambda: Ints().fillna('asdf'),
+            lambda: Ints().fillna(u'asdf'),
             TypeError,
             "Fill value 'asdf' is not a valid choice for term Ints with "
             "dtype int64.\n\n"

--- a/tests/pipeline/test_computable_term.py
+++ b/tests/pipeline/test_computable_term.py
@@ -102,9 +102,10 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         float_expected = np.where(null_locs, float_fillval, floats)
         float_expected_zero = np.where(null_locs, 0.0, floats)
 
-        dates = (
-            np.arange(num_cells).view('M8[D]').astype('M8[ns]').reshape(shape)
-        )
+        dates = (np.arange(num_cells, dtype='i8')
+                 .view('M8[D]')
+                 .astype('M8[ns]')
+                 .reshape(shape))
         dates[null_locs] = NaTns
         date_fillval = np.datetime64('2014-01-02', 'ns')
         date_expected = np.where(null_locs, date_fillval, dates)
@@ -176,7 +177,10 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         float_expected = np.where(null_locs, float_fillval, floats)
         float_expected_1d = np.where(null_locs, float_fillval[:, [0]], floats)
 
-        dates = np.arange(16).view('M8[D]').astype('M8[ns]').reshape(shape)
+        dates = (np.arange(16, dtype='i8')
+                 .view('M8[D]')
+                 .astype('M8[ns]').
+                 reshape(shape))
         dates[null_locs] = NaTns
         date_fillval = rand_vals('M8[D]').astype('M8[ns]')
         date_expected = np.where(null_locs, date_fillval, dates)

--- a/tests/pipeline/test_computable_term.py
+++ b/tests/pipeline/test_computable_term.py
@@ -115,7 +115,7 @@ class FillNATestCase(BaseUSEquityPipelineTestCase):
         str_fillval = "filled"
         str_expected = np.where(null_locs, str_fillval, strs)
 
-        ints = np.arange(num_cells).reshape(shape)
+        ints = np.arange(num_cells, dtype='i8').reshape(shape)
         ints[null_locs] = -1
         int_fillval = 777
         int_expected = np.where(null_locs, int_fillval, ints)

--- a/tests/pipeline/test_numerical_expression.py
+++ b/tests/pipeline/test_numerical_expression.py
@@ -30,8 +30,8 @@ from pandas import (
 )
 
 from zipline.pipeline import Factor, Filter
+from zipline.pipeline.factors.factor import NumExprFactor
 from zipline.pipeline.expression import (
-    NumericalExpression,
     NUMEXPR_MATH_FUNCS,
 )
 from zipline.testing import check_allclose
@@ -101,39 +101,39 @@ class NumericalExpressionTestCase(TestCase):
         f = self.f
         g = self.g
 
-        NumericalExpression("x_0", (f,), dtype=float64_dtype)
-        NumericalExpression("x_0 ", (f,), dtype=float64_dtype)
-        NumericalExpression("x_0 + x_0", (f,), dtype=float64_dtype)
-        NumericalExpression("x_0 + 2", (f,), dtype=float64_dtype)
-        NumericalExpression("2 * x_0", (f,), dtype=float64_dtype)
-        NumericalExpression("x_0 + x_1", (f, g), dtype=float64_dtype)
-        NumericalExpression("x_0 + x_1 + x_0", (f, g), dtype=float64_dtype)
-        NumericalExpression("x_0 + 1 + x_1", (f, g), dtype=float64_dtype)
+        NumExprFactor("x_0", (f,), dtype=float64_dtype)
+        NumExprFactor("x_0 ", (f,), dtype=float64_dtype)
+        NumExprFactor("x_0 + x_0", (f,), dtype=float64_dtype)
+        NumExprFactor("x_0 + 2", (f,), dtype=float64_dtype)
+        NumExprFactor("2 * x_0", (f,), dtype=float64_dtype)
+        NumExprFactor("x_0 + x_1", (f, g), dtype=float64_dtype)
+        NumExprFactor("x_0 + x_1 + x_0", (f, g), dtype=float64_dtype)
+        NumExprFactor("x_0 + 1 + x_1", (f, g), dtype=float64_dtype)
 
     def test_validate_bad(self):
         f, g, h = self.f, self.g, self.h
 
         # Too few inputs.
         with self.assertRaises(ValueError):
-            NumericalExpression("x_0", (), dtype=float64_dtype)
+            NumExprFactor("x_0", (), dtype=float64_dtype)
         with self.assertRaises(ValueError):
-            NumericalExpression("x_0 + x_1", (f,), dtype=float64_dtype)
+            NumExprFactor("x_0 + x_1", (f,), dtype=float64_dtype)
 
         # Too many inputs.
         with self.assertRaises(ValueError):
-            NumericalExpression("x_0", (f, g), dtype=float64_dtype)
+            NumExprFactor("x_0", (f, g), dtype=float64_dtype)
         with self.assertRaises(ValueError):
-            NumericalExpression("x_0 + x_1", (f, g, h), dtype=float64_dtype)
+            NumExprFactor("x_0 + x_1", (f, g, h), dtype=float64_dtype)
 
         # Invalid variable name.
         with self.assertRaises(ValueError):
-            NumericalExpression("x_0x_1", (f,), dtype=float64_dtype)
+            NumExprFactor("x_0x_1", (f,), dtype=float64_dtype)
         with self.assertRaises(ValueError):
-            NumericalExpression("x_0x_1", (f, g), dtype=float64_dtype)
+            NumExprFactor("x_0x_1", (f, g), dtype=float64_dtype)
 
         # Variable index must start at 0.
         with self.assertRaises(ValueError):
-            NumericalExpression("x_1", (f,), dtype=float64_dtype)
+            NumExprFactor("x_1", (f,), dtype=float64_dtype)
 
         # Scalar operands must be numeric.
         with self.assertRaises(TypeError):

--- a/tests/pipeline/test_term.py
+++ b/tests/pipeline/test_term.py
@@ -34,7 +34,7 @@ from zipline.pipeline.domain import US_EQUITIES
 from zipline.pipeline.expression import NUMEXPR_MATH_FUNCS
 from zipline.pipeline.factors import RecarrayField
 from zipline.pipeline.sentinels import NotSpecified
-from zipline.pipeline.term import AssetExists, LoadableTerm, Slice
+from zipline.pipeline.term import AssetExists, LoadableTerm
 from zipline.testing import parameter_space
 from zipline.testing.fixtures import WithTradingSessions, ZiplineTestCase
 from zipline.testing.predicates import (
@@ -350,15 +350,15 @@ class ObjectIdentityTestCase(TestCase):
 
         f = GenericCustomFactor()
         f_slice = f[my_asset]
-        self.assertIs(f_slice, Slice(GenericCustomFactor(), my_asset))
+        self.assertIs(f_slice, type(f_slice)(GenericCustomFactor(), my_asset))
 
-        f = GenericFilter()
-        f_slice = f[my_asset]
-        self.assertIs(f_slice, Slice(GenericFilter(), my_asset))
+        filt = GenericFilter()
+        filt_slice = filt[my_asset]
+        self.assertIs(filt_slice, type(filt_slice)(GenericFilter(), my_asset))
 
         c = GenericClassifier()
         c_slice = c[my_asset]
-        self.assertIs(c_slice, Slice(GenericClassifier(), my_asset))
+        self.assertIs(c_slice, type(c_slice)(GenericClassifier(), my_asset))
 
     def test_instance_non_caching(self):
 

--- a/zipline/lib/labelarray.py
+++ b/zipline/lib/labelarray.py
@@ -825,6 +825,7 @@ class _sortable_sentinel(object):
         return True
 
 
+@expect_types(trues=LabelArray, falses=LabelArray)
 def labelarray_where(cond, trues, falses):
     """LabelArray-aware implementation of np.where.
     """

--- a/zipline/lib/labelarray.py
+++ b/zipline/lib/labelarray.py
@@ -823,3 +823,15 @@ class _sortable_sentinel(object):
 
     def __lt__(self, other):
         return True
+
+
+def labelarray_where(cond, trues, falses):
+    """LabelArray-aware implementation of np.where.
+    """
+    if trues.missing_value != falses.missing_value:
+        raise ValueError(
+            "Can't compute where on arrays with different missing values."
+        )
+
+    strs = np.where(cond, trues.as_string_array(), falses.as_string_array())
+    return LabelArray(strs, missing_value=trues.missing_value)

--- a/zipline/pipeline/classifiers/classifier.py
+++ b/zipline/pipeline/classifiers/classifier.py
@@ -65,18 +65,6 @@ class Classifier(RestrictedDTypeMixin, ComputableTerm):
     ALLOWED_DTYPES = CLASSIFIER_DTYPES
     categories = NotSpecified
 
-    def isnull(self):
-        """
-        A Filter producing True for values where this term has missing data.
-        """
-        return NullFilter(self)
-
-    def notnull(self):
-        """
-        A Filter producing True for values where this term has complete data.
-        """
-        return NotNullFilter(self)
-
     # We explicitly don't support classifier to classifier comparisons, since
     # the stored values likely don't mean the same thing. This may be relaxed
     # in the future, but for now we're starting conservatively.
@@ -370,13 +358,9 @@ class Classifier(RestrictedDTypeMixin, ComputableTerm):
             self.missing_value,
         )
 
-    @classlazyval
-    def _downsampled_type(self):
-        return DownsampledMixin.make_downsampled_type(Classifier)
-
-    @classlazyval
-    def _aliased_type(self):
-        return AliasedMixin.make_aliased_type(Classifier)
+    @classmethod
+    def _principal_computable_term_type(cls):
+        return Classifier
 
     def _to_integral(self, output_array):
         """

--- a/zipline/pipeline/classifiers/classifier.py
+++ b/zipline/pipeline/classifiers/classifier.py
@@ -22,18 +22,15 @@ from zipline.pipeline.sentinels import NotSpecified
 from zipline.pipeline.term import ComputableTerm
 from zipline.utils.compat import unicode
 from zipline.utils.input_validation import expect_types, expect_dtypes
-from zipline.utils.memoize import classlazyval
 from zipline.utils.numpy_utils import (
     categorical_dtype,
     int64_dtype,
     vectorized_is_element,
 )
 
-from ..filters import ArrayPredicate, NotNullFilter, NullFilter, NumExprFilter
+from ..filters import ArrayPredicate, NumExprFilter
 from ..mixins import (
-    AliasedMixin,
     CustomTermMixin,
-    DownsampledMixin,
     LatestMixin,
     PositiveWindowLengthMixin,
     RestrictedDTypeMixin,

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -40,13 +40,9 @@ from zipline.pipeline.filters import (
     NumExprFilter,
     PercentileFilter,
     MaximumFilter,
-    NotNullFilter,
-    NullFilter,
 )
 from zipline.pipeline.mixins import (
-    AliasedMixin,
     CustomTermMixin,
-    DownsampledMixin,
     LatestMixin,
     PositiveWindowLengthMixin,
     RestrictedDTypeMixin,
@@ -57,7 +53,6 @@ from zipline.pipeline.term import AssetExists, ComputableTerm, Term
 from zipline.utils.functional import with_doc, with_name
 from zipline.utils.input_validation import expect_types
 from zipline.utils.math_utils import nanmean, nanstd
-from zipline.utils.memoize import classlazyval
 from zipline.utils.numpy_utils import (
     bool_dtype,
     coerce_to_dtype,

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -1195,33 +1195,6 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
             mask=mask,
         )
 
-    def isnull(self):
-        """
-        A Filter producing True for values where this Factor has missing data.
-
-        Equivalent to self.isnan() when ``self.dtype`` is float64.
-        Otherwise equivalent to ``self.eq(self.missing_value)``.
-
-        Returns
-        -------
-        filter : zipline.pipeline.Filter
-        """
-        if self.dtype == float64_dtype:
-            # Using isnan is more efficient when possible because we can fold
-            # the isnan computation with other NumExpr expressions.
-            return self.isnan()
-        else:
-            return NullFilter(self)
-
-    def notnull(self):
-        """
-        A Filter producing True for values where this Factor has complete data.
-
-        Equivalent to ``~self.isnan()` when ``self.dtype`` is float64.
-        Otherwise equivalent to ``(self != self.missing_value)``.
-        """
-        return NotNullFilter(self)
-
     @if_not_float64_tell_caller_to_use_isnull
     def isnan(self):
         """
@@ -1252,13 +1225,9 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
         """
         return (-inf < self) & (self < inf)
 
-    @classlazyval
-    def _downsampled_type(self):
-        return DownsampledMixin.make_downsampled_type(Factor)
-
-    @classlazyval
-    def _aliased_type(self):
-        return AliasedMixin.make_aliased_type(Factor)
+    @classmethod
+    def _principal_computable_term_type(cls):
+        return Factor
 
 
 class NumExprFactor(NumericalExpression, Factor):

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -219,13 +219,10 @@ class Filter(RestrictedDTypeMixin, ComputableTerm):
             )
         return retval
 
-    @classlazyval
-    def _downsampled_type(self):
-        return DownsampledMixin.make_downsampled_type(Filter)
+    @classmethod
+    def _principal_computable_term_type(cls):
+        return Filter
 
-    @classlazyval
-    def _aliased_type(self):
-        return AliasedMixin.make_aliased_type(Filter)
 
 
 class NumExprFilter(NumericalExpression, Filter):

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -32,6 +32,7 @@ from zipline.pipeline.expression import (
 )
 from zipline.pipeline.mixins import (
     CustomTermMixin,
+    IfElseMixin,
     LatestMixin,
     PositiveWindowLengthMixin,
     RestrictedDTypeMixin,
@@ -309,7 +310,9 @@ class Filter(RestrictedDTypeMixin, ComputableTerm):
                 .format(if_true.missing_value, if_false.missing_value)
             )
 
-        return if_true._if_else_type(
+        return_type = type(if_true)._with_mixin(IfElseMixin)
+
+        return return_type(
             condition=self,
             if_true=if_true,
             if_false=if_false,

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -44,6 +44,7 @@ from zipline.pipeline.term import ComputableTerm, Term
 from zipline.utils.input_validation import expect_types
 from zipline.utils.memoize import classlazyval
 from zipline.utils.numpy_utils import (
+    same,
     bool_dtype,
     int64_dtype,
     repeat_first_axis,
@@ -223,6 +224,99 @@ class Filter(RestrictedDTypeMixin, ComputableTerm):
     def _principal_computable_term_type(cls):
         return Filter
 
+    @expect_types(if_true=ComputableTerm, if_false=ComputableTerm)
+    def if_else(self, if_true, if_false):
+        """
+        Create a term that selects values from one of two choices.
+
+        Parameters
+        ----------
+        if_true : zipline.pipeline.term.ComputableTerm
+            Expression whose values should be used at locations where this
+            filter outputs True.
+        if_false : zipline.pipeline.term.ComputableTerm
+            Expression whose values should be used at locations where this
+            filter outputs False.
+
+        Returns
+        -------
+        merged : zipline.pipeline.term.ComputableTerm
+           A term that computes by taking values from either ``if_true`` or
+           ``if_false``, depending on the values produced by ``self``.
+
+           The returned term draws from``if_true`` at locations where ``self``
+           produces True, and it draws from ``if_false`` at locations where
+           ``self`` produces False.
+
+        Example
+        -------
+
+        Let ``f`` be a Factor that produces the following output::
+
+                         AAPL   MSFT    MCD     BK
+            2017-03-13    1.0    2.0    3.0    4.0
+            2017-03-14    5.0    6.0    7.0    8.0
+
+        Let ``g`` be another Factor that produces the following output::
+
+                         AAPL   MSFT    MCD     BK
+            2017-03-13   10.0   20.0   30.0   40.0
+            2017-03-14   50.0   60.0   70.0   80.0
+
+        Finally, let ``condition`` be a Filter that produces the following
+        output::
+
+                         AAPL   MSFT    MCD     BK
+            2017-03-13   True  False   True  False
+            2017-03-14   True   True  False  False
+
+        Then, the expression ``condition.if_else(f, g)`` produces the following
+        output::
+
+                         AAPL   MSFT    MCD     BK
+            2017-03-13    1.0   20.0    3.0   40.0
+            2017-03-14    5.0    6.0   70.0   80.0
+
+        See Also
+        --------
+        numpy.where
+        Factor.fillna
+        """
+        true_type = if_true._principal_computable_term_type()
+        false_type = if_false._principal_computable_term_type()
+
+        if true_type is not false_type:
+            raise TypeError(
+                "Mismatched types in if_else(): if_true={}, but if_false={}"
+                .format(true_type.__name__, false_type.__name__)
+            )
+
+        if if_true.dtype != if_false.dtype:
+            raise TypeError(
+                "Mismatched dtypes in if_else(): "
+                "if_true.dtype = {}, if_false.dtype = {}"
+                .format(if_true.dtype, if_false.dtype)
+            )
+
+        if if_true.outputs != if_false.outputs:
+            raise ValueError(
+                "Mismatched outputs in if_else(): "
+                "if_true.outputs = {}, if_false.outputs = {}"
+                .format(if_true.outputs, if_false.outputs),
+            )
+
+        if not same(if_true.missing_value, if_false.missing_value):
+            raise ValueError(
+                "Mismatched missing values in if_else(): "
+                "if_true.missing_value = {!r}, if_false.missing_value = {!r}"
+                .format(if_true.missing_value, if_false.missing_value)
+            )
+
+        return if_true._if_else_type(
+            condition=self,
+            if_true=if_true,
+            if_false=if_false,
+        )
 
 
 class NumExprFilter(NumericalExpression, Filter):

--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -31,9 +31,7 @@ from zipline.pipeline.expression import (
     NumericalExpression,
 )
 from zipline.pipeline.mixins import (
-    AliasedMixin,
     CustomTermMixin,
-    DownsampledMixin,
     LatestMixin,
     PositiveWindowLengthMixin,
     RestrictedDTypeMixin,
@@ -42,7 +40,6 @@ from zipline.pipeline.mixins import (
 )
 from zipline.pipeline.term import ComputableTerm, Term
 from zipline.utils.input_validation import expect_types
-from zipline.utils.memoize import classlazyval
 from zipline.utils.numpy_utils import (
     same,
     bool_dtype,

--- a/zipline/pipeline/mixins.py
+++ b/zipline/pipeline/mixins.py
@@ -326,28 +326,10 @@ class AliasedMixin(SingleInputMixin):
         """
         Factory for making Aliased{Filter,Factor,Classifier}.
         """
-        docstring = dedent(
-            """
-            A {t} that names another {t}.
-
-            Parameters
-            ----------
-            term : {t}
-            {{name}}
-            """
-        ).format(t=other_base.__name__)
-
-        doc = format_docstring(
-            owner_name=other_base.__name__,
-            docstring=docstring,
-            formatters={'name': PIPELINE_ALIAS_NAME_DOC},
-        )
-
         return type(
             'Aliased' + other_base.__name__,
             (cls, other_base),
-            {'__doc__': doc,
-             '__module__': other_base.__module__},
+            {'__module__': other_base.__module__},
         )
 
 
@@ -548,26 +530,8 @@ class DownsampledMixin(StandardOutputs):
         """
         Factory for making Downsampled{Filter,Factor,Classifier}.
         """
-        docstring = dedent(
-            """
-            A {t} that defers to another {t} at lower-than-daily frequency.
-
-            Parameters
-            ----------
-            term : {t}
-            {{frequency}}
-            """
-        ).format(t=other_base.__name__)
-
-        doc = format_docstring(
-            owner_name=other_base.__name__,
-            docstring=docstring,
-            formatters={'frequency': PIPELINE_DOWNSAMPLING_FREQUENCY_DOC},
-        )
-
         return type(
             'Downsampled' + other_base.__name__,
             (cls, other_base,),
-            {'__doc__': doc,
-             '__module__': other_base.__module__},
+            {'__module__': other_base.__module__},
         )

--- a/zipline/pipeline/mixins.py
+++ b/zipline/pipeline/mixins.py
@@ -606,7 +606,6 @@ class SliceMixin(UniversalMixin):
 
     def __repr__(self):
         return "{parent_term}[{asset}]".format(
-            type=type(self).__name__,
             parent_term=self.inputs[0].recursive_repr(),
             asset=self._asset,
         )

--- a/zipline/pipeline/mixins.py
+++ b/zipline/pipeline/mixins.py
@@ -4,7 +4,6 @@ Mixins classes for use with Filters and Factors.
 The mixin classes inherit from Term to ensure they appear before
 Term in the MRO of any class using the mixin
 """
-from textwrap import dedent
 
 from numpy import (
     array,
@@ -25,12 +24,6 @@ from zipline.errors import (
 from zipline.lib.labelarray import LabelArray, labelarray_where
 from zipline.utils.context_tricks import nop_context
 from zipline.utils.input_validation import expect_dtypes, expect_types
-from zipline.utils.memoize import classlazyval
-from zipline.utils.sharedoc import (
-    format_docstring,
-    PIPELINE_ALIAS_NAME_DOC,
-    PIPELINE_DOWNSAMPLING_FREQUENCY_DOC,
-)
 from zipline.utils.numpy_utils import bool_dtype
 from zipline.utils.pandas_utils import nearest_unequal_elements
 

--- a/zipline/pipeline/term.py
+++ b/zipline/pipeline/term.py
@@ -972,7 +972,7 @@ def _assert_valid_categorical_missing_value(value):
     label_types = LabelArray.SUPPORTED_SCALAR_TYPES
     if not isinstance(value, label_types):
         raise TypeError(
-            "Classifiers can only produce values of type {types}."
+            "String-dtype classifiers can only produce strings or None."
             .format(types=' or '.join([t.__name__ for t in label_types]))
         )
 

--- a/zipline/pipeline/term.py
+++ b/zipline/pipeline/term.py
@@ -34,7 +34,6 @@ from zipline.utils.numpy_utils import (
     bool_dtype,
     categorical_dtype,
     datetime64ns_dtype,
-    float64_dtype,
     default_missing_value_for_dtype,
     float64_dtype,
 )

--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -349,6 +349,11 @@ def is_missing(data, missing_value):
         return isnan(data)
     elif is_datetime(data) and isnat(missing_value):
         return isnat(data)
+    elif is_object(data) and missing_value is None:
+        # XXX: Older versions of numpy returns True/False for array ==
+        # None. Work around this by boxing None in a 1x1 array, which causes
+        # numpy to do the broadcasted comparison we want.
+        return data == np.array([missing_value])
     return (data == missing_value)
 
 

--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -357,6 +357,20 @@ def is_missing(data, missing_value):
     return (data == missing_value)
 
 
+def same(x, y):
+    """
+    Check if two scalar values are "the same".
+
+    Returns True if `x == y`, or if x and y are both NaN or both NaT.
+    """
+    if is_float(x) and isnan(x) and is_float(y) and isnan(y):
+        return True
+    elif is_datetime(x) and isnat(x) and is_datetime(y) and isnat(y):
+        return True
+    else:
+        return x == y
+
+
 def busday_count_mask_NaT(begindates, enddates, out=None):
     """
     Simple of numpy.busday_count that returns `float` arrays rather than int


### PR DESCRIPTION
This PR implements several improvements to "universal terms", and implements several new such terms to enable conditional-based terms.

- Refines our existing machinery for implementing behaviors common to multiple `ComputableTerm` subclasses. The existing `DownsampledMixin` and `AliasedMixin` classes no longer require separate boilerplate in each of `Factor`, `Filter`, and `Classifier`. Instead, the boilerplate has been moved into `ComputableTerm`, where it can appear just once. Factor, Filter, and Classifier now provide a method called `_principal_computable_term_type`, which is used to implement the necessary boilerplate. The existing `Slice` class has been refactored to use this machinery as well, which means `Factor[asset]` is now a proper `Factor` instance (same for `Filter` and `Classifier`). We might also consider refactoring `NumericalExpression` (which implements all our binary operators) to use the new machinery, but that's a bigger refactor than I wanted to do here.

  In the code, I've taken to calling these shared mixins "universal mixins". In addition to the refactored existing mixins, this PR adds two new such mixin, `IfElseMixin` and `ConstantMixin`. See below for details

- Adds a new method, `Filter.if_else()`, that wraps `np.where`. This allows
  users to create expressions that conditionally draw from the outputs of one
  of two terms. This is implemented using the newly-standardized "universal"
  term machinery, similarly to downsample() and alias(), and Slice.

  This is implemented using the new universal `IfElseMixin`.

- Adds a new method, `ComputableTerm.fillna()`, implemented in terms of
  `if_else()`. `fillna` allows users to fill missing data with either a
  constant value, or values from another term. It supports both 2d and 1d
  terms. The constant case is implemented using a new universal `ConstantMixin`.