### PR TITLE
MAINT: Rework universal mixins to share more code.

### DIFF
--- a/zipline/pipeline/filters/filter.py
+++ b/zipline/pipeline/filters/filter.py
@@ -32,6 +32,7 @@ from zipline.pipeline.expression import (
 )
 from zipline.pipeline.mixins import (
     CustomTermMixin,
+    IfElseMixin,
     LatestMixin,
     PositiveWindowLengthMixin,
     RestrictedDTypeMixin,
@@ -309,7 +310,9 @@ class Filter(RestrictedDTypeMixin, ComputableTerm):
                 .format(if_true.missing_value, if_false.missing_value)
             )
 
-        return if_true._if_else_type(
+        return_type = type(if_true)._with_mixin(IfElseMixin)
+
+        return return_type(
             condition=self,
             if_true=if_true,
             if_false=if_false,


### PR DESCRIPTION
Adds a new base class for for "universal" mixins, which are intended to be used
to create identical or near-identical specializations of Factor, Filter, and
Classifier. The base class serves two purposes:

1. It consolidates code that was previously duplicated among the existing
   mixins.
2. Arguably more importantly, it gives a name and some documentation to the
   universal mixin pattern.