### PR TITLE
Reference the correct requirements files in Dockerfile-dev

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -29,6 +29,6 @@ FROM quantopian/zipline
 
 WORKDIR /zipline
 
-RUN pip install -r etc/requirements_dev.txt -r etc/requirements_blaze.txt
+RUN pip install -r etc/requirements_dev.in -r etc/requirements_blaze.in
 # Clean out any cython assets. The pip install re-builds them.
 RUN find . -type f -name '*.c' -exec rm {} + && pip install -e .[all]


### PR DESCRIPTION
The Docker-dev file has refers to [requirements_dev.txt and requirements_blaze.txt](https://github.com/quantopian/zipline/blob/688d29716a018a988a2116f03edd1e347e6df11c/Dockerfile-dev#L32) when it should refer to requirements_blaze.in and requirements_dev.in I believe. 