### PR TITLE
ENH: Add daily summary methods to Factor.

### DIFF
--- a/tests/pipeline/base.py
+++ b/tests/pipeline/base.py
@@ -123,6 +123,17 @@ class BaseUSEquityPipelineTestCase(WithTradingSessions,
             hooks=NoHooks(),
         )
 
+    def run_terms(self, terms, initial_workspace, mask):
+        start_date, end_date = mask.index[[0, -1]]
+        graph = ExecutionPlan(
+            domain=US_EQUITIES,
+            terms=terms,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        return self.run_graph(graph, initial_workspace, mask)
+
     def check_terms(self,
                     terms,
                     expected,
@@ -133,15 +144,8 @@ class BaseUSEquityPipelineTestCase(WithTradingSessions,
         Compile the given terms into a TermGraph, compute it with
         initial_workspace, and compare the results with ``expected``.
         """
-        start_date, end_date = mask.index[[0, -1]]
-        graph = ExecutionPlan(
-            domain=US_EQUITIES,
-            terms=terms,
-            start_date=start_date,
-            end_date=end_date,
-        )
+        results = self.run_terms(terms, initial_workspace, mask)
 
-        results = self.run_graph(graph, initial_workspace, mask)
         for key, (res, exp) in dzip_exact(results, expected).items():
             check(res, exp)
 

--- a/zipline/pipeline/factors/factor.py
+++ b/zipline/pipeline/factors/factor.py
@@ -52,11 +52,20 @@ from zipline.pipeline.sentinels import NotSpecified, NotSpecifiedType
 from zipline.pipeline.term import AssetExists, ComputableTerm, Term
 from zipline.utils.functional import with_doc, with_name
 from zipline.utils.input_validation import expect_types
-from zipline.utils.math_utils import nanmean, nanstd
+from zipline.utils.math_utils import (
+    nanmax,
+    nanmean,
+    nanmedian,
+    nanmin,
+    nanstd,
+    nansum,
+)
 from zipline.utils.numpy_utils import (
+    as_column,
     bool_dtype,
     coerce_to_dtype,
     float64_dtype,
+    is_missing,
 )
 from zipline.utils.sharedoc import templated_docstring
 
@@ -382,6 +391,73 @@ CORRELATION_METHOD_NOTE = dedent(
 )
 
 
+class summary_funcs(object):
+    """Namespace of functions meant to be used with DailySummary.
+    """
+
+    @staticmethod
+    def mean(a, missing_value):
+        return nanmean(a, axis=1)
+
+    @staticmethod
+    def stddev(a, missing_value):
+        return nanstd(a, axis=1)
+
+    @staticmethod
+    def max(a, missing_value):
+        return nanmax(a, axis=1)
+
+    @staticmethod
+    def min(a, missing_value):
+        return nanmin(a, axis=1)
+
+    @staticmethod
+    def median(a, missing_value):
+        return nanmedian(a, axis=1)
+
+    @staticmethod
+    def sum(a, missing_value):
+        return nansum(a, axis=1)
+
+    @staticmethod
+    def notnull_count(a, missing_value):
+        return (~is_missing(a, missing_value)).sum(axis=1)
+
+    names = {k for k in locals() if not k.startswith('_')}
+
+
+def summary_method(name):
+    func = getattr(summary_funcs, name)
+
+    @expect_types(mask=(Filter, NotSpecifiedType))
+    @float64_only
+    def f(self, mask=NotSpecified):
+        """Create a 1-dimensional factor computing the {} of self, each day.
+
+        Parameters
+        ----------
+        mask : zipline.pipeline.Filter, optional
+           A Filter representing assets to consider when computing results.
+           If supplied, we ignore asset/date pairs where ``mask`` produces
+           ``False``.
+
+        Returns
+        -------
+        result : zipline.pipeline.Factor
+        """
+        return DailySummary(
+            func,
+            self,
+            mask=mask,
+            dtype=self.dtype,
+        )
+
+    f.__name__ = func.__name__
+    f.__doc__ = f.__doc__.format(f.__name__)
+
+    return f
+
+
 class Factor(RestrictedDTypeMixin, ComputableTerm):
     """
     Pipeline API expression producing a numerical or date-valued output.
@@ -446,6 +522,11 @@ class Factor(RestrictedDTypeMixin, ComputableTerm):
 
     __truediv__ = clsdict['__div__']
     __rtruediv__ = clsdict['__rdiv__']
+
+    # Add summary functions.
+    clsdict.update(
+        {name: summary_method(name) for name in summary_funcs.names},
+    )
 
     del clsdict  # don't pollute the class namespace with this.
 
@@ -1683,6 +1764,51 @@ class Latest(LatestMixin, CustomFactor):
 
     def compute(self, today, assets, out, data):
         out[:] = data[-1]
+
+
+class DailySummary(SingleInputMixin, Factor):
+    """1D Factor that computes a summary statistic across all assets.
+    """
+    ndim = 1
+    window_length = 0
+    params = ('func',)
+
+    def __new__(cls, func, input_, mask, dtype):
+        # TODO: We should be able to support datetime64 as well, but that
+        # requires extra care for handling NaT.
+        if dtype != float64_dtype:
+            raise AssertionError(
+                "DailySummary only supports float64 dtype, got {}"
+                .format(dtype),
+            )
+
+        return super(DailySummary, cls).__new__(
+            cls,
+            inputs=[input_],
+            dtype=dtype,
+            missing_value=nan,
+            window_safe=input_.window_safe,
+            func=func,
+            mask=mask,
+        )
+
+    def _compute(self, arrays, dates, assets, mask):
+        func = self.params['func']
+
+        data = arrays[0]
+        data[~mask] = nan
+        if not isnan(self.inputs[0].missing_value):
+            data[data == self.inputs[0].missing_value] = nan
+
+        return as_column(func(data, self.inputs[0].missing_value))
+
+    def __repr__(self):
+        return "{}.{}()".format(
+            self.inputs[0].recursive_repr(),
+            self.params['func'].__name__,
+        )
+
+    graph_repr = recursive_repr = __repr__
 
 
 # Functions to be passed to GroupedRowTransform.  These aren't defined inline

--- a/zipline/utils/math_utils.py
+++ b/zipline/utils/math_utils.py
@@ -57,6 +57,7 @@ try:
     nanmin = bn.nanmin
     nanargmax = bn.nanargmax
     nanargmin = bn.nanargmin
+    nanmedian = bn.nanmedian
 except ImportError:
     # slower numpy
     import numpy as np
@@ -67,6 +68,7 @@ except ImportError:
     nanmin = np.nanmin
     nanargmax = np.nanargmax
     nanargmin = np.nanargmin
+    nanmedian = np.nanmedian
 
 
 def round_if_near_integer(a, epsilon=1e-4):


### PR DESCRIPTION
Adds several methods to Factor for producing daily summary statistics. The
following methods are supported:

- mean
- median
- stddev
- max
- min
- sum
- notnull_count

Each of these methods produces a term with ndim=1, meaning that it produces a
single scalar value per day.