### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "\"echo\""

--- a/README.rst
+++ b/README.rst
@@ -135,3 +135,4 @@ Feel free to ask questions on the `mailing list <https://groups.google.com/forum
    :target: https://coveralls.io/r/quantopian/zipline
 
 .. _`Zipline Install Documentation` : https://www.zipline.io/install
+[![Run on Repl.it](https://repl.it/badge/github/quantopian/zipline)](https://repl.it/github/quantopian/zipline)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).