### PR TITLE
Window length 0 fails to copy input

### DIFF
--- a/zipline/pipeline/engine.py
+++ b/zipline/pipeline/engine.py
@@ -577,10 +577,9 @@ class SimplePipelineEngine(PipelineEngine):
             for input_ in specialized:
                 input_data = ensure_ndarray(workspace[input_])
                 offset = offsets[term, input_]
-                # OPTIMIZATION: Don't make a copy by doing input_data[0:] if
-                # offset is zero.
-                if offset:
-                    input_data = input_data[offset:]
+                input_data = input_data[offset:]
+                if refcounts[input_] > 1:
+                    input_data = input_data.copy()
                 out.append(input_data)
         return out
 

--- a/zipline/utils/numpy_utils.py
+++ b/zipline/utils/numpy_utils.py
@@ -481,7 +481,7 @@ def as_column(a):
     if a.ndim != 1:
         raise ValueError(
             "as_column expected an 1-dimensional array, "
-            "but got an array of shape %s" % a.shape
+            "but got an array of shape %s" % (a.shape,)
         )
     return a[:, None]
 


### PR DESCRIPTION
Some terms mutate their inputs, but by not copying the data before passing them
to a term, the input could be corrupted and then used in other terms that didn't
expect the mutated input.

This change uses the same reference counting mechanism to only copy when needed
that is applied to windowed terms.