### PR TITLE
Assert fixes

### DIFF
--- a/zipline/testing/pipeline_terms.py
+++ b/zipline/testing/pipeline_terms.py
@@ -25,7 +25,9 @@ class CheckWindowsMixin(object):
             else:
                 expected = np.asanyarray(expected)
                 actual = input_[:, col_ix]
-                assert_equal(actual, expected)
+                assert_equal(actual, expected,
+                             array_decimal=(6 if expected.dtype.kind == 'f'
+                                            else None))
 
         # output is just latest
         out[:] = input_[-1]

--- a/zipline/testing/predicates.py
+++ b/zipline/testing/predicates.py
@@ -582,7 +582,7 @@ def assert_array_equal(result,
             compare_datetime_arrays,
             header='Arrays are not equal',
         )
-    elif array_decimal is not None and expected_dtype.kind != 'O':
+    elif array_decimal is not None and expected_dtype.kind not in {'O', 'S'}:
         f = partial(
             np.testing.assert_array_almost_equal,
             decimal=array_decimal,


### PR DESCRIPTION
- Assert that float pipeline outputs are equal with a tolerance
- Don't assert_almost_equal with string arrays