### PR TITLE
Bundle fixes and documentation improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,17 +93,16 @@ The following code implements a simple dual moving average algorithm.
                long_mavg=long_mavg)
 
 
-You can then run this algorithm using the Zipline CLI; you'll need a `Quandl <https://docs.quandl.com/docs#section-authentication>`__ API key to ingest the default data bundle.
-Once you have your key, run the following from the command line:
+You can then run this algorithm using the Zipline CLI.
+First, you must download some sample pricing and asset data:
 
 .. code:: bash
 
-    $ QUANDL_API_KEY=<yourkey> zipline ingest -b quandl
+    $ zipline ingest
     $ zipline run -f dual_moving_average.py --start 2014-1-1 --end 2018-1-1 -o dma.pickle --no-benchmark
 
-This will download asset pricing data data from `quandl`, and stream it through the algorithm
-over the specified time range. Then, the resulting performance DataFrame is saved in `dma.pickle`, which you
-can load and analyze from within Python.
+This will download asset pricing data data sourced from Quandl, and stream it through the algorithm over the specified time range.
+Then, the resulting performance DataFrame is saved in ``dma.pickle``, which you can load and analyze from within Python.
 
 You can find other examples in the ``zipline/examples`` directory.
 

--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -53,7 +53,7 @@ To ingest a bundle, run:
    $ zipline ingest [-b <bundle>]
 
 
-where ``<bundle>`` is the name of the bundle to ingest, defaulting to ``quantoipian-quandl``.
+where ``<bundle>`` is the name of the bundle to ingest, defaulting to ``quantopian-quandl``.
 
 Old Data
 ~~~~~~~~
@@ -127,7 +127,7 @@ To ingest the ``quantopian-quandl`` data bundle, run either of the following com
    $ zipline ingest -b quantopian-quandl
    $ zipline ingest
 
-These commands should only take a few seconds to download the data.
+Either command should only take a few seconds to download the data.
 
 .. note::
 

--- a/docs/source/bundles.rst
+++ b/docs/source/bundles.rst
@@ -28,8 +28,8 @@ new bundles. To see which bundles we have available, we may run the
 The output here shows that there are 3 bundles available:
 
 - ``my-custom-bundle`` (added by the user)
-- ``quandl`` (provided by zipline)
-- ``quantopian-quandl`` (provided by zipline)
+- ``quandl`` (provided by zipline, though deprecated)
+- ``quantopian-quandl`` (provided by zipline, the default bundle)
 
 The dates and times next to the name show the times when the data for this
 bundle was ingested. We have run three different ingestions for
@@ -42,20 +42,18 @@ ingestion for ``quantopian-quandl``.
 Ingesting Data
 ~~~~~~~~~~~~~~
 
-The first step to using a data bundle is to ingest the data. The ingestion
-process will invoke some custom bundle command and then write the data to a
-standard location that zipline can find. By default the location where ingested
-data will be written is ``$ZIPLINE_ROOT/data/<bundle>`` where by default
-``ZIPLINE_ROOT=~/.zipline``. The ingestion step may take some time as it could
-involve downloading and processing a lot of data. You'll need a
-`Quandl <https://docs.quandl.com/docs#section-authentication>`__ API key to ingest the default bundle. This can be run with:
+The first step to using a data bundle is to ingest the data.
+The ingestion process will invoke some custom bundle command and then write the data to a standard location that zipline can find.
+By default the location where ingested data will be written is ``$ZIPLINE_ROOT/data/<bundle>`` where by default ``ZIPLINE_ROOT=~/.zipline``.
+The ingestion step may take some time as it could involve downloading and processing a lot of data.
+To ingest a bundle, run:
 
 .. code-block:: bash
 
-   $ QUANDL_API_KEY=<yourkey> zipline ingest [-b <bundle>]
+   $ zipline ingest [-b <bundle>]
 
 
-where ``<bundle>`` is the name of the bundle to ingest, defaulting to ``quandl``.
+where ``<bundle>`` is the name of the bundle to ingest, defaulting to ``quantoipian-quandl``.
 
 Old Data
 ~~~~~~~~
@@ -119,30 +117,22 @@ Default Data Bundles
 Quandl WIKI Bundle
 ``````````````````
 
-By default zipline comes with the ``quandl`` data bundle which uses quandl's
-`WIKI dataset <https://www.quandl.com/data/WIKI>`_. The quandl data bundle
-includes daily pricing data, splits, cash dividends, and asset metadata. To
-ingest the ``quandl`` data bundle we recommend creating an account on quandl.com
-to get an API key to be able to make more API requests per day. Once we have an
-API key we may run:
+By default zipline comes with the ``quantopian-quandl`` data bundle which uses quandl's `WIKI dataset <https://www.quandl.com/data/WIKI>`_.
+The quandl data bundle includes daily pricing data, splits, cash dividends, and asset metadata.
+Quantopian has ingested the data from quandl and rebundled it to make ingestion much faster.
+To ingest the ``quantopian-quandl`` data bundle, run either of the following commands:
 
 .. code-block:: bash
 
-   $ QUANDL_API_KEY=<api-key> zipline ingest -b quandl
+   $ zipline ingest -b quantopian-quandl
+   $ zipline ingest
 
-though we may still run ``ingest`` as an anonymous quandl user (with no API
-key). We may also set the ``QUANDL_DOWNLOAD_ATTEMPTS`` environment variable to
-an integer which is the number of attempts that should be made to download data
-from quandl's servers. By default ``QUANDL_DOWNLOAD_ATTEMPTS`` will be 5, meaning
-that we will retry each attempt 5 times.
+These commands should only take a few seconds to download the data.
 
 .. note::
 
-   ``QUANDL_DOWNLOAD_ATTEMPTS`` is not the total number of allowed failures,
-   just the number of allowed failures per request. The quandl loader will make
-   one request per 100 equities for the metadata followed by one request per
-   equity.
-
+   Quandl has discontinued this dataset.
+   The dataset is no longer updating, but is reasonable for trying out Zipline without setting up your own dataset.
 
 Writing a New Bundle
 ~~~~~~~~~~~~~~~~~~~~

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -151,7 +151,7 @@ def ipython_only(option):
 @click.option(
     '-b',
     '--bundle',
-    default='quandl',
+    default='quantiopian-quandl',
     metavar='BUNDLE-NAME',
     show_default=True,
     help='The data bundle to use for the simulation.',

--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -151,7 +151,7 @@ def ipython_only(option):
 @click.option(
     '-b',
     '--bundle',
-    default='quantiopian-quandl',
+    default='quantopian-quandl',
     metavar='BUNDLE-NAME',
     show_default=True,
     help='The data bundle to use for the simulation.',

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -142,7 +142,7 @@ AttachedPipeline = namedtuple('AttachedPipeline', 'pipe chunks eager')
 
 class NoBenchmark(ValueError):
     def __init__(self):
-        super().__init__(
+        super(NoBenchmark, self).__init__(
             'Must specify either benchmark_sid or benchmark_returns.',
         )
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -140,6 +140,13 @@ log = logbook.Logger("ZiplineLog")
 AttachedPipeline = namedtuple('AttachedPipeline', 'pipe chunks eager')
 
 
+class NoBenchmark(ValueError):
+    def __init__(self):
+        super().__init__(
+            'Must specify either benchmark_sid or benchmark_returns.',
+        )
+
+
 class TradingAlgorithm(object):
     """A class that represents a trading strategy and parameters to execute
     the strategy.
@@ -533,8 +540,7 @@ class TradingAlgorithm(object):
             benchmark_returns = None
         else:
             if self.benchmark_returns is None:
-                raise ValueError("Must specify either benchmark_sid "
-                                 "or benchmark_returns.")
+                raise NoBenchmark()
             benchmark_asset = None
             benchmark_returns = self.benchmark_returns
         return BenchmarkSource(

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -308,10 +308,6 @@ QUANTOPIAN_QUANDL_URL = (
 
 
 @bundles.register('quantopian-quandl', create_writers=False)
-@deprecated(
-    'quantopian-quandl has been deprecated and '
-    'will be removed in a future release.'
-)
 def quantopian_quandl_bundle(environ,
                              asset_db_writer,
                              minute_bar_writer,

--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -13,7 +13,6 @@ from six.moves.urllib.parse import urlencode
 from six import iteritems
 from trading_calendars import register_calendar_alias
 
-from zipline.utils.deprecate import deprecated
 from . import core as bundles
 import numpy as np
 

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -219,14 +219,14 @@ def _run(handle_data,
     except NoBenchmark:
         raise _RunAlgoError(
             (
-                'no ``benchmark_spec`` was provided and'
+                'No ``benchmark_spec`` was provided, and'
                 ' ``zipline.api.set_benchmark`` was not called in'
-                ' ``initialize``'
+                ' ``initialize``.'
             ),
             (
-                "neither '--benchmark-symbol' nor '--benchmark-sid' was"
-                " provided and ``zipline.api.set_benchmark`` was not called"
-                " in ``initialize``, did you mean to pass '--no-benchmark'"
+                "Neither '--benchmark-symbol' nor '--benchmark-sid' was"
+                " provided, and ``zipline.api.set_benchmark`` was not called"
+                " in ``initialize``. Did you mean to pass '--no-benchmark'?"
             ),
         )
 

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -28,7 +28,7 @@ from zipline.pipeline.loaders import USEquityPricingLoader
 import zipline.utils.paths as pth
 from zipline.extensions import load
 from zipline.errors import SymbolNotFound
-from zipline.algorithm import TradingAlgorithm
+from zipline.algorithm import TradingAlgorithm, NoBenchmark
 from zipline.finance.blotter import Blotter
 
 log = logbook.Logger(__name__)
@@ -189,32 +189,46 @@ def _run(handle_data,
         except ValueError as e:
             raise _RunAlgoError(str(e))
 
-    perf = TradingAlgorithm(
-        namespace=namespace,
-        data_portal=data,
-        get_pipeline_loader=choose_loader,
-        trading_calendar=trading_calendar,
-        sim_params=SimulationParameters(
-            start_session=start,
-            end_session=end,
+    try:
+        perf = TradingAlgorithm(
+            namespace=namespace,
+            data_portal=data,
+            get_pipeline_loader=choose_loader,
             trading_calendar=trading_calendar,
-            capital_base=capital_base,
-            data_frequency=data_frequency,
-        ),
-        metrics_set=metrics_set,
-        blotter=blotter,
-        benchmark_returns=benchmark_returns,
-        benchmark_sid=benchmark_sid,
-        **{
-            'initialize': initialize,
-            'handle_data': handle_data,
-            'before_trading_start': before_trading_start,
-            'analyze': analyze,
-        } if algotext is None else {
-            'algo_filename': getattr(algofile, 'name', '<algorithm>'),
-            'script': algotext,
-        }
-    ).run()
+            sim_params=SimulationParameters(
+                start_session=start,
+                end_session=end,
+                trading_calendar=trading_calendar,
+                capital_base=capital_base,
+                data_frequency=data_frequency,
+            ),
+            metrics_set=metrics_set,
+            blotter=blotter,
+            benchmark_returns=benchmark_returns,
+            benchmark_sid=benchmark_sid,
+            **{
+                'initialize': initialize,
+                'handle_data': handle_data,
+                'before_trading_start': before_trading_start,
+                'analyze': analyze,
+            } if algotext is None else {
+                'algo_filename': getattr(algofile, 'name', '<algorithm>'),
+                'script': algotext,
+            }
+        ).run()
+    except NoBenchmark:
+        raise _RunAlgoError(
+            (
+                'no ``benchmark_spec`` was provided and'
+                ' ``zipline.api.set_benchmark`` was not called in'
+                ' ``initialize``'
+            ),
+            (
+                "neither '--benchmark-symbol' nor '--benchmark-sid' was"
+                " provided and ``zipline.api.set_benchmark`` was not called"
+                " in ``initialize``, did you mean to pass '--no-benchmark'"
+            ),
+        )
 
     if output == '-':
         click.echo(str(perf))


### PR DESCRIPTION
- make `quantopian-quandl` the default bundle
- update documentation to reflect new default bundle
- update documentation to make `quandl` bundle as deprecated
- improve error message when no benchmark is provided