### PR TITLE
Update the Dockerfile to use 3.6, requirements needed to be updated.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 #    docker exec -it zipline zipline run -f /projects/my_algo.py --start 2015-1-1 --end 2016-1-1 -o /projects/result.pickle
 #
-FROM python:3.5
+FROM python:3.6
 
 #
 # set up environment

--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,7 @@ Features
 Installation
 ============
 
-Zipline currently supports Python 2.7 and Python 3.5, and may be installed via
-either pip or conda.
+Zipline currently supports Python 3.6, and may be installed via either pip or conda.
 
 **Note:** Installing Zipline is slightly more involved than the average Python
 package. See the full `Zipline Install Documentation`_ for detailed

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -133,13 +133,7 @@ the `Conda User Guide <https://conda.io/projects/conda/en/latest/user-guide/task
 
 Assuming ``conda`` has been set up, you can create a ``conda`` environment:
 
-- Python 2.7:
-
-.. code-block:: bash
-
-    $ conda create -n env_zipline python=2.7
-
-- Python 3.5:
+- Python 3.6:
 
 .. code-block:: bash
 

--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -17,10 +17,10 @@ multipledispatch>=0.6.0
 toolz>=0.8.2
 
 # Scientific Libraries
-numpy>=1.11.3
+numpy>=1.11.3,<=1.18.0
 pandas>=0.18.1,<=0.22
 pandas-datareader>=0.2.1
-scipy>=0.17.1
+scipy>1.0.0,<=1.1.0
 # Needed for parts of pandas.stats
 patsy>=0.4.0
 statsmodels>=0.6.1


### PR DESCRIPTION
When requirements had a "softer" pin it seemed to get a Numpy which was incompatible.
Not sure how it works when building the code to a pypi.. ?

Thanks for making 3.6 possible!