### PR TITLE
MAINT: Don't need contextlib2 in our py3 envs

### DIFF
--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -10,7 +10,7 @@ click>=4.0.0
 
 # Language utilities
 six>=1.10.0
-contextlib2>=0.4.0
+contextlib2>=0.4.0; python_version < "3.0"
 python-interface>=1.5.3
 multipledispatch>=0.6.0
 # FUNctional programming utilities

--- a/etc/requirements_locked.txt
+++ b/etc/requirements_locked.txt
@@ -66,7 +66,7 @@ partd==0.3.7              # via dask
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 patsy==0.4.0              # via -r etc/requirements.in
 pbr==4.3.0                # via mock
-pip-tools==5.2.1          # via -r etc/requirements_dev.in
+pip-tools==5.3.1          # via -r etc/requirements_dev.in
 port-for==0.3.1           # via sphinx-autobuild
 psutil==5.6.7             # via blaze
 pycodestyle==2.4.0        # via flake8

--- a/etc/requirements_locked.txt
+++ b/etc/requirements_locked.txt
@@ -19,7 +19,7 @@ chardet==3.0.4            # via requests
 click==7.0.0              # via -r etc/requirements.in, flask, pip-tools
 cloudpickle==0.2.1        # via dask
 configparser==3.5.0       # via flake8
-contextlib2==0.4.0        # via -r etc/requirements.in, blaze
+contextlib2==0.4.0 ; python_version < "3.0"  # via -r etc/requirements.in, blaze
 cookies==2.2.1            # via responses
 coverage==4.0.3           # via -r etc/requirements_dev.in
 cycler==0.10.0            # via matplotlib

--- a/etc/requirements_py36_locked.txt
+++ b/etc/requirements_py36_locked.txt
@@ -16,7 +16,6 @@ bottleneck==1.3.2         # via -r etc/requirements.in
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r etc/requirements.in, flask, pip-tools
-contextlib2==0.6.0.post1  # via -r etc/requirements.in
 coverage==5.2.1           # via -r etc/requirements_dev.in
 cycler==0.10.0            # via matplotlib
 cython==0.29.21           # via -r etc/requirements_build.in

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def _filter_requirements(lines_iter, filter_names=None,
 REQ_PATTERN = re.compile(
     r"(?P<name>[^=<>;]+)((?P<comp>[<=>]{1,2})(?P<spec>[^;]+))?"
     r"(?:(;\W*python_version\W*(?P<pycomp>[<=>]{1,2})\W*"
-    r"(?P<pyspec>[0-9\.]+)))?"
+    r"(?P<pyspec>[0-9.]+)))?\W*"
 )
 
 

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -19,7 +19,6 @@ from datetime import tzinfo, time
 import logbook
 import pytz
 import pandas as pd
-from contextlib2 import ExitStack
 import numpy as np
 
 from itertools import chain, repeat
@@ -95,6 +94,7 @@ from zipline.utils.api_support import (
     require_not_initialized,
     ZiplineAPI,
     disallowed_in_before_trading_start)
+from zipline.utils.compat import ExitStack
 from zipline.utils.input_validation import (
     coerce_string,
     ensure_upper_case,

--- a/zipline/assets/asset_writer.py
+++ b/zipline/assets/asset_writer.py
@@ -15,7 +15,6 @@
 from collections import namedtuple
 import re
 
-from contextlib2 import ExitStack
 import numpy as np
 import pandas as pd
 import sqlalchemy as sa
@@ -35,7 +34,7 @@ from zipline.assets.asset_db_schema import (
     metadata,
     version_info,
 )
-
+from zipline.utils.compat import ExitStack
 from zipline.utils.preprocess import preprocess
 from zipline.utils.range import from_tuple, intersecting_ranges
 from zipline.utils.sqlite_utils import coerce_string_to_eng

--- a/zipline/data/bundles/core.py
+++ b/zipline/data/bundles/core.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import warnings
 
-from contextlib2 import ExitStack
 import click
 from logbook import Logger
 import pandas as pd
@@ -24,7 +23,7 @@ from zipline.utils.cache import (
     working_dir,
     working_file,
 )
-from zipline.utils.compat import mappingproxy
+from zipline.utils.compat import ExitStack, mappingproxy
 from zipline.utils.input_validation import ensure_timestamp, optionally
 import zipline.utils.paths as pth
 from zipline.utils.preprocess import preprocess

--- a/zipline/gens/tradesimulation.py
+++ b/zipline/gens/tradesimulation.py
@@ -12,12 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib2 import ExitStack
 from copy import copy
 from logbook import Logger, Processor
 from zipline.finance.order import ORDER_STATUS
 from zipline.protocol import BarData
 from zipline.utils.api_support import ZiplineAPI
+from zipline.utils.compat import ExitStack
 from six import viewkeys
 
 from zipline.gens.sim_engine import (

--- a/zipline/pipeline/hooks/delegate.py
+++ b/zipline/pipeline/hooks/delegate.py
@@ -1,7 +1,6 @@
-from contextlib2 import ExitStack
 from interface import implements
 
-from zipline.utils.compat import contextmanager, wraps
+from zipline.utils.compat import ExitStack, contextmanager, wraps
 
 from .iface import PipelineHooks, PIPELINE_HOOKS_CONTEXT_MANAGERS
 from .no import NoHooks

--- a/zipline/testing/fixtures.py
+++ b/zipline/testing/fixtures.py
@@ -3,7 +3,6 @@ import sqlite3
 from unittest import TestCase
 import warnings
 
-from contextlib2 import ExitStack
 from logbook import NullHandler, Logger
 import numpy as np
 import pandas as pd
@@ -32,6 +31,7 @@ from zipline.pipeline.domain import GENERIC, US_EQUITIES
 from zipline.pipeline.loaders import USEquityPricingLoader
 from zipline.pipeline.loaders.testing import make_seeded_random_loader
 from zipline.protocol import BarData
+from zipline.utils.compat import ExitStack
 from zipline.utils.paths import ensure_directory, ensure_directory_containing
 from .core import (
     create_daily_bar_data,

--- a/zipline/utils/compat.py
+++ b/zipline/utils/compat.py
@@ -11,6 +11,7 @@ if PY2:
     from types import DictProxyType
     from cgi import escape as escape_html
     import contextlib
+    from contextlib2 import ExitStack
     from ctypes import py_object, pythonapi
 
     _new_mappingproxy = pythonapi.PyDictProxy_New
@@ -95,7 +96,7 @@ if PY2:
         return helper
 
 else:
-    from contextlib import contextmanager
+    from contextlib import contextmanager, ExitStack
     from html import escape as escape_html
     from types import MappingProxyType as mappingproxy
     from math import ceil
@@ -134,6 +135,7 @@ unicode = type(u'')
 
 __all__ = [
     'PY2',
+    'ExitStack',
     'consistent_round',
     'contextmanager',
     'escape_html',


### PR DESCRIPTION
(Technically, I think we'd need it in python 3.3. Oh well. 🤷 )