### PR TITLE
BLD: Fix caching in Github Actions builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-py${{matrix.python-version}}-${{ hashFiles(env.PIP_CONSTRAINT) }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-pip-py${{matrix.python-version}}-
     - name: Install requirements
       run: |
         python -m pip install wheel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-py${{matrix.python-version}}-${{ hashFiles('$PIP_CONSTRAINT') }}
+        key: ${{ runner.os }}-pip-py${{matrix.python-version}}-${{ hashFiles(env.PIP_CONSTRAINT) }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Install requirements

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
       uses: actions/setup-python@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install wheel
+      run: |
+        python -m pip install wheel
     - name: Install TA lib (ubuntu)
       if: startsWith(matrix.os, 'ubuntu')
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,6 @@ jobs:
       uses: actions/setup-python@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install wheel
-      run: |
-        python -m pip install wheel
     - name: Install TA lib (ubuntu)
       if: startsWith(matrix.os, 'ubuntu')
       run: |
@@ -63,6 +60,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install requirements
       run: |
+        python -m pip install wheel
         python -m pip install -r etc/requirements_build.in
         python -m pip install --no-binary=bcolz -e .[all] -r etc/requirements_blaze.in
     - name: Run tests


### PR DESCRIPTION
Makes a few changes to fix our usage of `actions/cache` work:

1. Installs `wheel` as part of CI so that we actually build wheels and they get cached properly
2. Fixes the environment variable passed to `hashFiles` so that we're actually hashing the right requirements file (this was failing silently before)
3. Fixes `restore-keys` to be more specific

While we are now actually caching/restoring wheels correctly, this does not speed up builds all that much. Most of our time in install is spent building/installing zipline itself. 