### PR TITLE
DOC: Add a description to build docs for anaconda users

### DIFF
--- a/docs/source/development-guidelines.rst
+++ b/docs/source/development-guidelines.rst
@@ -196,7 +196,7 @@ __ https://www.sphinx-doc.org/en/master/
 
    $ pip install -r ./etc/requirements_docs.in -c ./etc/requirements_locked.txt
 
-If you would like to use Anaconda, please follow `the installation guide <https://www.zipline.io/install#managing-conda-environments>`_ utill ``source activate env_zipline``, then run the command above.
+If you would like to use Anaconda, please follow :ref:`the installation guide<managing-conda-environments>` to create and activate an environment, and then run the command above.
 
 To build and view the docs locally, run:
 

--- a/docs/source/development-guidelines.rst
+++ b/docs/source/development-guidelines.rst
@@ -196,6 +196,8 @@ __ https://www.sphinx-doc.org/en/master/
 
    $ pip install -r ./etc/requirements_docs.in -c ./etc/requirements_locked.txt
 
+If you would like to use Anaconda, please follow `the installation guide <https://www.zipline.io/install#managing-conda-environments>`_ utill ``source activate env_zipline``, then run the command above.
+
 To build and view the docs locally, run:
 
 .. code-block:: bash


### PR DESCRIPTION
## Motivation
There was no description for anaconda user to install dependencies to build docs. 
So I run the pip install command below in my local Mac environment, but an error happened.
```
pip install -r ./etc/requirements_docs.in -c ./etc/requirements_locked.txt
```
<details>
<summary>This is the error I encountered</summary>

```
Requirement already satisfied: Sphinx>=1.3.2 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from -r ./etc/requirements_docs.in (line 1)) (3.1.2)
Requirement already satisfied: numpydoc>=0.5.0 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from -r ./etc/requirements_docs.in (line 2)) (1.1.0)
Collecting sphinx-autobuild>=0.6.0
  Downloading sphinx_autobuild-2020.9.1-py3-none-any.whl (9.8 kB)
Collecting sphinx-rtd-theme
  Downloading sphinx_rtd_theme-0.5.0-py2.py3-none-any.whl (10.8 MB)
     |████████████████████████████████| 10.8 MB 2.6 MB/s 
Requirement already satisfied: sphinxcontrib-serializinghtml in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.1.4)
Requirement already satisfied: snowballstemmer>=1.1 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (2.0.0)
Requirement already satisfied: alabaster<0.8,>=0.7 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (0.7.12)
Requirement already satisfied: sphinxcontrib-htmlhelp in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.0.3)
Requirement already satisfied: sphinxcontrib-jsmath in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.0.1)
Requirement already satisfied: Pygments>=2.0 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (2.6.1)
Requirement already satisfied: sphinxcontrib-applehelp in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.0.2)
Requirement already satisfied: sphinxcontrib-devhelp in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.0.2)
Requirement already satisfied: docutils>=0.12 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (0.16)
Requirement already satisfied: babel>=1.3 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (2.8.0)
Requirement already satisfied: sphinxcontrib-qthelp in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.0.3)
Requirement already satisfied: setuptools in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (49.2.0.post20200714)
Requirement already satisfied: imagesize in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (1.2.0)
Requirement already satisfied: packaging in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from Sphinx>=1.3.2->-r ./etc/requirements_docs.in (line 1)) (20.4)
Collecting jinja2==2.10.1
  Downloading Jinja2-2.10.1-py2.py3-none-any.whl (124 kB)
     |████████████████████████████████| 124 kB 1.4 MB/s 
Collecting requests==2.20.1
  Downloading requests-2.20.1-py2.py3-none-any.whl (57 kB)
     |████████████████████████████████| 57 kB 813 kB/s 
Collecting livereload
  Downloading livereload-2.6.3.tar.gz (25 kB)
Collecting pytz==2018.5
  Downloading pytz-2018.5-py2.py3-none-any.whl (510 kB)
     |████████████████████████████████| 510 kB 1.2 MB/s 
Collecting pyparsing==2.0.3
  Downloading pyparsing-2.0.3-py2.py3-none-any.whl (37 kB)
Collecting six==1.11.0
  Downloading six-1.11.0-py2.py3-none-any.whl (10 kB)
Collecting markupsafe==0.23
  Downloading MarkupSafe-0.23.tar.gz (13 kB)
Collecting idna==2.7
  Downloading idna-2.7-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 1.9 MB/s 
Requirement already satisfied: chardet==3.0.4 in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from -c ./etc/requirements_locked.txt (line 14)) (3.0.4)
Collecting urllib3==1.24.3
  Downloading urllib3-1.24.3-py2.py3-none-any.whl (118 kB)
     |████████████████████████████████| 118 kB 968 kB/s 
Collecting certifi==2018.8.24
  Downloading certifi-2018.8.24-py2.py3-none-any.whl (147 kB)
     |████████████████████████████████| 147 kB 2.0 MB/s 
Requirement already satisfied: tornado in /Users/yoshinobu.a.nakada/opt/anaconda3/lib/python3.8/site-packages (from livereload->sphinx-autobuild>=0.6.0->-r ./etc/requirements_docs.in (line 3)) (6.0.4)
Building wheels for collected packages: markupsafe, livereload
  Building wheel for markupsafe (setup.py) ... done
  Created wheel for markupsafe: filename=MarkupSafe-0.23-cp38-cp38-macosx_10_9_x86_64.whl size=17655 sha256=fa8d89488e104cb5322c8d71a7f3f88769abe89a61eeaf22e47db095fd1886dd
  Stored in directory: /Users/yoshinobu.a.nakada/Library/Caches/pip/wheels/65/8f/24/603cee4e10464a0504406b5eae7754495e357b227ac3b61ac5
  Building wheel for livereload (setup.py) ... done
  Created wheel for livereload: filename=livereload-2.6.3-py2.py3-none-any.whl size=24713 sha256=1123cda9cf9620197f823267000d289c3a831746ea9402a35ff4763c1c192b9d
  Stored in directory: /Users/yoshinobu.a.nakada/Library/Caches/pip/wheels/48/d7/34/372e0521bd5c9f6dcdff307e37ef6f9c00c1e1e2afc9707b5c
Successfully built markupsafe livereload
ERROR: astroid 2.4.2 has requirement six~=1.12, but you'll have six 1.11.0 which is incompatible.
Installing collected packages: certifi, idna, markupsafe, jinja2, pyparsing, pytz, urllib3, requests, six, livereload, sphinx-autobuild, sphinx-rtd-theme
  Attempting uninstall: certifi
    Found existing installation: certifi 2020.6.20
    Uninstalling certifi-2020.6.20:
      Successfully uninstalled certifi-2020.6.20
  Attempting uninstall: idna
    Found existing installation: idna 2.10
    Uninstalling idna-2.10:
      Successfully uninstalled idna-2.10
  Attempting uninstall: markupsafe
    Found existing installation: MarkupSafe 1.1.1
    Uninstalling MarkupSafe-1.1.1:
      Successfully uninstalled MarkupSafe-1.1.1
  Attempting uninstall: jinja2
    Found existing installation: Jinja2 2.11.2
    Uninstalling Jinja2-2.11.2:
      Successfully uninstalled Jinja2-2.11.2
  Attempting uninstall: pyparsing
    Found existing installation: pyparsing 2.4.7
    Uninstalling pyparsing-2.4.7:
      Successfully uninstalled pyparsing-2.4.7
  Attempting uninstall: pytz
    Found existing installation: pytz 2020.1
    Uninstalling pytz-2020.1:
      Successfully uninstalled pytz-2020.1
  Attempting uninstall: urllib3
    Found existing installation: urllib3 1.25.9
    Uninstalling urllib3-1.25.9:
      Successfully uninstalled urllib3-1.25.9
  Attempting uninstall: requests
    Found existing installation: requests 2.24.0
    Uninstalling requests-2.24.0:
      Successfully uninstalled requests-2.24.0
  Attempting uninstall: six
    Found existing installation: six 1.15.0
    Uninstalling six-1.15.0:
      Successfully uninstalled six-1.15.0
Successfully installed certifi-2018.8.24 idna-2.7 jinja2-2.10.1 livereload-2.6.3 markupsafe-0.23 pyparsing-2.0.3 pytz-2018.5 requests-2.20.1 six-1.11.0 sphinx-autobuild-2020.9.1 sphinx-rtd-theme-0.5.0 urllib3-1.24.3
```
</details>

However, I have followed [this instruction](https://www.zipline.io/install#managing-conda-environments) and already installed Anaconda and finished until the following command, then the pip command succeeded without an error.
```
$ source activate env_zipline
```
## Solution
So I modified [this doc for contribution](https://www.zipline.io/development-guidelines#contributing-to-the-docs) to add a description for Anaconda users.
 
What do you think about this modification? Also if there is any grammatical mistake, please let me know.