### PR TITLE
DOC: Update source activate command to conda activate

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -152,7 +152,7 @@ by using the command
 
 .. code-block:: bash
 
-    $ source activate env_zipline
+    $ conda activate env_zipline
 
 You can install Zipline by running
 
@@ -164,4 +164,10 @@ To deactivate the ``conda`` environment:
 
 .. code-block:: bash
 
-    (env_zipline) $ source deactivate
+    (env_zipline) $ conda deactivate
+
+.. note::
+   ``conda activate`` and ``conda deactivate`` only work on conda 4.6 and later versions. For conda versions prior to 4.6, run:
+   
+      * Windows: ``activate`` or ``deactivate``
+      * Linux and macOS: ``source activate`` or ``source deactivate``


### PR DESCRIPTION
Zipline installation docs currently uses `source activate` and `source deactivate` - which only work on Linux and MacOS. So I thought we might want to change that to `conda activate` and `conda deactivate` as they are supported on all OS (available on Conda 4.4 onwards https://www.anaconda.com/blog/conda-4-6-release)