### PR TITLE
Update quandl.py

### DIFF
--- a/zipline/data/bundles/quandl.py
+++ b/zipline/data/bundles/quandl.py
@@ -268,7 +268,7 @@ def download_with_progress(url, chunk_size, **progress_kwargs):
     data : BytesIO
         A BytesIO containing the downloaded data.
     """
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, verify=False)
     resp.raise_for_status()
 
     total_size = int(resp.headers['content-length'])


### PR DESCRIPTION
$ zipline ingest -b quandl

To avoid SSL verification error like the following

requests.exceptions.SSLError: HTTPSConnectionPool(host='quandl-production-datahub.s3.amazonaws.com', port=443): Max retries exceeded with url: /export/WIKI/PRICES/WIKI_PRICES_212b326a081eacca455e13140d7bb9db.zip?X-Amz-Expires=1800&X-Amz-Date=20210202T040708Z&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEOT//////////wEaCXVzLWVhc3QtMSJHMEUCICsGHLe1hCAIDHa4mGun%2BS6ca3kaY/aFJmsPPwzzisOQAiEAgUiC1vTB0HxqL/pJm5h1e0VJ8PNbkxwn7mAXv//EH3wqvQMIzf//////////ARACGgwzMDYzMjA1MDAyMDQiDFUp%2BpXEQxhjUAlsDyqRA1aIlzwSDqkkdj479A6kS5C48OF9Gmr1GeAec0mrd5S/z8SFkbAEUUmuVMznhGYUHE1FQpNi9STUTy7y4UTeOpRYjWC%2BqPQJen0Ku%2BCiQldfTof7Tmg%2BLWmNHjSRFbvkK99jsQLqToNd14Rza8JnZ63XnbVMSNLmbPB%2ByNGRjscpwnbSSeSaRQ94DUG2pXcnePxVb/Bb8JazoGjFBfk3V3jEmMuOh4zYNVnOAJSDzSOy7LGL3lDX%2BGpZlQBhpjp23XrUGiJj0kBvLaXItYwdN9mhPFz8FoE/RuiaUh3bElrPiVFtgiVqH/lTHU34u2RT0Rs0wx8pGXxOsE7DgnHbVs44sVfaYvs7AfFqgmE1VokIRiu6x1nIsYndcXHQZ8tBzTqll5aIFiBmXv%2BzcT1a6DH5ataZ8teHlGAlvzzPcgl6kmrpiFeesw730s245mXzfaQBNwIG5QuHedAK%2BJGBly031BgkwlXoS5KZFKCfFtx8bK8yuTRRkLVTqJhPM2dCA9axQjKRd7zTk5u5DiPAIrz7MKqR44AGOusBaDciHu50csg9ymgbQXTTOIgRULLCJmL/svVyfgTvAdLFdOoEyBq48pKeC1QTNtvjikExrzvE2pY/E/2qcndxBz4p7lcuQHZ%2BEAeu4fqINQPucopkNiC1Fe9xpfhHA3hE0TNCs8ddFmaPRu02NAzG/eMPmlsn0%2Bum6iQKThZQHDZaUht3hsiCZHVYLndpj5TLuDXcLXxvkc3G3iXor%2BseB6N1f/3vb2WMeAJ3wraBNiwkY/gT42JTmbGkE52EkaYlOV3lO86Xi405ZY7WlP8DhZJt/GtIbtJcyim%2Bc4A1CAe4VhDCFeGvCFzLxQ%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAUOUQ74XWL7MAXJEP/20210202/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=3561e007170a11372b94bddb8e4ed04cb7b2931fe258116c4f1fdfef0a298aa3 (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),))
