### PR TITLE
FIX: Fix to generalize the before_trading_start call for custom calendars

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -517,11 +517,12 @@ class TradingAlgorithm(object):
                 self.trading_calendar.execution_time_from_close(market_closes)
             execution_opens = execution_closes
 
-        # FIXME generalize these values
+        # call 1 hour before before trading open
+        cal_market_open = self.trading_calendar.open_times[0][1]
         before_trading_start_minutes = days_at_time(
             self.sim_params.sessions,
-            time(8, 45),
-            "US/Eastern"
+            time(cal_market_open.hour-1, cal_market_open.minute),
+            self.trading_calendar.tz
         )
 
         return MinuteSimulationClock(


### PR DESCRIPTION
currently the before_trading_start is hard coded to run at 8:45
local time of 'US/eastern' zone which may not work for other
data bundles of other exchanges in different timezone.
Currently before_trading_start is not invoked for data bundle of BSE
stock exchange with 'XBOM' calander.
This fix generalizes the code to call it 1 hour before the trading open
for each calandars local timezone.
Verified it fixes the issue with XBOM calandar bundles.