### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -2108,7 +2108,7 @@ class TestAssetDBVersioning(ZiplineTestCase):
         self.assertIsNone(sa.select((version_table.c.version,)).scalar())
 
         # This should fail because the table has no version info and is,
-        # therefore, consdered v0
+        # therefore, considered v0
         with self.assertRaises(AssetDBVersionError):
             check_version_info(self.engine, version_table, -2)
 

--- a/zipline/data/minute_bars.py
+++ b/zipline/data/minute_bars.py
@@ -707,7 +707,7 @@ class BcolzMinuteBarWriter(object):
         Parameters
         ----------
         sid : int
-            The asset identifer for the data being written.
+            The asset identifier for the data being written.
         df : pd.DataFrame
             DataFrame of market data with the following characteristics.
             columns : ('open', 'high', 'low', 'close', 'volume')

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -73,7 +73,7 @@ class WrongDataForTransform(ZiplineError):
 class UnsupportedSlippageModel(ZiplineError):
     """
     Raised if a user script calls the set_slippage magic
-    with a slipage object that isn't a VolumeShareSlippage or
+    with a slippage object that isn't a VolumeShareSlippage or
     FixedSlipapge
     """
     msg = """

--- a/zipline/finance/controls.py
+++ b/zipline/finance/controls.py
@@ -62,7 +62,7 @@ class TradingControl(with_metaclass(abc.ABCMeta)):
         restraint given the information in `portfolio`, this method should
         return None and have no externally-visible side-effects.
 
-        If the desired order violates this TradingControl's contraint, this
+        If the desired order violates this TradingControl's constraint, this
         method should call self.fail(asset, amount).
         """
         raise NotImplementedError
@@ -381,7 +381,7 @@ class AccountControl(with_metaclass(abc.ABCMeta)):
         the information in `portfolio` and `account`, this method should
         return None and have no externally-visible side-effects.
 
-        If the desired order violates this AccountControl's contraint, this
+        If the desired order violates this AccountControl's constraint, this
         method should call self.fail().
         """
         raise NotImplementedError


### PR DESCRIPTION
There are small typos in:
- tests/test_assets.py
- zipline/data/minute_bars.py
- zipline/errors.py
- zipline/finance/controls.py

Fixes:
- Should read `constraint` rather than `contraint`.
- Should read `slippage` rather than `slipage`.
- Should read `identifier` rather than `identifer`.
- Should read `considered` rather than `consdered`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md