### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build-and-test:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -18,51 +17,51 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.5, 3.6]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'recursive'
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.1.1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install TA lib (ubuntu)
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        wget https://s3.amazonaws.com/quantopian-orchestration/packages/ta-lib-0.4.0-src.tar.gz
-        tar xvfz ta-lib-0.4.0-src.tar.gz
-        cd ta-lib
-        ./configure
-        make
-        sudo make install
-        sudo ldconfig
-    - name: Install TA lib (macOS)
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        brew install ta-lib
-    - name: Set Lockfile py 35
-      if: matrix.python-version == 3.5
-      run: |
-        echo ::set-env name=PIP_CONSTRAINT::etc/requirements_locked.txt
-    - name: Set Lockfile py36
-      if: matrix.python-version == 3.6
-      run: |
-        echo ::set-env name=PIP_CONSTRAINT::etc/requirements_py36_locked.txt
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-py${{matrix.python-version}}-${{ hashFiles(env.PIP_CONSTRAINT) }}
-        restore-keys: |
-          ${{ runner.os }}-pip-py${{matrix.python-version}}-
-    - name: Install requirements
-      run: |
-        python -m pip install wheel
-        python -m pip install -r etc/requirements_build.in
-        python -m pip install --no-binary=bcolz -e .[all] -r etc/requirements_blaze.in
-    - name: Run tests
-      run: |
-        nosetests tests
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2.1.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install TA lib (ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          wget https://s3.amazonaws.com/quantopian-orchestration/packages/ta-lib-0.4.0-src.tar.gz
+          tar xvfz ta-lib-0.4.0-src.tar.gz
+          cd ta-lib
+          ./configure
+          make
+          sudo make install
+          sudo ldconfig
+      - name: Install TA lib (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install ta-lib
+      - name: Set Lockfile py 35
+        if: matrix.python-version == 3.5
+        run: |
+          echo ::set-env name=PIP_CONSTRAINT::etc/requirements_locked.txt
+      - name: Set Lockfile py36
+        if: matrix.python-version == 3.6
+        run: |
+          echo ::set-env name=PIP_CONSTRAINT::etc/requirements_py36_locked.txt
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-py${{matrix.python-version}}-${{ hashFiles(env.PIP_CONSTRAINT) }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{matrix.python-version}}-
+      - name: Install requirements
+        run: |
+          python -m pip install wheel
+          python -m pip install -r etc/requirements_build.in
+          python -m pip install --no-binary=bcolz -e .[all] -r etc/requirements_blaze.in
+      - name: Run tests
+        run: |
+          nosetests tests


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter